### PR TITLE
Fix 4938 to support slotProps and InputProps with endAdornment already specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 6.2.5
+
+## @rjsf/mui
+
+- Updated `BaseInputTemplate` to properly handle `slotProps` and `InputProps` (deprecated by MUI) with existing `endAdornment`s when the `allowClearTextInputs` flag is true, fixing [#4938](https://github.com/rjsf-team/react-jsonschema-form/issues/4938) 
+
+## Dev / docs / playground
+
+- Updated `uiSchema.md` to add documentation for `allowClearTextInputs`
+- Updated the `formTests.tsx` in `snapshot-tests` to render string fields with the `allowClearTextInputs` flag enabled, with data and readonly to test the new feature
+
 # 6.2.4
 
 ## Dev / docs / playground

--- a/packages/antd/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Form.test.tsx.snap
@@ -16567,7 +16567,155 @@ exports[`single fields string field required field with markdown help 1`] = `
 </DocumentFragment>
 `;
 
-exports[`single fields string field with placeholder 1`] = `
+exports[`single fields string field string field with allowClearTextInputs and readonly 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="ant-form-item css-dev-only-do-not-override-ac2jek ant-form-item-horizontal"
+      >
+        <div
+          class="ant-row ant-form-item-row css-dev-only-do-not-override-ac2jek"
+        >
+          <div
+            class="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-ac2jek"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <span
+                  class="ant-input-affix-wrapper ant-input-disabled ant-input-affix-wrapper-disabled css-dev-only-do-not-override-ac2jek ant-input-outlined"
+                  style="width: 100%;"
+                >
+                  <input
+                    aria-describedby="root__error root__description root__help"
+                    class="ant-input ant-input-disabled css-dev-only-do-not-override-ac2jek"
+                    disabled=""
+                    id="root"
+                    name="root"
+                    placeholder=""
+                    type="text"
+                    value="foo"
+                  />
+                  <span
+                    class="ant-input-suffix"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <button
+      class="ant-btn css-dev-only-do-not-override-ac2jek ant-btn-submit"
+      type="submit"
+    >
+      <span>
+        Submit
+      </span>
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with allowClearTextInputs and value 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="ant-form-item css-dev-only-do-not-override-ac2jek ant-form-item-horizontal"
+      >
+        <div
+          class="ant-row ant-form-item-row css-dev-only-do-not-override-ac2jek"
+        >
+          <div
+            class="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-ac2jek"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <span
+                  class="ant-input-affix-wrapper css-dev-only-do-not-override-ac2jek ant-input-outlined"
+                  style="width: 100%;"
+                >
+                  <input
+                    aria-describedby="root__error root__description root__help"
+                    class="ant-input css-dev-only-do-not-override-ac2jek"
+                    id="root"
+                    name="root"
+                    placeholder=""
+                    type="text"
+                    value="foo"
+                  />
+                  <span
+                    class="ant-input-suffix"
+                  />
+                </span>
+                <button
+                  class="ant-btn css-dev-only-do-not-override-ac2jek ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-icon-only"
+                  style="padding-top: 4px;"
+                  title="clear input"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="close"
+                      class="anticon anticon-close"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="close"
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <button
+      class="ant-btn css-dev-only-do-not-override-ac2jek ant-btn-submit"
+      type="submit"
+    >
+      <span>
+        Submit
+      </span>
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with placeholder 1`] = `
 <DocumentFragment>
   <form
     class="rjsf"

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -543,7 +543,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r91:::legend"
+        aria-labelledby="fieldset:::r95:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -559,7 +559,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r92:::legend"
+                  aria-labelledby="fieldset:::r96:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -597,7 +597,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                 class="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r93:::legend"
+                                  aria-labelledby="fieldset:::r97:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -628,7 +628,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           class="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r94:::legend"
+                                            aria-labelledby="fieldset:::r98:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -640,15 +640,15 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r95:"
+                                                id="field:::r99:"
                                                 role="group"
                                               >
                                                 <label
                                                   class="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  for=":r95:"
-                                                  id="field:::r95:::label"
+                                                  for=":r99:"
+                                                  id="field:::r99:::label"
                                                 >
                                                   title
                                                 </label>
@@ -673,7 +673,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           class="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r96:::legend"
+                                            aria-labelledby="fieldset:::r9a:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -685,7 +685,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r97:"
+                                                id="field:::r9b:"
                                                 role="group"
                                               >
                                                 <label
@@ -695,13 +695,13 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="unchecked"
                                                   dir="ltr"
-                                                  for=":r97:"
+                                                  for=":r9b:"
                                                   id="checkbox:root_tasks_0_done"
                                                 >
                                                   <input
                                                     aria-invalid="false"
-                                                    aria-labelledby="field:::r97:::label"
-                                                    id=":r97:"
+                                                    aria-labelledby="field:::r9b:::label"
+                                                    id=":r9b:"
                                                     name="root[tasks][0][done]"
                                                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                                     type="checkbox"
@@ -728,7 +728,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="unchecked"
                                                     dir="ltr"
-                                                    id="field:::r97:::label"
+                                                    id="field:::r9b:::label"
                                                   >
                                                     <p>
                                                       done
@@ -850,7 +850,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                 class="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r99:::legend"
+                                  aria-labelledby="fieldset:::r9d:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -881,7 +881,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           class="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r9a:::legend"
+                                            aria-labelledby="fieldset:::r9e:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -893,15 +893,15 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r9b:"
+                                                id="field:::r9f:"
                                                 role="group"
                                               >
                                                 <label
                                                   class="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  for=":r9b:"
-                                                  id="field:::r9b:::label"
+                                                  for=":r9f:"
+                                                  id="field:::r9f:::label"
                                                 >
                                                   title
                                                 </label>
@@ -926,7 +926,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           class="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r9c:::legend"
+                                            aria-labelledby="fieldset:::r9g:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -938,7 +938,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r9d:"
+                                                id="field:::r9h:"
                                                 role="group"
                                               >
                                                 <label
@@ -948,14 +948,14 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="checked"
                                                   dir="ltr"
-                                                  for=":r9d:"
+                                                  for=":r9h:"
                                                   id="checkbox:root_tasks_1_done"
                                                 >
                                                   <input
                                                     aria-invalid="false"
-                                                    aria-labelledby="field:::r9d:::label"
+                                                    aria-labelledby="field:::r9h:::label"
                                                     checked=""
-                                                    id=":r9d:"
+                                                    id=":r9h:"
                                                     name="root[tasks][1][done]"
                                                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                                     type="checkbox"
@@ -986,7 +986,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="checked"
                                                     dir="ltr"
-                                                    id="field:::r9d:::label"
+                                                    id="field:::r9h:::label"
                                                   >
                                                     <p>
                                                       done
@@ -1596,7 +1596,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r8r:::legend"
+        aria-labelledby="fieldset:::r8v:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -1612,7 +1612,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8s:::legend"
+                  aria-labelledby="fieldset:::r90:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -1650,7 +1650,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r8t:::legend"
+                                  aria-labelledby="fieldset:::r91:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -1662,7 +1662,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                       class="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::r8u:"
+                                      id="field:::r92:"
                                       role="group"
                                     >
                                       <label
@@ -1670,8 +1670,8 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":r8u:"
-                                        id="field:::r8u:::label"
+                                        for=":r92:"
+                                        id="field:::r92:::label"
                                       >
                                         tags-1
                                         <span
@@ -1804,7 +1804,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r8v:::legend"
+                                  aria-labelledby="fieldset:::r93:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -1816,7 +1816,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                       class="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::r90:"
+                                      id="field:::r94:"
                                       role="group"
                                     >
                                       <label
@@ -1824,8 +1824,8 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":r90:"
-                                        id="field:::r90:::label"
+                                        for=":r94:"
+                                        id="field:::r94:::label"
                                       >
                                         tags-2
                                         <span
@@ -2322,7 +2322,7 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9n:::legend"
+        aria-labelledby="fieldset:::r9r:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -2338,7 +2338,7 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9o:::legend"
+                  aria-labelledby="fieldset:::r9s:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -2347,7 +2347,7 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
                     class="fieldset__content emotion-1"
                   >
                     <fieldset
-                      aria-labelledby="fieldset:::r9p:::legend"
+                      aria-labelledby="fieldset:::r9t:::legend"
                       class="fieldset__root emotion-5"
                       data-part="root"
                       data-scope="fieldset"
@@ -2356,7 +2356,7 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
                         class="fieldset__legend emotion-6"
                         data-part="legend"
                         data-scope="fieldset"
-                        id="fieldset:::r9p:::legend"
+                        id="fieldset:::r9t:::legend"
                       >
                         choices
                       </legend>
@@ -2790,7 +2790,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r8g:::legend"
+        aria-labelledby="fieldset:::r8k:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -2806,7 +2806,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8h:::legend"
+                  aria-labelledby="fieldset:::r8l:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -2837,7 +2837,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8i:::legend"
+                            aria-labelledby="fieldset:::r8m:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -2849,15 +2849,15 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                 class="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r8j:"
+                                id="field:::r8n:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r8j:"
-                                  id="field:::r8j:::label"
+                                  for=":r8n:"
+                                  id="field:::r8n:::label"
                                 >
                                   firstName
                                 </label>
@@ -2882,7 +2882,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8k:::legend"
+                            aria-labelledby="fieldset:::r8o:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -2894,15 +2894,15 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                 class="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r8l:"
+                                id="field:::r8p:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r8l:"
-                                  id="field:::r8l:::label"
+                                  for=":r8p:"
+                                  id="field:::r8p:::label"
                                 >
                                   lastName
                                 </label>
@@ -2927,7 +2927,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8m:::legend"
+                            aria-labelledby="fieldset:::r8q:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -2958,7 +2958,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r8n:::legend"
+                                      aria-labelledby="fieldset:::r8r:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -2970,15 +2970,15 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                           class="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r8o:"
+                                          id="field:::r8s:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":r8o:"
-                                            id="field:::r8o:::label"
+                                            for=":r8s:"
+                                            id="field:::r8s:::label"
                                           >
                                             street
                                           </label>
@@ -3003,7 +3003,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r8p:::legend"
+                                      aria-labelledby="fieldset:::r8t:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -3015,15 +3015,15 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                           class="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r8q:"
+                                          id="field:::r8u:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":r8q:"
-                                            id="field:::r8q:::label"
+                                            for=":r8u:"
+                                            id="field:::r8u:::label"
                                           >
                                             city
                                           </label>
@@ -3369,7 +3369,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9j:::legend"
+        aria-labelledby="fieldset:::r9n:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -3385,7 +3385,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9k:::legend"
+                  aria-labelledby="fieldset:::r9o:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -3397,28 +3397,28 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r9l:"
+                      id="field:::r9p:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":r9l:"
-                        id="field:::r9l:::label"
+                        for=":r9p:"
+                        id="field:::r9p:::label"
                       >
                         option
                       </label>
                       <div
                         aria-describedby="root_option__error root_option__description root_option__help"
-                        aria-labelledby="radio-group::r9m::label"
+                        aria-labelledby="radio-group::r9q::label"
                         aria-orientation="vertical"
                         class="chakra-radio-group__root"
                         data-orientation="vertical"
                         data-part="root"
                         data-scope="radio-group"
                         dir="ltr"
-                        id="radio-group::r9m:"
+                        id="radio-group::r9q:"
                         role="radiogroup"
                         style="position: relative;"
                       >
@@ -3433,12 +3433,12 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                             data-ssr=""
                             data-state="unchecked"
                             dir="ltr"
-                            for="radio-group::r9m::radio:input:0"
+                            for="radio-group::r9q::radio:input:0"
                             id="root_option-0"
                           >
                             <input
-                              data-ownedby="radio-group::r9m:"
-                              id="radio-group::r9m::radio:input:0"
+                              data-ownedby="radio-group::r9q:"
+                              id="radio-group::r9q::radio:input:0"
                               name="root[option]"
                               style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                               type="radio"
@@ -3453,7 +3453,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::r9m::radio:control:0"
+                              id="radio-group::r9q::radio:control:0"
                             />
                             <span
                               class="chakra-radio-group__itemText"
@@ -3463,7 +3463,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::r9m::radio:label:0"
+                              id="radio-group::r9q::radio:label:0"
                             >
                               foo
                             </span>
@@ -3476,12 +3476,12 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                             data-ssr=""
                             data-state="unchecked"
                             dir="ltr"
-                            for="radio-group::r9m::radio:input:1"
+                            for="radio-group::r9q::radio:input:1"
                             id="root_option-1"
                           >
                             <input
-                              data-ownedby="radio-group::r9m:"
-                              id="radio-group::r9m::radio:input:1"
+                              data-ownedby="radio-group::r9q:"
+                              id="radio-group::r9q::radio:input:1"
                               name="root[option]"
                               style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                               type="radio"
@@ -3496,7 +3496,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::r9m::radio:control:1"
+                              id="radio-group::r9q::radio:control:1"
                             />
                             <span
                               class="chakra-radio-group__itemText"
@@ -3506,7 +3506,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::r9m::radio:label:1"
+                              id="radio-group::r9q::radio:label:1"
                             >
                               bar
                             </span>
@@ -4021,7 +4021,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9f:::legend"
+        aria-labelledby="fieldset:::r9j:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -4037,7 +4037,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9g:::legend"
+                  aria-labelledby="fieldset:::r9k:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -4049,15 +4049,15 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r9h:"
+                      id="field:::r9l:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":r9h:"
-                        id="field:::r9h:::label"
+                        for=":r9l:"
+                        id="field:::r9l:::label"
                       >
                         color
                       </label>
@@ -4071,8 +4071,8 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                       >
                         <select
                           aria-hidden="true"
-                          aria-labelledby="field:::r9h:::label"
-                          id=":r9h:"
+                          aria-labelledby="field:::r9l:::label"
+                          id=":r9l:"
                           name="root[color]"
                           style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                           tabindex="-1"
@@ -4117,7 +4117,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                               aria-expanded="false"
                               aria-haspopup="listbox"
                               aria-invalid="false"
-                              aria-labelledby="field:::r9h:::label"
+                              aria-labelledby="field:::r9l:::label"
                               aria-required="false"
                               class="chakra-select__trigger emotion-10"
                               data-part="trigger"
@@ -4168,7 +4168,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                           style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                         >
                           <div
-                            aria-labelledby="field:::r9h:::label"
+                            aria-labelledby="field:::r9l:::label"
                             class="chakra-select__content emotion-16"
                             data-part="content"
                             data-scope="select"
@@ -4643,7 +4643,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r88:::legend"
+        aria-labelledby="fieldset:::r8c:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -4659,7 +4659,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r89:::legend"
+                  aria-labelledby="fieldset:::r8d:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -4671,15 +4671,15 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r8a:"
+                      id="field:::r8e:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":r8a:"
-                        id="field:::r8a:::label"
+                        for=":r8e:"
+                        id="field:::r8e:::label"
                       >
                         firstName
                       </label>
@@ -4704,7 +4704,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                 class="rjsf-field rjsf-field-number"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8b:::legend"
+                  aria-labelledby="fieldset:::r8f:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -4716,15 +4716,15 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r8c:"
+                      id="field:::r8g:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":r8c:"
-                        id="field:::r8c:::label"
+                        for=":r8g:"
+                        id="field:::r8g:::label"
                       >
                         age
                       </label>
@@ -4750,7 +4750,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                 class="rjsf-field rjsf-field-boolean"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8d:::legend"
+                  aria-labelledby="fieldset:::r8h:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -4762,7 +4762,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r8e:"
+                      id="field:::r8i:"
                       role="group"
                     >
                       <label
@@ -4772,13 +4772,13 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                         data-scope="checkbox"
                         data-state="unchecked"
                         dir="ltr"
-                        for=":r8e:"
+                        for=":r8i:"
                         id="checkbox:root_active"
                       >
                         <input
                           aria-invalid="false"
-                          aria-labelledby="field:::r8e:::label"
-                          id=":r8e:"
+                          aria-labelledby="field:::r8i:::label"
+                          id=":r8i:"
                           name="root[active]"
                           style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                           type="checkbox"
@@ -4805,7 +4805,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                           data-scope="checkbox"
                           data-state="unchecked"
                           dir="ltr"
-                          id="field:::r8e:::label"
+                          id="field:::r8i:::label"
                         >
                           <p>
                             active
@@ -5068,7 +5068,7 @@ exports[`nameGenerator bracketNameGenerator textarea field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9t:::legend"
+        aria-labelledby="fieldset:::ra1:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -5084,7 +5084,7 @@ exports[`nameGenerator bracketNameGenerator textarea field 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9u:::legend"
+                  aria-labelledby="fieldset:::ra2:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -5096,15 +5096,15 @@ exports[`nameGenerator bracketNameGenerator textarea field 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r9v:"
+                      id="field:::ra3:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":r9v:"
-                        id="field:::r9v:::label"
+                        for=":ra3:"
+                        id="field:::ra3:::label"
                       >
                         description
                       </label>
@@ -5686,7 +5686,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::rap:::legend"
+        aria-labelledby="fieldset:::rat:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -5702,7 +5702,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::raq:::legend"
+                  aria-labelledby="fieldset:::rau:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -5740,7 +5740,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                 class="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::rar:::legend"
+                                  aria-labelledby="fieldset:::rav:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -5771,7 +5771,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           class="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::ras:::legend"
+                                            aria-labelledby="fieldset:::rb0:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -5783,15 +5783,15 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rat:"
+                                                id="field:::rb1:"
                                                 role="group"
                                               >
                                                 <label
                                                   class="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  for=":rat:"
-                                                  id="field:::rat:::label"
+                                                  for=":rb1:"
+                                                  id="field:::rb1:::label"
                                                 >
                                                   title
                                                 </label>
@@ -5816,7 +5816,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           class="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::rau:::legend"
+                                            aria-labelledby="fieldset:::rb2:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -5828,7 +5828,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rav:"
+                                                id="field:::rb3:"
                                                 role="group"
                                               >
                                                 <label
@@ -5838,13 +5838,13 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="unchecked"
                                                   dir="ltr"
-                                                  for=":rav:"
+                                                  for=":rb3:"
                                                   id="checkbox:root_tasks_0_done"
                                                 >
                                                   <input
                                                     aria-invalid="false"
-                                                    aria-labelledby="field:::rav:::label"
-                                                    id=":rav:"
+                                                    aria-labelledby="field:::rb3:::label"
+                                                    id=":rb3:"
                                                     name="root.tasks.0.done"
                                                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                                     type="checkbox"
@@ -5871,7 +5871,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="unchecked"
                                                     dir="ltr"
-                                                    id="field:::rav:::label"
+                                                    id="field:::rb3:::label"
                                                   >
                                                     <p>
                                                       done
@@ -5993,7 +5993,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                 class="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::rb1:::legend"
+                                  aria-labelledby="fieldset:::rb5:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -6024,7 +6024,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           class="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::rb2:::legend"
+                                            aria-labelledby="fieldset:::rb6:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -6036,15 +6036,15 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rb3:"
+                                                id="field:::rb7:"
                                                 role="group"
                                               >
                                                 <label
                                                   class="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  for=":rb3:"
-                                                  id="field:::rb3:::label"
+                                                  for=":rb7:"
+                                                  id="field:::rb7:::label"
                                                 >
                                                   title
                                                 </label>
@@ -6069,7 +6069,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           class="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::rb4:::legend"
+                                            aria-labelledby="fieldset:::rb8:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -6081,7 +6081,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rb5:"
+                                                id="field:::rb9:"
                                                 role="group"
                                               >
                                                 <label
@@ -6091,14 +6091,14 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="checked"
                                                   dir="ltr"
-                                                  for=":rb5:"
+                                                  for=":rb9:"
                                                   id="checkbox:root_tasks_1_done"
                                                 >
                                                   <input
                                                     aria-invalid="false"
-                                                    aria-labelledby="field:::rb5:::label"
+                                                    aria-labelledby="field:::rb9:::label"
                                                     checked=""
-                                                    id=":rb5:"
+                                                    id=":rb9:"
                                                     name="root.tasks.1.done"
                                                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                                     type="checkbox"
@@ -6129,7 +6129,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="checked"
                                                     dir="ltr"
-                                                    id="field:::rb5:::label"
+                                                    id="field:::rb9:::label"
                                                   >
                                                     <p>
                                                       done
@@ -6739,7 +6739,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::raj:::legend"
+        aria-labelledby="fieldset:::ran:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -6755,7 +6755,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rak:::legend"
+                  aria-labelledby="fieldset:::rao:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -6793,7 +6793,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::ral:::legend"
+                                  aria-labelledby="fieldset:::rap:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -6805,7 +6805,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                       class="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::ram:"
+                                      id="field:::raq:"
                                       role="group"
                                     >
                                       <label
@@ -6813,8 +6813,8 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":ram:"
-                                        id="field:::ram:::label"
+                                        for=":raq:"
+                                        id="field:::raq:::label"
                                       >
                                         tags-1
                                         <span
@@ -6947,7 +6947,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::ran:::legend"
+                                  aria-labelledby="fieldset:::rar:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -6959,7 +6959,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                       class="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::rao:"
+                                      id="field:::ras:"
                                       role="group"
                                     >
                                       <label
@@ -6967,8 +6967,8 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":rao:"
-                                        id="field:::rao:::label"
+                                        for=":ras:"
+                                        id="field:::ras:::label"
                                       >
                                         tags-2
                                         <span
@@ -7408,7 +7408,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::ra8:::legend"
+        aria-labelledby="fieldset:::rac:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -7424,7 +7424,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::ra9:::legend"
+                  aria-labelledby="fieldset:::rad:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -7455,7 +7455,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::raa:::legend"
+                            aria-labelledby="fieldset:::rae:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -7467,15 +7467,15 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                 class="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::rab:"
+                                id="field:::raf:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":rab:"
-                                  id="field:::rab:::label"
+                                  for=":raf:"
+                                  id="field:::raf:::label"
                                 >
                                   firstName
                                 </label>
@@ -7500,7 +7500,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::rac:::legend"
+                            aria-labelledby="fieldset:::rag:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -7512,15 +7512,15 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                 class="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::rad:"
+                                id="field:::rah:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":rad:"
-                                  id="field:::rad:::label"
+                                  for=":rah:"
+                                  id="field:::rah:::label"
                                 >
                                   lastName
                                 </label>
@@ -7545,7 +7545,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::rae:::legend"
+                            aria-labelledby="fieldset:::rai:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -7576,7 +7576,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::raf:::legend"
+                                      aria-labelledby="fieldset:::raj:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -7588,15 +7588,15 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                           class="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::rag:"
+                                          id="field:::rak:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":rag:"
-                                            id="field:::rag:::label"
+                                            for=":rak:"
+                                            id="field:::rak:::label"
                                           >
                                             street
                                           </label>
@@ -7621,7 +7621,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::rah:::legend"
+                                      aria-labelledby="fieldset:::ral:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -7633,15 +7633,15 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                           class="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::rai:"
+                                          id="field:::ram:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":rai:"
-                                            id="field:::rai:::label"
+                                            for=":ram:"
+                                            id="field:::ram:::label"
                                           >
                                             city
                                           </label>
@@ -8174,7 +8174,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::rb7:::legend"
+        aria-labelledby="fieldset:::rbb:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -8190,7 +8190,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rb8:::legend"
+                  aria-labelledby="fieldset:::rbc:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -8202,15 +8202,15 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::rb9:"
+                      id="field:::rbd:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":rb9:"
-                        id="field:::rb9:::label"
+                        for=":rbd:"
+                        id="field:::rbd:::label"
                       >
                         color
                       </label>
@@ -8224,8 +8224,8 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                       >
                         <select
                           aria-hidden="true"
-                          aria-labelledby="field:::rb9:::label"
-                          id=":rb9:"
+                          aria-labelledby="field:::rbd:::label"
+                          id=":rbd:"
                           name="root.color"
                           style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                           tabindex="-1"
@@ -8270,7 +8270,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                               aria-expanded="false"
                               aria-haspopup="listbox"
                               aria-invalid="false"
-                              aria-labelledby="field:::rb9:::label"
+                              aria-labelledby="field:::rbd:::label"
                               aria-required="false"
                               class="chakra-select__trigger emotion-10"
                               data-part="trigger"
@@ -8321,7 +8321,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                           style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                         >
                           <div
-                            aria-labelledby="field:::rb9:::label"
+                            aria-labelledby="field:::rbd:::label"
                             class="chakra-select__content emotion-16"
                             data-part="content"
                             data-scope="select"
@@ -8796,7 +8796,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::ra0:::legend"
+        aria-labelledby="fieldset:::ra4:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -8812,7 +8812,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::ra1:::legend"
+                  aria-labelledby="fieldset:::ra5:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -8824,15 +8824,15 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::ra2:"
+                      id="field:::ra6:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":ra2:"
-                        id="field:::ra2:::label"
+                        for=":ra6:"
+                        id="field:::ra6:::label"
                       >
                         firstName
                       </label>
@@ -8857,7 +8857,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                 class="rjsf-field rjsf-field-number"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::ra3:::legend"
+                  aria-labelledby="fieldset:::ra7:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -8869,15 +8869,15 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::ra4:"
+                      id="field:::ra8:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":ra4:"
-                        id="field:::ra4:::label"
+                        for=":ra8:"
+                        id="field:::ra8:::label"
                       >
                         age
                       </label>
@@ -8903,7 +8903,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                 class="rjsf-field rjsf-field-boolean"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::ra5:::legend"
+                  aria-labelledby="fieldset:::ra9:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -8915,7 +8915,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::ra6:"
+                      id="field:::raa:"
                       role="group"
                     >
                       <label
@@ -8925,13 +8925,13 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                         data-scope="checkbox"
                         data-state="unchecked"
                         dir="ltr"
-                        for=":ra6:"
+                        for=":raa:"
                         id="checkbox:root_active"
                       >
                         <input
                           aria-invalid="false"
-                          aria-labelledby="field:::ra6:::label"
-                          id=":ra6:"
+                          aria-labelledby="field:::raa:::label"
+                          id=":raa:"
                           name="root.active"
                           style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                           type="checkbox"
@@ -8958,7 +8958,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                           data-scope="checkbox"
                           data-state="unchecked"
                           dir="ltr"
-                          id="field:::ra6:::label"
+                          id="field:::raa:::label"
                         >
                           <p>
                             active
@@ -9243,7 +9243,7 @@ exports[`single fields checkbox field 1`] = `
       class="rjsf-field rjsf-field-boolean"
     >
       <fieldset
-        aria-labelledby="fieldset:::r2l:::legend"
+        aria-labelledby="fieldset:::r2p:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -9255,7 +9255,7 @@ exports[`single fields checkbox field 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r2m:"
+            id="field:::r2q:"
             role="group"
           >
             <label
@@ -9265,13 +9265,13 @@ exports[`single fields checkbox field 1`] = `
               data-scope="checkbox"
               data-state="unchecked"
               dir="ltr"
-              for=":r2m:"
+              for=":r2q:"
               id="checkbox:root"
             >
               <input
                 aria-invalid="false"
-                aria-labelledby="field:::r2m:::label"
-                id=":r2m:"
+                aria-labelledby="field:::r2q:::label"
+                id=":r2q:"
                 name="root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                 type="checkbox"
@@ -9603,7 +9603,7 @@ exports[`single fields checkbox field with description in schema and FieldTempla
       class="rjsf-field rjsf-field-boolean"
     >
       <fieldset
-        aria-labelledby="fieldset:::r31:::legend"
+        aria-labelledby="fieldset:::r35:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -9612,7 +9612,7 @@ exports[`single fields checkbox field with description in schema and FieldTempla
           class="fieldset__legend emotion-1"
           data-part="legend"
           data-scope="fieldset"
-          id="fieldset:::r31:::legend"
+          id="fieldset:::r35:::legend"
         >
           <sup
             class="emotion-2"
@@ -9628,7 +9628,7 @@ exports[`single fields checkbox field with description in schema and FieldTempla
             class="chakra-field__root emotion-4"
             data-part="root"
             data-scope="field"
-            id="field:::r32:"
+            id="field:::r36:"
             role="group"
           >
             <label
@@ -9638,13 +9638,13 @@ exports[`single fields checkbox field with description in schema and FieldTempla
               data-scope="checkbox"
               data-state="unchecked"
               dir="ltr"
-              for=":r32:"
+              for=":r36:"
               id="checkbox:root"
             >
               <input
                 aria-invalid="false"
-                aria-labelledby="field:::r32:::label"
-                id=":r32:"
+                aria-labelledby="field:::r36:::label"
+                id=":r36:"
                 name="root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                 type="checkbox"
@@ -9671,7 +9671,7 @@ exports[`single fields checkbox field with description in schema and FieldTempla
                 data-scope="checkbox"
                 data-state="unchecked"
                 dir="ltr"
-                id="field:::r32:::label"
+                id="field:::r36:::label"
               >
                 <p>
                   test
@@ -9967,7 +9967,7 @@ exports[`single fields checkbox field with label 1`] = `
       class="rjsf-field rjsf-field-boolean"
     >
       <fieldset
-        aria-labelledby="fieldset:::r2o:::legend"
+        aria-labelledby="fieldset:::r2s:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -9979,7 +9979,7 @@ exports[`single fields checkbox field with label 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r2p:"
+            id="field:::r2t:"
             role="group"
           >
             <label
@@ -9989,13 +9989,13 @@ exports[`single fields checkbox field with label 1`] = `
               data-scope="checkbox"
               data-state="unchecked"
               dir="ltr"
-              for=":r2p:"
+              for=":r2t:"
               id="checkbox:root"
             >
               <input
                 aria-invalid="false"
-                aria-labelledby="field:::r2p:::label"
-                id=":r2p:"
+                aria-labelledby="field:::r2t:::label"
+                id=":r2t:"
                 name="root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                 type="checkbox"
@@ -10022,7 +10022,7 @@ exports[`single fields checkbox field with label 1`] = `
                 data-scope="checkbox"
                 data-state="unchecked"
                 dir="ltr"
-                id="field:::r2p:::label"
+                id="field:::r2t:::label"
               >
                 <p>
                   test
@@ -10322,7 +10322,7 @@ exports[`single fields checkbox field with label and description 1`] = `
       class="rjsf-field rjsf-field-boolean"
     >
       <fieldset
-        aria-labelledby="fieldset:::r2r:::legend"
+        aria-labelledby="fieldset:::r2v:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -10334,7 +10334,7 @@ exports[`single fields checkbox field with label and description 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r2s:"
+            id="field:::r30:"
             role="group"
           >
             <sup
@@ -10350,13 +10350,13 @@ exports[`single fields checkbox field with label and description 1`] = `
               data-scope="checkbox"
               data-state="unchecked"
               dir="ltr"
-              for=":r2s:"
+              for=":r30:"
               id="checkbox:root"
             >
               <input
                 aria-invalid="false"
-                aria-labelledby="field:::r2s:::label"
-                id=":r2s:"
+                aria-labelledby="field:::r30:::label"
+                id=":r30:"
                 name="root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                 type="checkbox"
@@ -10383,7 +10383,7 @@ exports[`single fields checkbox field with label and description 1`] = `
                 data-scope="checkbox"
                 data-state="unchecked"
                 dir="ltr"
-                id="field:::r2s:::label"
+                id="field:::r30:::label"
               >
                 <p>
                   test
@@ -10683,7 +10683,7 @@ exports[`single fields checkbox field with label and rich text description 1`] =
       class="rjsf-field rjsf-field-boolean"
     >
       <fieldset
-        aria-labelledby="fieldset:::r2u:::legend"
+        aria-labelledby="fieldset:::r32:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -10695,7 +10695,7 @@ exports[`single fields checkbox field with label and rich text description 1`] =
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r2v:"
+            id="field:::r33:"
             role="group"
           >
             <sup
@@ -10719,13 +10719,13 @@ exports[`single fields checkbox field with label and rich text description 1`] =
               data-scope="checkbox"
               data-state="unchecked"
               dir="ltr"
-              for=":r2v:"
+              for=":r33:"
               id="checkbox:root"
             >
               <input
                 aria-invalid="false"
-                aria-labelledby="field:::r2v:::label"
-                id=":r2v:"
+                aria-labelledby="field:::r33:::label"
+                id=":r33:"
                 name="root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                 type="checkbox"
@@ -10752,7 +10752,7 @@ exports[`single fields checkbox field with label and rich text description 1`] =
                 data-scope="checkbox"
                 data-state="unchecked"
                 dir="ltr"
-                id="field:::r2v:::label"
+                id="field:::r33:::label"
               >
                 <p>
                   test
@@ -11085,7 +11085,7 @@ exports[`single fields checkboxes field 1`] = `
       class="rjsf-field rjsf-field-array"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3a:::legend"
+        aria-labelledby="fieldset:::r3e:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -11094,7 +11094,7 @@ exports[`single fields checkboxes field 1`] = `
           class="fieldset__content emotion-1"
         >
           <fieldset
-            aria-labelledby="fieldset:::r3b:::legend"
+            aria-labelledby="fieldset:::r3f:::legend"
             class="fieldset__root emotion-2"
             data-part="root"
             data-scope="fieldset"
@@ -11103,7 +11103,7 @@ exports[`single fields checkboxes field 1`] = `
               class="fieldset__legend emotion-3"
               data-part="legend"
               data-scope="fieldset"
-              id="fieldset:::r3b:::legend"
+              id="fieldset:::r3f:::legend"
             >
               An enum list rendered as checkboxes
             </legend>
@@ -11650,7 +11650,7 @@ exports[`single fields checkboxes widget with custom options and labels 1`] = `
       class="rjsf-field rjsf-field-array"
     >
       <fieldset
-        aria-labelledby="fieldset:::r25:::legend"
+        aria-labelledby="fieldset:::r29:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -11659,7 +11659,7 @@ exports[`single fields checkboxes widget with custom options and labels 1`] = `
           class="fieldset__legend emotion-1"
           data-part="legend"
           data-scope="fieldset"
-          id="fieldset:::r25:::legend"
+          id="fieldset:::r29:::legend"
         >
           <sup
             class="emotion-2"
@@ -11678,7 +11678,7 @@ exports[`single fields checkboxes widget with custom options and labels 1`] = `
           class="fieldset__content emotion-4"
         >
           <fieldset
-            aria-labelledby="fieldset:::r26:::legend"
+            aria-labelledby="fieldset:::r2a:::legend"
             class="fieldset__root emotion-5"
             data-part="root"
             data-scope="fieldset"
@@ -11687,7 +11687,7 @@ exports[`single fields checkboxes widget with custom options and labels 1`] = `
               class="fieldset__legend emotion-6"
               data-part="legend"
               data-scope="fieldset"
-              id="fieldset:::r26:::legend"
+              id="fieldset:::r2a:::legend"
             >
               Checkbox Group
             </legend>
@@ -12193,7 +12193,7 @@ exports[`single fields checkboxes widget with required field 1`] = `
       class="rjsf-field rjsf-field-array"
     >
       <fieldset
-        aria-labelledby="fieldset:::r2a:::legend"
+        aria-labelledby="fieldset:::r2e:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -12202,7 +12202,7 @@ exports[`single fields checkboxes widget with required field 1`] = `
           class="fieldset__legend emotion-1"
           data-part="legend"
           data-scope="fieldset"
-          id="fieldset:::r2a:::legend"
+          id="fieldset:::r2e:::legend"
         >
           <sup
             class="emotion-2"
@@ -12215,7 +12215,7 @@ exports[`single fields checkboxes widget with required field 1`] = `
           class="fieldset__content emotion-3"
         >
           <fieldset
-            aria-labelledby="fieldset:::r2b:::legend"
+            aria-labelledby="fieldset:::r2f:::legend"
             class="fieldset__root emotion-4"
             data-part="root"
             data-scope="fieldset"
@@ -12224,7 +12224,7 @@ exports[`single fields checkboxes widget with required field 1`] = `
               class="fieldset__legend emotion-5"
               data-part="legend"
               data-scope="fieldset"
-              id="fieldset:::r2b:::legend"
+              id="fieldset:::r2f:::legend"
             >
               Required Checkbox Group
             </legend>
@@ -12650,7 +12650,7 @@ exports[`single fields field with description 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3n:::legend"
+        aria-labelledby="fieldset:::r3r:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -12666,7 +12666,7 @@ exports[`single fields field with description 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r3o:::legend"
+                  aria-labelledby="fieldset:::r3s:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -12675,7 +12675,7 @@ exports[`single fields field with description 1`] = `
                     class="fieldset__legend emotion-4"
                     data-part="legend"
                     data-scope="fieldset"
-                    id="fieldset:::r3o:::legend"
+                    id="fieldset:::r3s:::legend"
                   >
                     <sup
                       class="emotion-5"
@@ -12691,15 +12691,15 @@ exports[`single fields field with description 1`] = `
                       class="chakra-field__root emotion-7"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r3p:"
+                      id="field:::r3t:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-8"
                         data-part="label"
                         data-scope="field"
-                        for=":r3p:"
-                        id="field:::r3p:::label"
+                        for=":r3t:"
+                        id="field:::r3t:::label"
                       >
                         my-field
                       </label>
@@ -12991,7 +12991,7 @@ exports[`single fields field with description in uiSchema 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3q:::legend"
+        aria-labelledby="fieldset:::r3u:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -13007,7 +13007,7 @@ exports[`single fields field with description in uiSchema 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r3r:::legend"
+                  aria-labelledby="fieldset:::r3v:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -13016,7 +13016,7 @@ exports[`single fields field with description in uiSchema 1`] = `
                     class="fieldset__legend emotion-4"
                     data-part="legend"
                     data-scope="fieldset"
-                    id="fieldset:::r3r:::legend"
+                    id="fieldset:::r3v:::legend"
                   >
                     <sup
                       class="emotion-5"
@@ -13032,15 +13032,15 @@ exports[`single fields field with description in uiSchema 1`] = `
                       class="chakra-field__root emotion-7"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r3s:"
+                      id="field:::r40:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-8"
                         data-part="label"
                         data-scope="field"
-                        for=":r3s:"
-                        id="field:::r3s:::label"
+                        for=":r40:"
+                        id="field:::r40:::label"
                       >
                         my-field
                       </label>
@@ -13332,7 +13332,7 @@ exports[`single fields field with markdown description 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3t:::legend"
+        aria-labelledby="fieldset:::r41:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -13348,7 +13348,7 @@ exports[`single fields field with markdown description 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r3u:::legend"
+                  aria-labelledby="fieldset:::r42:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -13357,7 +13357,7 @@ exports[`single fields field with markdown description 1`] = `
                     class="fieldset__legend emotion-4"
                     data-part="legend"
                     data-scope="fieldset"
-                    id="fieldset:::r3u:::legend"
+                    id="fieldset:::r42:::legend"
                   >
                     <sup
                       class="emotion-5"
@@ -13379,15 +13379,15 @@ exports[`single fields field with markdown description 1`] = `
                       class="chakra-field__root emotion-7"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r3v:"
+                      id="field:::r43:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-8"
                         data-part="label"
                         data-scope="field"
-                        for=":r3v:"
-                        id="field:::r3v:::label"
+                        for=":r43:"
+                        id="field:::r43:::label"
                       >
                         my-field
                       </label>
@@ -13679,7 +13679,7 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r40:::legend"
+        aria-labelledby="fieldset:::r44:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -13695,7 +13695,7 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r41:::legend"
+                  aria-labelledby="fieldset:::r45:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -13704,7 +13704,7 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
                     class="fieldset__legend emotion-4"
                     data-part="legend"
                     data-scope="fieldset"
-                    id="fieldset:::r41:::legend"
+                    id="fieldset:::r45:::legend"
                   >
                     <sup
                       class="emotion-5"
@@ -13722,15 +13722,15 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
                       class="chakra-field__root emotion-7"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r42:"
+                      id="field:::r46:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-8"
                         data-part="label"
                         data-scope="field"
-                        for=":r42:"
-                        id="field:::r42:::label"
+                        for=":r46:"
+                        id="field:::r46:::label"
                       >
                         my-field
                       </label>
@@ -13969,7 +13969,7 @@ exports[`single fields format color 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::ro:::legend"
+        aria-labelledby="fieldset:::rs:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -13981,7 +13981,7 @@ exports[`single fields format color 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::rp:"
+            id="field:::rt:"
             role="group"
           >
             <input
@@ -14214,7 +14214,7 @@ exports[`single fields format date 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::rq:::legend"
+        aria-labelledby="fieldset:::ru:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -14226,7 +14226,7 @@ exports[`single fields format date 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::rr:"
+            id="field:::rv:"
             role="group"
           >
             <input
@@ -14459,7 +14459,7 @@ exports[`single fields format datetime 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::rs:::legend"
+        aria-labelledby="fieldset:::r10:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -14471,7 +14471,7 @@ exports[`single fields format datetime 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::rt:"
+            id="field:::r11:"
             role="group"
           >
             <input
@@ -14704,7 +14704,7 @@ exports[`single fields format time 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::ru:::legend"
+        aria-labelledby="fieldset:::r12:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -14716,7 +14716,7 @@ exports[`single fields format time 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::rv:"
+            id="field:::r13:"
             role="group"
           >
             <input
@@ -15159,7 +15159,7 @@ exports[`single fields help and error display 1`] = `
       class="rjsf-field rjsf-field-string rjsf-field-error"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4c:::legend"
+        aria-labelledby="fieldset:::r4g:::legend"
         class="fieldset__root emotion-8"
         data-invalid=""
         data-part="root"
@@ -15179,7 +15179,7 @@ exports[`single fields help and error display 1`] = `
             data-invalid=""
             data-part="root"
             data-scope="field"
-            id="field:::r4d:"
+            id="field:::r4h:"
             role="group"
           >
             <input
@@ -15361,7 +15361,7 @@ exports[`single fields hidden field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3m:::legend"
+        aria-labelledby="fieldset:::r3q:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -15601,7 +15601,7 @@ exports[`single fields hidden label 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r46:::legend"
+        aria-labelledby="fieldset:::r4a:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -15613,7 +15613,7 @@ exports[`single fields hidden label 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r47:"
+            id="field:::r4b:"
             role="group"
           >
             <input
@@ -15778,7 +15778,7 @@ exports[`single fields null field 1`] = `
       class="rjsf-field rjsf-field-null"
     >
       <fieldset
-        aria-labelledby="fieldset:::rm:::legend"
+        aria-labelledby="fieldset:::rq:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -16003,7 +16003,7 @@ exports[`single fields number field 0 1`] = `
       class="rjsf-field rjsf-field-number"
     >
       <fieldset
-        aria-labelledby="fieldset:::rk:::legend"
+        aria-labelledby="fieldset:::ro:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -16015,7 +16015,7 @@ exports[`single fields number field 0 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::rl:"
+            id="field:::rp:"
             role="group"
           >
             <input
@@ -16249,7 +16249,7 @@ exports[`single fields number field 1`] = `
       class="rjsf-field rjsf-field-number"
     >
       <fieldset
-        aria-labelledby="fieldset:::ri:::legend"
+        aria-labelledby="fieldset:::rm:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -16261,7 +16261,7 @@ exports[`single fields number field 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::rj:"
+            id="field:::rn:"
             role="group"
           >
             <input
@@ -16934,7 +16934,7 @@ exports[`single fields optional data controls does not show optional controls wh
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4e:::legend"
+        aria-labelledby="fieldset:::r4i:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -16965,7 +16965,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4f:::legend"
+                  aria-labelledby="fieldset:::r4j:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -16996,7 +16996,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4g:::legend"
+                            aria-labelledby="fieldset:::r4k:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17008,15 +17008,15 @@ exports[`single fields optional data controls does not show optional controls wh
                                 class="chakra-field__root emotion-14"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r4h:"
+                                id="field:::r4l:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-15"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r4h:"
-                                  id="field:::r4h:::label"
+                                  for=":r4l:"
+                                  id="field:::r4l:::label"
                                 >
                                   test
                                 </label>
@@ -17041,7 +17041,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4i:::legend"
+                            aria-labelledby="fieldset:::r4m:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17072,7 +17072,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r4j:::legend"
+                                      aria-labelledby="fieldset:::r4n:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -17084,15 +17084,15 @@ exports[`single fields optional data controls does not show optional controls wh
                                           class="chakra-field__root emotion-14"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r4k:"
+                                          id="field:::r4o:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-15"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":r4k:"
-                                            id="field:::r4k:::label"
+                                            for=":r4o:"
+                                            id="field:::r4o:::label"
                                           >
                                             deepTest
                                           </label>
@@ -17122,7 +17122,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4l:::legend"
+                            aria-labelledby="fieldset:::r4p:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17153,7 +17153,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r4m:::legend"
+                                      aria-labelledby="fieldset:::r4q:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -17165,15 +17165,15 @@ exports[`single fields optional data controls does not show optional controls wh
                                           class="chakra-field__root emotion-14"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r4n:"
+                                          id="field:::r4r:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-15"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":r4n:"
-                                            id="field:::r4n:::label"
+                                            for=":r4r:"
+                                            id="field:::r4r:::label"
                                           >
                                             deepTest
                                           </label>
@@ -17203,7 +17203,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4o:::legend"
+                            aria-labelledby="fieldset:::r4s:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17277,7 +17277,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4p:::legend"
+                            aria-labelledby="fieldset:::r4t:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17351,7 +17351,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4q:::legend"
+                            aria-labelledby="fieldset:::r4u:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17430,7 +17430,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4r:::legend"
+                  aria-labelledby="fieldset:::r4v:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -17504,7 +17504,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4s:::legend"
+                  aria-labelledby="fieldset:::r50:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -17535,7 +17535,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4t:::legend"
+                            aria-labelledby="fieldset:::r51:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17547,15 +17547,15 @@ exports[`single fields optional data controls does not show optional controls wh
                                 class="chakra-field__root emotion-14"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r4u:"
+                                id="field:::r52:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-15"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r4u:"
-                                  id="field:::r4u:::label"
+                                  for=":r52:"
+                                  id="field:::r52:::label"
                                 >
                                   test
                                 </label>
@@ -17585,7 +17585,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4v:::legend"
+                  aria-labelledby="fieldset:::r53:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -17659,7 +17659,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r50:::legend"
+                  aria-labelledby="fieldset:::r54:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -17680,15 +17680,15 @@ exports[`single fields optional data controls does not show optional controls wh
                             class="chakra-field__root emotion-100"
                             data-part="root"
                             data-scope="field"
-                            id="field:::r51:"
+                            id="field:::r55:"
                             role="group"
                           >
                             <label
                               class="chakra-field__label emotion-15"
                               data-part="label"
                               data-scope="field"
-                              for=":r51:"
-                              id="field:::r51:::label"
+                              for=":r55:"
+                              id="field:::r55:::label"
                             >
                               optionalObjectWithOneofs
                             </label>
@@ -17702,8 +17702,8 @@ exports[`single fields optional data controls does not show optional controls wh
                             >
                               <select
                                 aria-hidden="true"
-                                aria-labelledby="field:::r51:::label"
-                                id=":r51:"
+                                aria-labelledby="field:::r55:::label"
+                                id=":r55:"
                                 name="root_optionalObjectWithOneofs__oneof_select"
                                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                 tabindex="-1"
@@ -17746,7 +17746,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-invalid="false"
-                                    aria-labelledby="field:::r51:::label"
+                                    aria-labelledby="field:::r55:::label"
                                     aria-required="false"
                                     class="chakra-select__trigger emotion-105"
                                     data-part="trigger"
@@ -17798,7 +17798,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                               >
                                 <div
-                                  aria-labelledby="field:::r51:::label"
+                                  aria-labelledby="field:::r55:::label"
                                   class="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -17907,7 +17907,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r53:::legend"
+                            aria-labelledby="fieldset:::r57:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17938,7 +17938,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r54:::legend"
+                                      aria-labelledby="fieldset:::r58:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -17952,7 +17952,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r55:"
+                                          id="field:::r59:"
                                           role="group"
                                         >
                                           <label
@@ -17961,8 +17961,8 @@ exports[`single fields optional data controls does not show optional controls wh
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            for=":r55:"
-                                            id="field:::r55:::label"
+                                            for=":r59:"
+                                            id="field:::r59:::label"
                                           >
                                             name
                                           </label>
@@ -18000,7 +18000,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r56:::legend"
+                  aria-labelledby="fieldset:::r5a:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18021,15 +18021,15 @@ exports[`single fields optional data controls does not show optional controls wh
                             class="chakra-field__root emotion-100"
                             data-part="root"
                             data-scope="field"
-                            id="field:::r57:"
+                            id="field:::r5b:"
                             role="group"
                           >
                             <label
                               class="chakra-field__label emotion-15"
                               data-part="label"
                               data-scope="field"
-                              for=":r57:"
-                              id="field:::r57:::label"
+                              for=":r5b:"
+                              id="field:::r5b:::label"
                             >
                               optionalArrayWithAnyofs
                             </label>
@@ -18043,8 +18043,8 @@ exports[`single fields optional data controls does not show optional controls wh
                             >
                               <select
                                 aria-hidden="true"
-                                aria-labelledby="field:::r57:::label"
-                                id=":r57:"
+                                aria-labelledby="field:::r5b:::label"
+                                id=":r5b:"
                                 name="root_optionalArrayWithAnyofs__anyof_select"
                                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                 tabindex="-1"
@@ -18087,7 +18087,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-invalid="false"
-                                    aria-labelledby="field:::r57:::label"
+                                    aria-labelledby="field:::r5b:::label"
                                     aria-required="false"
                                     class="chakra-select__trigger emotion-105"
                                     data-part="trigger"
@@ -18139,7 +18139,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                               >
                                 <div
-                                  aria-labelledby="field:::r57:::label"
+                                  aria-labelledby="field:::r5b:::label"
                                   class="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -18248,7 +18248,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r59:::legend"
+                            aria-labelledby="fieldset:::r5d:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -18980,7 +18980,7 @@ exports[`single fields optional data controls does not show optional controls wh
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r6b:::legend"
+        aria-labelledby="fieldset:::r6f:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -19012,7 +19012,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6c:::legend"
+                  aria-labelledby="fieldset:::r6g:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -19044,7 +19044,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6d:::legend"
+                            aria-labelledby="fieldset:::r6h:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19058,7 +19058,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r6e:"
+                                id="field:::r6i:"
                                 role="group"
                               >
                                 <label
@@ -19067,8 +19067,8 @@ exports[`single fields optional data controls does not show optional controls wh
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  for=":r6e:"
-                                  id="field:::r6e:::label"
+                                  for=":r6i:"
+                                  id="field:::r6i:::label"
                                 >
                                   test
                                 </label>
@@ -19096,7 +19096,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6f:::legend"
+                            aria-labelledby="fieldset:::r6j:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19128,7 +19128,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r6g:::legend"
+                                      aria-labelledby="fieldset:::r6k:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -19142,7 +19142,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r6h:"
+                                          id="field:::r6l:"
                                           role="group"
                                         >
                                           <label
@@ -19151,8 +19151,8 @@ exports[`single fields optional data controls does not show optional controls wh
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            for=":r6h:"
-                                            id="field:::r6h:::label"
+                                            for=":r6l:"
+                                            id="field:::r6l:::label"
                                           >
                                             deepTest
                                           </label>
@@ -19185,7 +19185,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6i:::legend"
+                            aria-labelledby="fieldset:::r6m:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19217,7 +19217,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r6j:::legend"
+                                      aria-labelledby="fieldset:::r6n:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -19231,7 +19231,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r6k:"
+                                          id="field:::r6o:"
                                           role="group"
                                         >
                                           <label
@@ -19240,8 +19240,8 @@ exports[`single fields optional data controls does not show optional controls wh
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            for=":r6k:"
-                                            id="field:::r6k:::label"
+                                            for=":r6o:"
+                                            id="field:::r6o:::label"
                                           >
                                             deepTest
                                           </label>
@@ -19274,7 +19274,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6l:::legend"
+                            aria-labelledby="fieldset:::r6p:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19349,7 +19349,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6m:::legend"
+                            aria-labelledby="fieldset:::r6q:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19424,7 +19424,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6n:::legend"
+                            aria-labelledby="fieldset:::r6r:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19504,7 +19504,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6o:::legend"
+                  aria-labelledby="fieldset:::r6s:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -19579,7 +19579,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6p:::legend"
+                  aria-labelledby="fieldset:::r6t:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -19611,7 +19611,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6q:::legend"
+                            aria-labelledby="fieldset:::r6u:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19625,7 +19625,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r6r:"
+                                id="field:::r6v:"
                                 role="group"
                               >
                                 <label
@@ -19634,8 +19634,8 @@ exports[`single fields optional data controls does not show optional controls wh
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  for=":r6r:"
-                                  id="field:::r6r:::label"
+                                  for=":r6v:"
+                                  id="field:::r6v:::label"
                                 >
                                   test
                                 </label>
@@ -19668,7 +19668,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6s:::legend"
+                  aria-labelledby="fieldset:::r70:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -19743,7 +19743,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6t:::legend"
+                  aria-labelledby="fieldset:::r71:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -19766,7 +19766,7 @@ exports[`single fields optional data controls does not show optional controls wh
                             data-part="root"
                             data-readonly=""
                             data-scope="field"
-                            id="field:::r6u:"
+                            id="field:::r72:"
                             role="group"
                           >
                             <label
@@ -19775,8 +19775,8 @@ exports[`single fields optional data controls does not show optional controls wh
                               data-part="label"
                               data-readonly=""
                               data-scope="field"
-                              for=":r6u:"
-                              id="field:::r6u:::label"
+                              for=":r72:"
+                              id="field:::r72:::label"
                             >
                               optionalObjectWithOneofs
                             </label>
@@ -19791,9 +19791,9 @@ exports[`single fields optional data controls does not show optional controls wh
                             >
                               <select
                                 aria-hidden="true"
-                                aria-labelledby="field:::r6u:::label"
+                                aria-labelledby="field:::r72:::label"
                                 disabled=""
-                                id=":r6u:"
+                                id=":r72:"
                                 name="root_optionalObjectWithOneofs__oneof_select"
                                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                 tabindex="-1"
@@ -19838,7 +19838,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-invalid="false"
-                                    aria-labelledby="field:::r6u:::label"
+                                    aria-labelledby="field:::r72:::label"
                                     aria-required="false"
                                     class="chakra-select__trigger emotion-105"
                                     data-disabled=""
@@ -19896,7 +19896,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                               >
                                 <div
-                                  aria-labelledby="field:::r6u:::label"
+                                  aria-labelledby="field:::r72:::label"
                                   class="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -20011,7 +20011,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r70:::legend"
+                            aria-labelledby="fieldset:::r74:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -20043,7 +20043,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r71:::legend"
+                                      aria-labelledby="fieldset:::r75:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -20057,7 +20057,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r72:"
+                                          id="field:::r76:"
                                           role="group"
                                         >
                                           <label
@@ -20066,8 +20066,8 @@ exports[`single fields optional data controls does not show optional controls wh
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            for=":r72:"
-                                            id="field:::r72:::label"
+                                            for=":r76:"
+                                            id="field:::r76:::label"
                                           >
                                             name
                                           </label>
@@ -20105,7 +20105,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r73:::legend"
+                  aria-labelledby="fieldset:::r77:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -20128,7 +20128,7 @@ exports[`single fields optional data controls does not show optional controls wh
                             data-part="root"
                             data-readonly=""
                             data-scope="field"
-                            id="field:::r74:"
+                            id="field:::r78:"
                             role="group"
                           >
                             <label
@@ -20137,8 +20137,8 @@ exports[`single fields optional data controls does not show optional controls wh
                               data-part="label"
                               data-readonly=""
                               data-scope="field"
-                              for=":r74:"
-                              id="field:::r74:::label"
+                              for=":r78:"
+                              id="field:::r78:::label"
                             >
                               optionalArrayWithAnyofs
                             </label>
@@ -20153,9 +20153,9 @@ exports[`single fields optional data controls does not show optional controls wh
                             >
                               <select
                                 aria-hidden="true"
-                                aria-labelledby="field:::r74:::label"
+                                aria-labelledby="field:::r78:::label"
                                 disabled=""
-                                id=":r74:"
+                                id=":r78:"
                                 name="root_optionalArrayWithAnyofs__anyof_select"
                                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                 tabindex="-1"
@@ -20200,7 +20200,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-invalid="false"
-                                    aria-labelledby="field:::r74:::label"
+                                    aria-labelledby="field:::r78:::label"
                                     aria-required="false"
                                     class="chakra-select__trigger emotion-105"
                                     data-disabled=""
@@ -20258,7 +20258,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                               >
                                 <div
-                                  aria-labelledby="field:::r74:::label"
+                                  aria-labelledby="field:::r78:::label"
                                   class="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -20373,7 +20373,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r76:::legend"
+                            aria-labelledby="fieldset:::r7a:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21065,7 +21065,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r5l:::legend"
+        aria-labelledby="fieldset:::r5p:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -21096,7 +21096,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5m:::legend"
+                  aria-labelledby="fieldset:::r5q:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -21165,7 +21165,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5n:::legend"
+                            aria-labelledby="fieldset:::r5r:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21177,15 +21177,15 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 class="chakra-field__root emotion-17"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r5o:"
+                                id="field:::r5s:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-18"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r5o:"
-                                  id="field:::r5o:::label"
+                                  for=":r5s:"
+                                  id="field:::r5s:::label"
                                 >
                                   test
                                 </label>
@@ -21210,7 +21210,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5p:::legend"
+                            aria-labelledby="fieldset:::r5t:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21280,7 +21280,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5q:::legend"
+                            aria-labelledby="fieldset:::r5u:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21311,7 +21311,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r5r:::legend"
+                                      aria-labelledby="fieldset:::r5v:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -21323,15 +21323,15 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                           class="chakra-field__root emotion-17"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r5s:"
+                                          id="field:::r60:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-18"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":r5s:"
-                                            id="field:::r5s:::label"
+                                            for=":r60:"
+                                            id="field:::r60:::label"
                                           >
                                             deepTest
                                           </label>
@@ -21361,7 +21361,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5t:::legend"
+                            aria-labelledby="fieldset:::r61:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21435,7 +21435,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5u:::legend"
+                            aria-labelledby="fieldset:::r62:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21509,7 +21509,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5v:::legend"
+                            aria-labelledby="fieldset:::r63:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21588,7 +21588,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r60:::legend"
+                  aria-labelledby="fieldset:::r64:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -21664,7 +21664,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r61:::legend"
+                                  aria-labelledby="fieldset:::r65:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -21676,7 +21676,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                       class="chakra-field__root emotion-17"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::r62:"
+                                      id="field:::r66:"
                                       role="group"
                                     >
                                       <label
@@ -21684,8 +21684,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":r62:"
-                                        id="field:::r62:::label"
+                                        for=":r66:"
+                                        id="field:::r66:::label"
                                       >
                                         nestedArrayOptional-1
                                         <span
@@ -21798,7 +21798,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r63:::legend"
+                  aria-labelledby="fieldset:::r67:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -21829,7 +21829,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r64:::legend"
+                            aria-labelledby="fieldset:::r68:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21841,15 +21841,15 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 class="chakra-field__root emotion-17"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r65:"
+                                id="field:::r69:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-18"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r65:"
-                                  id="field:::r65:::label"
+                                  for=":r69:"
+                                  id="field:::r69:::label"
                                 >
                                   test
                                 </label>
@@ -21879,7 +21879,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r66:::legend"
+                  aria-labelledby="fieldset:::r6a:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -21953,7 +21953,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r67:::legend"
+                  aria-labelledby="fieldset:::r6b:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -21974,7 +21974,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r68:::legend"
+                            aria-labelledby="fieldset:::r6c:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22049,7 +22049,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r69:::legend"
+                  aria-labelledby="fieldset:::r6d:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -22070,7 +22070,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6a:::legend"
+                            aria-labelledby="fieldset:::r6e:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22651,7 +22651,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r7i:::legend"
+        aria-labelledby="fieldset:::r7m:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -22683,7 +22683,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7j:::legend"
+                  aria-labelledby="fieldset:::r7n:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -22715,7 +22715,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7k:::legend"
+                            aria-labelledby="fieldset:::r7o:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22729,7 +22729,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r7l:"
+                                id="field:::r7p:"
                                 role="group"
                               >
                                 <label
@@ -22738,8 +22738,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  for=":r7l:"
-                                  id="field:::r7l:::label"
+                                  for=":r7p:"
+                                  id="field:::r7p:::label"
                                 >
                                   test
                                 </label>
@@ -22767,7 +22767,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7m:::legend"
+                            aria-labelledby="fieldset:::r7q:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22810,7 +22810,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7n:::legend"
+                            aria-labelledby="fieldset:::r7r:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22842,7 +22842,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r7o:::legend"
+                                      aria-labelledby="fieldset:::r7s:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -22856,7 +22856,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r7p:"
+                                          id="field:::r7t:"
                                           role="group"
                                         >
                                           <label
@@ -22865,8 +22865,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            for=":r7p:"
-                                            id="field:::r7p:::label"
+                                            for=":r7t:"
+                                            id="field:::r7t:::label"
                                           >
                                             deepTest
                                           </label>
@@ -22899,7 +22899,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7q:::legend"
+                            aria-labelledby="fieldset:::r7u:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22974,7 +22974,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7r:::legend"
+                            aria-labelledby="fieldset:::r7v:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23019,7 +23019,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7s:::legend"
+                            aria-labelledby="fieldset:::r80:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23099,7 +23099,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7t:::legend"
+                  aria-labelledby="fieldset:::r81:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23137,7 +23137,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r7u:::legend"
+                                  aria-labelledby="fieldset:::r82:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -23151,7 +23151,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                       data-part="root"
                                       data-readonly=""
                                       data-scope="field"
-                                      id="field:::r7v:"
+                                      id="field:::r83:"
                                       role="group"
                                     >
                                       <label
@@ -23161,8 +23161,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                         data-readonly=""
                                         data-required=""
                                         data-scope="field"
-                                        for=":r7v:"
-                                        id="field:::r7v:::label"
+                                        for=":r83:"
+                                        id="field:::r83:::label"
                                       >
                                         nestedArrayOptional-1
                                         <span
@@ -23280,7 +23280,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r80:::legend"
+                  aria-labelledby="fieldset:::r84:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23312,7 +23312,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r81:::legend"
+                            aria-labelledby="fieldset:::r85:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23326,7 +23326,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r82:"
+                                id="field:::r86:"
                                 role="group"
                               >
                                 <label
@@ -23335,8 +23335,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  for=":r82:"
-                                  id="field:::r82:::label"
+                                  for=":r86:"
+                                  id="field:::r86:::label"
                                 >
                                   test
                                 </label>
@@ -23369,7 +23369,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r83:::legend"
+                  aria-labelledby="fieldset:::r87:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23444,7 +23444,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r84:::legend"
+                  aria-labelledby="fieldset:::r88:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23465,7 +23465,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r85:::legend"
+                            aria-labelledby="fieldset:::r89:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23513,7 +23513,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r86:::legend"
+                  aria-labelledby="fieldset:::r8a:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23534,7 +23534,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r87:::legend"
+                            aria-labelledby="fieldset:::r8b:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24027,7 +24027,7 @@ exports[`single fields optional data controls shows "add" optional controls when
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r5a:::legend"
+        aria-labelledby="fieldset:::r5e:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -24058,7 +24058,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5b:::legend"
+                  aria-labelledby="fieldset:::r5f:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24128,7 +24128,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5c:::legend"
+                  aria-labelledby="fieldset:::r5g:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24202,7 +24202,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5d:::legend"
+                  aria-labelledby="fieldset:::r5h:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24233,7 +24233,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5e:::legend"
+                            aria-labelledby="fieldset:::r5i:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24245,15 +24245,15 @@ exports[`single fields optional data controls shows "add" optional controls when
                                 class="chakra-field__root emotion-32"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r5f:"
+                                id="field:::r5j:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-33"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r5f:"
-                                  id="field:::r5f:::label"
+                                  for=":r5j:"
+                                  id="field:::r5j:::label"
                                 >
                                   test
                                 </label>
@@ -24283,7 +24283,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5g:::legend"
+                  aria-labelledby="fieldset:::r5k:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24357,7 +24357,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5h:::legend"
+                  aria-labelledby="fieldset:::r5l:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24378,7 +24378,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5i:::legend"
+                            aria-labelledby="fieldset:::r5m:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24453,7 +24453,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5j:::legend"
+                  aria-labelledby="fieldset:::r5n:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24474,7 +24474,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5k:::legend"
+                            aria-labelledby="fieldset:::r5o:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24886,7 +24886,7 @@ exports[`single fields optional data controls shows "add" optional controls when
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r77:::legend"
+        aria-labelledby="fieldset:::r7b:::legend"
         class="fieldset__root emotion-0"
         data-disabled=""
         data-part="root"
@@ -24920,7 +24920,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r78:::legend"
+                  aria-labelledby="fieldset:::r7c:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -24965,7 +24965,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r79:::legend"
+                  aria-labelledby="fieldset:::r7d:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25012,7 +25012,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7a:::legend"
+                  aria-labelledby="fieldset:::r7e:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25046,7 +25046,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7b:::legend"
+                            aria-labelledby="fieldset:::r7f:::legend"
                             class="fieldset__root emotion-0"
                             data-disabled=""
                             data-part="root"
@@ -25061,7 +25061,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                 data-disabled=""
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r7c:"
+                                id="field:::r7g:"
                                 role="group"
                               >
                                 <label
@@ -25069,8 +25069,8 @@ exports[`single fields optional data controls shows "add" optional controls when
                                   data-disabled=""
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r7c:"
-                                  id="field:::r7c:::label"
+                                  for=":r7g:"
+                                  id="field:::r7g:::label"
                                 >
                                   test
                                 </label>
@@ -25101,7 +25101,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7d:::legend"
+                  aria-labelledby="fieldset:::r7h:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25178,7 +25178,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7e:::legend"
+                  aria-labelledby="fieldset:::r7i:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25201,7 +25201,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7f:::legend"
+                            aria-labelledby="fieldset:::r7j:::legend"
                             class="fieldset__root emotion-0"
                             data-disabled=""
                             data-part="root"
@@ -25251,7 +25251,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7g:::legend"
+                  aria-labelledby="fieldset:::r7k:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25274,7 +25274,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7h:::legend"
+                            aria-labelledby="fieldset:::r7l:::legend"
                             class="fieldset__root emotion-0"
                             data-disabled=""
                             data-part="root"
@@ -25541,7 +25541,7 @@ exports[`single fields password field 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r10:::legend"
+        aria-labelledby="fieldset:::r14:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -25553,7 +25553,7 @@ exports[`single fields password field 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r11:"
+            id="field:::r15:"
             role="group"
           >
             <input
@@ -25851,7 +25851,7 @@ exports[`single fields radio field 1`] = `
       class="rjsf-field rjsf-field-boolean"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3g:::legend"
+        aria-labelledby="fieldset:::r3k:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -25863,19 +25863,19 @@ exports[`single fields radio field 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r3h:"
+            id="field:::r3l:"
             role="group"
           >
             <div
               aria-describedby="root__error root__description root__help"
-              aria-labelledby="radio-group::r3i::label"
+              aria-labelledby="radio-group::r3m::label"
               aria-orientation="vertical"
               class="chakra-radio-group__root"
               data-orientation="vertical"
               data-part="root"
               data-scope="radio-group"
               dir="ltr"
-              id="radio-group::r3i:"
+              id="radio-group::r3m:"
               role="radiogroup"
               style="position: relative;"
             >
@@ -25890,12 +25890,12 @@ exports[`single fields radio field 1`] = `
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r3i::radio:input:0"
+                  for="radio-group::r3m::radio:input:0"
                   id="root-0"
                 >
                   <input
-                    data-ownedby="radio-group::r3i:"
-                    id="radio-group::r3i::radio:input:0"
+                    data-ownedby="radio-group::r3m:"
+                    id="radio-group::r3m::radio:input:0"
                     name="root"
                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -25910,7 +25910,7 @@ exports[`single fields radio field 1`] = `
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r3i::radio:control:0"
+                    id="radio-group::r3m::radio:control:0"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -25920,7 +25920,7 @@ exports[`single fields radio field 1`] = `
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r3i::radio:label:0"
+                    id="radio-group::r3m::radio:label:0"
                   >
                     Yes
                   </span>
@@ -25933,12 +25933,12 @@ exports[`single fields radio field 1`] = `
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r3i::radio:input:1"
+                  for="radio-group::r3m::radio:input:1"
                   id="root-1"
                 >
                   <input
-                    data-ownedby="radio-group::r3i:"
-                    id="radio-group::r3i::radio:input:1"
+                    data-ownedby="radio-group::r3m:"
+                    id="radio-group::r3m::radio:input:1"
                     name="root"
                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -25953,7 +25953,7 @@ exports[`single fields radio field 1`] = `
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r3i::radio:control:1"
+                    id="radio-group::r3m::radio:control:1"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -25963,7 +25963,7 @@ exports[`single fields radio field 1`] = `
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r3i::radio:label:1"
+                    id="radio-group::r3m::radio:label:1"
                   >
                     No
                   </span>
@@ -26301,7 +26301,7 @@ exports[`single fields radio widget with description in schema and FieldTemplate
       class="rjsf-field rjsf-field-boolean"
     >
       <fieldset
-        aria-labelledby="fieldset:::r34:::legend"
+        aria-labelledby="fieldset:::r38:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -26310,7 +26310,7 @@ exports[`single fields radio widget with description in schema and FieldTemplate
           class="fieldset__legend emotion-1"
           data-part="legend"
           data-scope="fieldset"
-          id="fieldset:::r34:::legend"
+          id="fieldset:::r38:::legend"
         >
           <sup
             class="emotion-2"
@@ -26326,28 +26326,28 @@ exports[`single fields radio widget with description in schema and FieldTemplate
             class="chakra-field__root emotion-4"
             data-part="root"
             data-scope="field"
-            id="field:::r35:"
+            id="field:::r39:"
             role="group"
           >
             <label
               class="chakra-field__label emotion-5"
               data-part="label"
               data-scope="field"
-              for=":r35:"
-              id="field:::r35:::label"
+              for=":r39:"
+              id="field:::r39:::label"
             >
               test
             </label>
             <div
               aria-describedby="root__error root__description root__help"
-              aria-labelledby="radio-group::r36::label"
+              aria-labelledby="radio-group::r3a::label"
               aria-orientation="vertical"
               class="chakra-radio-group__root"
               data-orientation="vertical"
               data-part="root"
               data-scope="radio-group"
               dir="ltr"
-              id="radio-group::r36:"
+              id="radio-group::r3a:"
               role="radiogroup"
               style="position: relative;"
             >
@@ -26362,12 +26362,12 @@ exports[`single fields radio widget with description in schema and FieldTemplate
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r36::radio:input:0"
+                  for="radio-group::r3a::radio:input:0"
                   id="root-0"
                 >
                   <input
-                    data-ownedby="radio-group::r36:"
-                    id="radio-group::r36::radio:input:0"
+                    data-ownedby="radio-group::r3a:"
+                    id="radio-group::r3a::radio:input:0"
                     name="root"
                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -26382,7 +26382,7 @@ exports[`single fields radio widget with description in schema and FieldTemplate
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r36::radio:control:0"
+                    id="radio-group::r3a::radio:control:0"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -26392,7 +26392,7 @@ exports[`single fields radio widget with description in schema and FieldTemplate
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r36::radio:label:0"
+                    id="radio-group::r3a::radio:label:0"
                   >
                     Yes
                   </span>
@@ -26405,12 +26405,12 @@ exports[`single fields radio widget with description in schema and FieldTemplate
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r36::radio:input:1"
+                  for="radio-group::r3a::radio:input:1"
                   id="root-1"
                 >
                   <input
-                    data-ownedby="radio-group::r36:"
-                    id="radio-group::r36::radio:input:1"
+                    data-ownedby="radio-group::r3a:"
+                    id="radio-group::r3a::radio:input:1"
                     name="root"
                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -26425,7 +26425,7 @@ exports[`single fields radio widget with description in schema and FieldTemplate
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r36::radio:control:1"
+                    id="radio-group::r3a::radio:control:1"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -26435,7 +26435,7 @@ exports[`single fields radio widget with description in schema and FieldTemplate
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r36::radio:label:1"
+                    id="radio-group::r3a::radio:label:1"
                   >
                     No
                   </span>
@@ -26661,7 +26661,7 @@ exports[`single fields schema examples 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4a:::legend"
+        aria-labelledby="fieldset:::r4e:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -26673,7 +26673,7 @@ exports[`single fields schema examples 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r4b:"
+            id="field:::r4f:"
             role="group"
           >
             <input
@@ -27178,7 +27178,7 @@ exports[`single fields select field 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r17:::legend"
+        aria-labelledby="fieldset:::r1b:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -27190,7 +27190,7 @@ exports[`single fields select field 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r18:"
+            id="field:::r1c:"
             role="group"
           >
             <div
@@ -27203,8 +27203,8 @@ exports[`single fields select field 1`] = `
             >
               <select
                 aria-hidden="true"
-                aria-labelledby="field:::r18:::label"
-                id=":r18:"
+                aria-labelledby="field:::r1c:::label"
+                id=":r1c:"
                 name="root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                 tabindex="-1"
@@ -27244,7 +27244,7 @@ exports[`single fields select field 1`] = `
                     aria-expanded="false"
                     aria-haspopup="listbox"
                     aria-invalid="false"
-                    aria-labelledby="field:::r18:::label"
+                    aria-labelledby="field:::r1c:::label"
                     aria-required="false"
                     class="chakra-select__trigger emotion-6"
                     data-part="trigger"
@@ -27295,7 +27295,7 @@ exports[`single fields select field 1`] = `
                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
               >
                 <div
-                  aria-labelledby="field:::r18:::label"
+                  aria-labelledby="field:::r1c:::label"
                   class="chakra-select__content emotion-12"
                   data-part="content"
                   data-scope="select"
@@ -27840,7 +27840,7 @@ exports[`single fields select field multiple choice 1`] = `
       class="rjsf-field rjsf-field-array"
     >
       <fieldset
-        aria-labelledby="fieldset:::r1a:::legend"
+        aria-labelledby="fieldset:::r1e:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -27852,7 +27852,7 @@ exports[`single fields select field multiple choice 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r1b:"
+            id="field:::r1f:"
             role="group"
           >
             <div
@@ -27865,8 +27865,8 @@ exports[`single fields select field multiple choice 1`] = `
             >
               <select
                 aria-hidden="true"
-                aria-labelledby="field:::r1b:::label"
-                id=":r1b:"
+                aria-labelledby="field:::r1f:::label"
+                id=":r1f:"
                 multiple=""
                 name="root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
@@ -27917,7 +27917,7 @@ exports[`single fields select field multiple choice 1`] = `
                     aria-expanded="false"
                     aria-haspopup="listbox"
                     aria-invalid="false"
-                    aria-labelledby="field:::r1b:::label"
+                    aria-labelledby="field:::r1f:::label"
                     aria-required="false"
                     class="chakra-select__trigger emotion-6"
                     data-part="trigger"
@@ -27968,7 +27968,7 @@ exports[`single fields select field multiple choice 1`] = `
                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
               >
                 <div
-                  aria-labelledby="field:::r1b:::label"
+                  aria-labelledby="field:::r1f:::label"
                   aria-multiselectable="true"
                   class="chakra-select__content emotion-12"
                   data-part="content"
@@ -28574,7 +28574,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
       class="rjsf-field rjsf-field-array"
     >
       <fieldset
-        aria-labelledby="fieldset:::r1s:::legend"
+        aria-labelledby="fieldset:::r20:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -28586,7 +28586,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r1t:"
+            id="field:::r21:"
             role="group"
           >
             <div
@@ -28599,8 +28599,8 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
             >
               <select
                 aria-hidden="true"
-                aria-labelledby="field:::r1t:::label"
-                id=":r1t:"
+                aria-labelledby="field:::r21:::label"
+                id=":r21:"
                 multiple=""
                 name="root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
@@ -28652,7 +28652,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
                     aria-expanded="false"
                     aria-haspopup="listbox"
                     aria-invalid="false"
-                    aria-labelledby="field:::r1t:::label"
+                    aria-labelledby="field:::r21:::label"
                     aria-required="false"
                     class="chakra-select__trigger emotion-6"
                     data-part="trigger"
@@ -28703,7 +28703,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
               >
                 <div
-                  aria-labelledby="field:::r1t:::label"
+                  aria-labelledby="field:::r21:::label"
                   aria-multiselectable="true"
                   class="chakra-select__content emotion-12"
                   data-part="content"
@@ -29153,7 +29153,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
       class="rjsf-field rjsf-field-array"
     >
       <fieldset
-        aria-labelledby="fieldset:::r1v:::legend"
+        aria-labelledby="fieldset:::r23:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -29162,7 +29162,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
           class="fieldset__content emotion-1"
         >
           <fieldset
-            aria-labelledby="fieldset:::r20:::legend"
+            aria-labelledby="fieldset:::r24:::legend"
             class="fieldset__root emotion-2"
             data-part="root"
             data-scope="fieldset"
@@ -29839,7 +29839,7 @@ exports[`single fields select field multiple choice formData 1`] = `
       class="rjsf-field rjsf-field-array"
     >
       <fieldset
-        aria-labelledby="fieldset:::r2i:::legend"
+        aria-labelledby="fieldset:::r2m:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -29851,7 +29851,7 @@ exports[`single fields select field multiple choice formData 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r2j:"
+            id="field:::r2n:"
             role="group"
           >
             <div
@@ -29864,8 +29864,8 @@ exports[`single fields select field multiple choice formData 1`] = `
             >
               <select
                 aria-hidden="true"
-                aria-labelledby="field:::r2j:::label"
-                id=":r2j:"
+                aria-labelledby="field:::r2n:::label"
+                id=":r2n:"
                 multiple=""
                 name="root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
@@ -29915,7 +29915,7 @@ exports[`single fields select field multiple choice formData 1`] = `
                     aria-expanded="false"
                     aria-haspopup="listbox"
                     aria-invalid="false"
-                    aria-labelledby="field:::r2j:::label"
+                    aria-labelledby="field:::r2n:::label"
                     aria-required="false"
                     class="chakra-select__trigger emotion-6"
                     data-part="trigger"
@@ -29967,7 +29967,7 @@ exports[`single fields select field multiple choice formData 1`] = `
                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
               >
                 <div
-                  aria-labelledby="field:::r2j:::label"
+                  aria-labelledby="field:::r2n:::label"
                   aria-multiselectable="true"
                   class="chakra-select__content emotion-12"
                   data-part="content"
@@ -30571,7 +30571,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
       class="rjsf-field rjsf-field-array"
     >
       <fieldset
-        aria-labelledby="fieldset:::r1d:::legend"
+        aria-labelledby="fieldset:::r1h:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -30583,7 +30583,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r1e:"
+            id="field:::r1i:"
             role="group"
           >
             <div
@@ -30596,8 +30596,8 @@ exports[`single fields select field multiple choice with labels 1`] = `
             >
               <select
                 aria-hidden="true"
-                aria-labelledby="field:::r1e:::label"
-                id=":r1e:"
+                aria-labelledby="field:::r1i:::label"
+                id=":r1i:"
                 multiple=""
                 name="root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
@@ -30643,7 +30643,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
                     aria-expanded="false"
                     aria-haspopup="listbox"
                     aria-invalid="false"
-                    aria-labelledby="field:::r1e:::label"
+                    aria-labelledby="field:::r1i:::label"
                     aria-required="false"
                     class="chakra-select__trigger emotion-6"
                     data-part="trigger"
@@ -30694,7 +30694,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
               >
                 <div
-                  aria-labelledby="field:::r1e:::label"
+                  aria-labelledby="field:::r1i:::label"
                   aria-multiselectable="true"
                   class="chakra-select__content emotion-12"
                   data-part="content"
@@ -31270,7 +31270,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r1g:::legend"
+        aria-labelledby="fieldset:::r1k:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -31282,7 +31282,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r1h:"
+            id="field:::r1l:"
             role="group"
           >
             <div
@@ -31295,8 +31295,8 @@ exports[`single fields select field single choice enumDisabled 1`] = `
             >
               <select
                 aria-hidden="true"
-                aria-labelledby="field:::r1h:::label"
-                id=":r1h:"
+                aria-labelledby="field:::r1l:::label"
+                id=":r1l:"
                 name="root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                 tabindex="-1"
@@ -31337,7 +31337,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
                     aria-expanded="false"
                     aria-haspopup="listbox"
                     aria-invalid="false"
-                    aria-labelledby="field:::r1h:::label"
+                    aria-labelledby="field:::r1l:::label"
                     aria-required="false"
                     class="chakra-select__trigger emotion-6"
                     data-part="trigger"
@@ -31388,7 +31388,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
               >
                 <div
-                  aria-labelledby="field:::r1h:::label"
+                  aria-labelledby="field:::r1l:::label"
                   class="chakra-select__content emotion-12"
                   data-part="content"
                   data-scope="select"
@@ -31748,7 +31748,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r1j:::legend"
+        aria-labelledby="fieldset:::r1n:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -31760,19 +31760,19 @@ exports[`single fields select field single choice enumDisabled using radio widge
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r1k:"
+            id="field:::r1o:"
             role="group"
           >
             <div
               aria-describedby="root__error root__description root__help"
-              aria-labelledby="radio-group::r1l::label"
+              aria-labelledby="radio-group::r1p::label"
               aria-orientation="vertical"
               class="chakra-radio-group__root"
               data-orientation="vertical"
               data-part="root"
               data-scope="radio-group"
               dir="ltr"
-              id="radio-group::r1l:"
+              id="radio-group::r1p:"
               role="radiogroup"
               style="position: relative;"
             >
@@ -31787,12 +31787,12 @@ exports[`single fields select field single choice enumDisabled using radio widge
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r1l::radio:input:0"
+                  for="radio-group::r1p::radio:input:0"
                   id="root-0"
                 >
                   <input
-                    data-ownedby="radio-group::r1l:"
-                    id="radio-group::r1l::radio:input:0"
+                    data-ownedby="radio-group::r1p:"
+                    id="radio-group::r1p::radio:input:0"
                     name="root"
                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -31807,7 +31807,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r1l::radio:control:0"
+                    id="radio-group::r1p::radio:control:0"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -31817,7 +31817,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r1l::radio:label:0"
+                    id="radio-group::r1p::radio:label:0"
                   >
                     foo
                   </span>
@@ -31831,13 +31831,13 @@ exports[`single fields select field single choice enumDisabled using radio widge
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r1l::radio:input:1"
+                  for="radio-group::r1p::radio:input:1"
                   id="root-1"
                 >
                   <input
-                    data-ownedby="radio-group::r1l:"
+                    data-ownedby="radio-group::r1p:"
                     disabled=""
-                    id="radio-group::r1l::radio:input:1"
+                    id="radio-group::r1p::radio:input:1"
                     name="root"
                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -31853,7 +31853,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r1l::radio:control:1"
+                    id="radio-group::r1p::radio:control:1"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -31864,7 +31864,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r1l::radio:label:1"
+                    id="radio-group::r1p::radio:label:1"
                   >
                     bar
                   </span>
@@ -32155,7 +32155,7 @@ exports[`single fields select field single choice form disabled using radio widg
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r1p:::legend"
+        aria-labelledby="fieldset:::r1t:::legend"
         class="fieldset__root emotion-0"
         data-disabled=""
         data-part="root"
@@ -32170,19 +32170,19 @@ exports[`single fields select field single choice form disabled using radio widg
             data-disabled=""
             data-part="root"
             data-scope="field"
-            id="field:::r1q:"
+            id="field:::r1u:"
             role="group"
           >
             <div
               aria-describedby="root__error root__description root__help"
-              aria-labelledby="radio-group::r1r::label"
+              aria-labelledby="radio-group::r1v::label"
               aria-orientation="vertical"
               class="chakra-radio-group__root"
               data-orientation="vertical"
               data-part="root"
               data-scope="radio-group"
               dir="ltr"
-              id="radio-group::r1r:"
+              id="radio-group::r1v:"
               role="radiogroup"
               style="position: relative;"
             >
@@ -32198,13 +32198,13 @@ exports[`single fields select field single choice form disabled using radio widg
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r1r::radio:input:0"
+                  for="radio-group::r1v::radio:input:0"
                   id="root-0"
                 >
                   <input
-                    data-ownedby="radio-group::r1r:"
+                    data-ownedby="radio-group::r1v:"
                     disabled=""
-                    id="radio-group::r1r::radio:input:0"
+                    id="radio-group::r1v::radio:input:0"
                     name="root"
                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -32220,7 +32220,7 @@ exports[`single fields select field single choice form disabled using radio widg
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r1r::radio:control:0"
+                    id="radio-group::r1v::radio:control:0"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -32231,7 +32231,7 @@ exports[`single fields select field single choice form disabled using radio widg
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r1r::radio:label:0"
+                    id="radio-group::r1v::radio:label:0"
                   >
                     foo
                   </span>
@@ -32245,13 +32245,13 @@ exports[`single fields select field single choice form disabled using radio widg
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r1r::radio:input:1"
+                  for="radio-group::r1v::radio:input:1"
                   id="root-1"
                 >
                   <input
-                    data-ownedby="radio-group::r1r:"
+                    data-ownedby="radio-group::r1v:"
                     disabled=""
-                    id="radio-group::r1r::radio:input:1"
+                    id="radio-group::r1v::radio:input:1"
                     name="root"
                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -32267,7 +32267,7 @@ exports[`single fields select field single choice form disabled using radio widg
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r1r::radio:control:1"
+                    id="radio-group::r1v::radio:control:1"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -32278,7 +32278,7 @@ exports[`single fields select field single choice form disabled using radio widg
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r1r::radio:label:1"
+                    id="radio-group::r1v::radio:label:1"
                   >
                     bar
                   </span>
@@ -32757,7 +32757,7 @@ exports[`single fields select field single choice formData 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r2f:::legend"
+        aria-labelledby="fieldset:::r2j:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -32769,7 +32769,7 @@ exports[`single fields select field single choice formData 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r2g:"
+            id="field:::r2k:"
             role="group"
           >
             <div
@@ -32782,8 +32782,8 @@ exports[`single fields select field single choice formData 1`] = `
             >
               <select
                 aria-hidden="true"
-                aria-labelledby="field:::r2g:::label"
-                id=":r2g:"
+                aria-labelledby="field:::r2k:::label"
+                id=":r2k:"
                 name="root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                 tabindex="-1"
@@ -32821,7 +32821,7 @@ exports[`single fields select field single choice formData 1`] = `
                     aria-expanded="false"
                     aria-haspopup="listbox"
                     aria-invalid="false"
-                    aria-labelledby="field:::r2g:::label"
+                    aria-labelledby="field:::r2k:::label"
                     aria-required="false"
                     class="chakra-select__trigger emotion-6"
                     data-part="trigger"
@@ -32873,7 +32873,7 @@ exports[`single fields select field single choice formData 1`] = `
                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
               >
                 <div
-                  aria-labelledby="field:::r2g:::label"
+                  aria-labelledby="field:::r2k:::label"
                   class="chakra-select__content emotion-12"
                   data-part="content"
                   data-scope="select"
@@ -33230,7 +33230,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r1m:::legend"
+        aria-labelledby="fieldset:::r1q:::legend"
         class="fieldset__root emotion-0"
         data-disabled=""
         data-part="root"
@@ -33245,19 +33245,19 @@ exports[`single fields select field single choice uiSchema disabled using radio 
             data-disabled=""
             data-part="root"
             data-scope="field"
-            id="field:::r1n:"
+            id="field:::r1r:"
             role="group"
           >
             <div
               aria-describedby="root__error root__description root__help"
-              aria-labelledby="radio-group::r1o::label"
+              aria-labelledby="radio-group::r1s::label"
               aria-orientation="vertical"
               class="chakra-radio-group__root"
               data-orientation="vertical"
               data-part="root"
               data-scope="radio-group"
               dir="ltr"
-              id="radio-group::r1o:"
+              id="radio-group::r1s:"
               role="radiogroup"
               style="position: relative;"
             >
@@ -33273,13 +33273,13 @@ exports[`single fields select field single choice uiSchema disabled using radio 
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r1o::radio:input:0"
+                  for="radio-group::r1s::radio:input:0"
                   id="root-0"
                 >
                   <input
-                    data-ownedby="radio-group::r1o:"
+                    data-ownedby="radio-group::r1s:"
                     disabled=""
-                    id="radio-group::r1o::radio:input:0"
+                    id="radio-group::r1s::radio:input:0"
                     name="root"
                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -33295,7 +33295,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r1o::radio:control:0"
+                    id="radio-group::r1s::radio:control:0"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -33306,7 +33306,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r1o::radio:label:0"
+                    id="radio-group::r1s::radio:label:0"
                   >
                     foo
                   </span>
@@ -33320,13 +33320,13 @@ exports[`single fields select field single choice uiSchema disabled using radio 
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r1o::radio:input:1"
+                  for="radio-group::r1s::radio:input:1"
                   id="root-1"
                 >
                   <input
-                    data-ownedby="radio-group::r1o:"
+                    data-ownedby="radio-group::r1s:"
                     disabled=""
-                    id="radio-group::r1o::radio:input:1"
+                    id="radio-group::r1s::radio:input:1"
                     name="root"
                     style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -33342,7 +33342,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r1o::radio:control:1"
+                    id="radio-group::r1s::radio:control:1"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -33353,7 +33353,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r1o::radio:label:1"
+                    id="radio-group::r1s::radio:label:1"
                   >
                     bar
                   </span>
@@ -33878,7 +33878,7 @@ exports[`single fields select widget with description in schema and FieldTemplat
       class="rjsf-field rjsf-field-boolean"
     >
       <fieldset
-        aria-labelledby="fieldset:::r37:::legend"
+        aria-labelledby="fieldset:::r3b:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -33887,7 +33887,7 @@ exports[`single fields select widget with description in schema and FieldTemplat
           class="fieldset__legend emotion-1"
           data-part="legend"
           data-scope="fieldset"
-          id="fieldset:::r37:::legend"
+          id="fieldset:::r3b:::legend"
         >
           <sup
             class="emotion-2"
@@ -33903,15 +33903,15 @@ exports[`single fields select widget with description in schema and FieldTemplat
             class="chakra-field__root emotion-4"
             data-part="root"
             data-scope="field"
-            id="field:::r38:"
+            id="field:::r3c:"
             role="group"
           >
             <label
               class="chakra-field__label emotion-5"
               data-part="label"
               data-scope="field"
-              for=":r38:"
-              id="field:::r38:::label"
+              for=":r3c:"
+              id="field:::r3c:::label"
             >
               test
             </label>
@@ -33925,8 +33925,8 @@ exports[`single fields select widget with description in schema and FieldTemplat
             >
               <select
                 aria-hidden="true"
-                aria-labelledby="field:::r38:::label"
-                id=":r38:"
+                aria-labelledby="field:::r3c:::label"
+                id=":r3c:"
                 name="root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                 tabindex="-1"
@@ -33966,7 +33966,7 @@ exports[`single fields select widget with description in schema and FieldTemplat
                     aria-expanded="false"
                     aria-haspopup="listbox"
                     aria-invalid="false"
-                    aria-labelledby="field:::r38:::label"
+                    aria-labelledby="field:::r3c:::label"
                     aria-required="false"
                     class="chakra-select__trigger emotion-9"
                     data-part="trigger"
@@ -34017,7 +34017,7 @@ exports[`single fields select widget with description in schema and FieldTemplat
                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
               >
                 <div
-                  aria-labelledby="field:::r38:::label"
+                  aria-labelledby="field:::r3c:::label"
                   class="chakra-select__content emotion-15"
                   data-part="content"
                   data-scope="select"
@@ -34392,7 +34392,7 @@ exports[`single fields slider field 1`] = `
       class="rjsf-field rjsf-field-integer"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3j:::legend"
+        aria-labelledby="fieldset:::r3n:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -34404,7 +34404,7 @@ exports[`single fields slider field 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r3k:"
+            id="field:::r3o:"
             role="group"
           >
             <div
@@ -36784,7 +36784,622 @@ exports[`single fields string field required field with markdown help 1`] = `
 </DocumentFragment>
 `;
 
-exports[`single fields string field with placeholder 1`] = `
+exports[`single fields string field string field with allowClearTextInputs and readonly 1`] = `
+<DocumentFragment>
+  @layer recipes {
+  .emotion-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+  }
+
+  .emotion-0>:not(style, [hidden])~:not(style, [hidden]) {
+    --space-y-reverse: 0;
+    margin-top: calc(var(--chakra-spacing-4) * calc(1 - var(--space-y-reverse)));
+    margin-bottom: calc(var(--chakra-spacing-4) * var(--space-y-reverse));
+  }
+}
+
+@layer recipes {
+  .emotion-1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+    gap: var(--chakra-spacing-4);
+  }
+}
+
+.emotion-2 {
+  margin-bottom: var(--chakra-spacing-1);
+}
+
+@layer recipes {
+  .emotion-2 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    width: 100%;
+    position: relative;
+    gap: var(--chakra-spacing-1\\.5);
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+@layer recipes {
+  .emotion-3 {
+    width: 100%;
+    min-width: var(--input-height);
+    outline: 0;
+    position: relative;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    text-align: start;
+    border-radius: var(--chakra-radii-l2);
+    height: var(--input-height);
+    --focus-color: var(--chakra-colors-color-palette-focus-ring);
+    --error-color: var(--chakra-colors-border-error);
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+    padding-inline: var(--chakra-spacing-3);
+    --input-height: var(--chakra-sizes-10);
+    background: var(--chakra-colors-transparent);
+    --bg-currentcolor: var(--chakra-colors-transparent);
+    border-width: 1px;
+    border-color: var(--chakra-colors-border);
+    --focus-ring-color: var(--focus-color);
+  }
+
+  .emotion-3:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-3:is([data-invalid], [aria-invalid=true], [data-state=invalid]) {
+    --focus-ring-color: var(--error-color);
+    border-color: var(--error-color);
+  }
+
+  .emotion-3:is(:focus-visible, [data-focus-visible]) {
+    outline-offset: 0px;
+    outline-width: var(--focus-ring-width, 1px);
+    outline-color: var(--focus-ring-color);
+    outline-style: var(--focus-ring-style, solid);
+    border-color: var(--focus-ring-color);
+  }
+}
+
+.emotion-4 {
+  margin-top: var(--chakra-spacing-3);
+}
+
+@layer recipes {
+  .emotion-5 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    position: relative;
+    border-radius: var(--chakra-radii-l2);
+    white-space: nowrap;
+    vertical-align: middle;
+    border-width: 1px;
+    border-color: var(--chakra-colors-transparent);
+    cursor: var(--chakra-cursor-button);
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    outline: 0;
+    line-height: 1.25rem;
+    isolation: isolate;
+    font-weight: var(--chakra-font-weights-medium);
+    transition-property: background-color,border-color,color,fill,stroke,opacity,box-shadow,translate,transform;
+    transition-duration: var(--chakra-durations-moderate);
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    height: var(--chakra-sizes-10);
+    min-width: var(--chakra-sizes-10);
+    font-size: var(--chakra-font-sizes-sm);
+    padding-inline: var(--chakra-spacing-4);
+    gap: var(--chakra-spacing-2);
+    background: var(--chakra-colors-color-palette-solid);
+    --bg-currentcolor: var(--chakra-colors-color-palette-solid);
+    color: var(--chakra-colors-color-palette-contrast);
+  }
+
+  .emotion-5:is(:focus-visible, [data-focus-visible]) {
+    outline-width: var(--focus-ring-width, 2px);
+    outline-offset: var(--focus-ring-offset, 2px);
+    outline-style: var(--focus-ring-style, solid);
+    outline-color: var(--focus-ring-color);
+  }
+
+  .emotion-5:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-5 :where(svg) {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    width: var(--chakra-sizes-5);
+    height: var(--chakra-sizes-5);
+  }
+
+  .emotion-5:is([aria-expanded=true], [data-expanded], [data-state=expanded]) {
+    --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+    background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+  }
+
+  @media (hover: hover) {
+    .emotion-5:is(:hover, [data-hover]):not(:disabled, [data-disabled]) {
+      --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+      background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+      --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    }
+  }
+}
+
+<form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <fieldset
+        aria-labelledby="fieldset:::rk:::legend"
+        class="fieldset__root emotion-0"
+        data-part="root"
+        data-scope="fieldset"
+      >
+        <div
+          class="fieldset__content emotion-1"
+        >
+          <div
+            class="chakra-field__root emotion-2"
+            data-disabled=""
+            data-part="root"
+            data-readonly=""
+            data-scope="field"
+            id="field:::rl:"
+            role="group"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              class="chakra-input emotion-3"
+              data-part="input"
+              data-readonly=""
+              data-scope="field"
+              disabled=""
+              id="root"
+              name="root"
+              placeholder=""
+              readonly=""
+              type="text"
+              value="foo"
+            />
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div
+      class="emotion-4"
+    >
+      <button
+        class="chakra-button emotion-5"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+  <span
+    hidden=""
+  />
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with allowClearTextInputs and value 1`] = `
+<DocumentFragment>
+  @layer recipes {
+  .emotion-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+  }
+
+  .emotion-0>:not(style, [hidden])~:not(style, [hidden]) {
+    --space-y-reverse: 0;
+    margin-top: calc(var(--chakra-spacing-4) * calc(1 - var(--space-y-reverse)));
+    margin-bottom: calc(var(--chakra-spacing-4) * var(--space-y-reverse));
+  }
+}
+
+@layer recipes {
+  .emotion-1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+    gap: var(--chakra-spacing-4);
+  }
+}
+
+.emotion-2 {
+  margin-bottom: var(--chakra-spacing-1);
+}
+
+@layer recipes {
+  .emotion-2 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    width: 100%;
+    position: relative;
+    gap: var(--chakra-spacing-1\\.5);
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+@layer recipes {
+  .emotion-3 {
+    width: 100%;
+    min-width: var(--input-height);
+    outline: 0;
+    position: relative;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    text-align: start;
+    border-radius: var(--chakra-radii-l2);
+    height: var(--input-height);
+    --focus-color: var(--chakra-colors-color-palette-focus-ring);
+    --error-color: var(--chakra-colors-border-error);
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+    padding-inline: var(--chakra-spacing-3);
+    --input-height: var(--chakra-sizes-10);
+    background: var(--chakra-colors-transparent);
+    --bg-currentcolor: var(--chakra-colors-transparent);
+    border-width: 1px;
+    border-color: var(--chakra-colors-border);
+    --focus-ring-color: var(--focus-color);
+  }
+
+  .emotion-3:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-3:is([data-invalid], [aria-invalid=true], [data-state=invalid]) {
+    --focus-ring-color: var(--error-color);
+    border-color: var(--error-color);
+  }
+
+  .emotion-3:is(:focus-visible, [data-focus-visible]) {
+    outline-offset: 0px;
+    outline-width: var(--focus-ring-width, 1px);
+    outline-color: var(--focus-ring-color);
+    outline-style: var(--focus-ring-style, solid);
+    border-color: var(--focus-ring-color);
+  }
+}
+
+.emotion-4 {
+  padding-inline: 0;
+  padding-block: 0;
+}
+
+@layer recipes {
+  .emotion-4 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    position: relative;
+    border-radius: var(--chakra-radii-l2);
+    white-space: nowrap;
+    vertical-align: middle;
+    border-width: 1px;
+    border-color: var(--chakra-colors-transparent);
+    cursor: var(--chakra-cursor-button);
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    outline: 0;
+    line-height: 1.25rem;
+    isolation: isolate;
+    font-weight: var(--chakra-font-weights-medium);
+    transition-property: background-color,border-color,color,fill,stroke,opacity,box-shadow,translate,transform;
+    transition-duration: var(--chakra-durations-moderate);
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    height: var(--chakra-sizes-10);
+    min-width: var(--chakra-sizes-10);
+    font-size: var(--chakra-font-sizes-sm);
+    padding-inline: var(--chakra-spacing-4);
+    gap: var(--chakra-spacing-2);
+    background: var(--chakra-colors-color-palette-solid);
+    --bg-currentcolor: var(--chakra-colors-color-palette-solid);
+    color: var(--chakra-colors-color-palette-contrast);
+  }
+
+  .emotion-4:is(:focus-visible, [data-focus-visible]) {
+    outline-width: var(--focus-ring-width, 2px);
+    outline-offset: var(--focus-ring-offset, 2px);
+    outline-style: var(--focus-ring-style, solid);
+    outline-color: var(--focus-ring-color);
+  }
+
+  .emotion-4:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-4 :where(svg) {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    width: var(--chakra-sizes-5);
+    height: var(--chakra-sizes-5);
+  }
+
+  .emotion-4:is([aria-expanded=true], [data-expanded], [data-state=expanded]) {
+    --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+    background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+  }
+
+  @media (hover: hover) {
+    .emotion-4:is(:hover, [data-hover]):not(:disabled, [data-disabled]) {
+      --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+      background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+      --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    }
+  }
+}
+
+.emotion-4 :where(svg) {
+  font-size: 1.2em;
+}
+
+.emotion-5 {
+  margin-top: var(--chakra-spacing-3);
+}
+
+@layer recipes {
+  .emotion-6 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    position: relative;
+    border-radius: var(--chakra-radii-l2);
+    white-space: nowrap;
+    vertical-align: middle;
+    border-width: 1px;
+    border-color: var(--chakra-colors-transparent);
+    cursor: var(--chakra-cursor-button);
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    outline: 0;
+    line-height: 1.25rem;
+    isolation: isolate;
+    font-weight: var(--chakra-font-weights-medium);
+    transition-property: background-color,border-color,color,fill,stroke,opacity,box-shadow,translate,transform;
+    transition-duration: var(--chakra-durations-moderate);
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    height: var(--chakra-sizes-10);
+    min-width: var(--chakra-sizes-10);
+    font-size: var(--chakra-font-sizes-sm);
+    padding-inline: var(--chakra-spacing-4);
+    gap: var(--chakra-spacing-2);
+    background: var(--chakra-colors-color-palette-solid);
+    --bg-currentcolor: var(--chakra-colors-color-palette-solid);
+    color: var(--chakra-colors-color-palette-contrast);
+  }
+
+  .emotion-6:is(:focus-visible, [data-focus-visible]) {
+    outline-width: var(--focus-ring-width, 2px);
+    outline-offset: var(--focus-ring-offset, 2px);
+    outline-style: var(--focus-ring-style, solid);
+    outline-color: var(--focus-ring-color);
+  }
+
+  .emotion-6:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-6 :where(svg) {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    width: var(--chakra-sizes-5);
+    height: var(--chakra-sizes-5);
+  }
+
+  .emotion-6:is([aria-expanded=true], [data-expanded], [data-state=expanded]) {
+    --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+    background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+  }
+
+  @media (hover: hover) {
+    .emotion-6:is(:hover, [data-hover]):not(:disabled, [data-disabled]) {
+      --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+      background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+      --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    }
+  }
+}
+
+<form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <fieldset
+        aria-labelledby="fieldset:::ri:::legend"
+        class="fieldset__root emotion-0"
+        data-part="root"
+        data-scope="fieldset"
+      >
+        <div
+          class="fieldset__content emotion-1"
+        >
+          <div
+            class="chakra-field__root emotion-2"
+            data-part="root"
+            data-scope="field"
+            id="field:::rj:"
+            role="group"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              class="chakra-input emotion-3"
+              data-part="input"
+              data-scope="field"
+              id="root"
+              name="root"
+              placeholder=""
+              type="text"
+              value="foo"
+            />
+            <button
+              aria-label="clear input"
+              class="chakra-button emotion-4"
+              title="clear input"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-x"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M18 6 6 18"
+                />
+                <path
+                  d="m6 6 12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div
+      class="emotion-5"
+    >
+      <button
+        class="chakra-button emotion-6"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+  <span
+    hidden=""
+  />
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with placeholder 1`] = `
 <DocumentFragment>
   @layer recipes {
   .emotion-0 {
@@ -37227,7 +37842,7 @@ exports[`single fields textarea field 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r15:::legend"
+        aria-labelledby="fieldset:::r19:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -37239,7 +37854,7 @@ exports[`single fields textarea field 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r16:"
+            id="field:::r1a:"
             role="group"
           >
             <textarea
@@ -37526,7 +38141,7 @@ exports[`single fields title field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r43:::legend"
+        aria-labelledby="fieldset:::r47:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -37557,7 +38172,7 @@ exports[`single fields title field 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r44:::legend"
+                  aria-labelledby="fieldset:::r48:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -37569,15 +38184,15 @@ exports[`single fields title field 1`] = `
                       class="chakra-field__root emotion-8"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r45:"
+                      id="field:::r49:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-9"
                         data-part="label"
                         data-scope="field"
-                        for=":r45:"
-                        id="field:::r45:::label"
+                        for=":r49:"
+                        id="field:::r49:::label"
                       >
                         Titre 2
                       </label>
@@ -37748,7 +38363,7 @@ exports[`single fields unsupported field 1`] = `
       class="rjsf-field rjsf-field-undefined"
     >
       <fieldset
-        aria-labelledby="fieldset:::rn:::legend"
+        aria-labelledby="fieldset:::rr:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -38142,7 +38757,7 @@ exports[`single fields up/down field 1`] = `
       class="rjsf-field rjsf-field-number"
     >
       <fieldset
-        aria-labelledby="fieldset:::r12:::legend"
+        aria-labelledby="fieldset:::r16:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -38154,7 +38769,7 @@ exports[`single fields up/down field 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r13:"
+            id="field:::r17:"
             role="group"
           >
             <div
@@ -38174,7 +38789,7 @@ exports[`single fields up/down field 1`] = `
                 role="group"
               >
                 <button
-                  aria-controls=":r13:"
+                  aria-controls=":r17:"
                   aria-label="increment value"
                   class="chakra-number-input__incrementTrigger emotion-5"
                   data-part="increment-trigger"
@@ -38194,7 +38809,7 @@ exports[`single fields up/down field 1`] = `
                   </svg>
                 </button>
                 <button
-                  aria-controls=":r13:"
+                  aria-controls=":r17:"
                   aria-label="decrease value"
                   class="chakra-number-input__decrementTrigger emotion-7"
                   data-part="decrement-trigger"
@@ -38224,7 +38839,7 @@ exports[`single fields up/down field 1`] = `
                 data-part="input"
                 data-scope="number-input"
                 dir="ltr"
-                id=":r13:"
+                id=":r17:"
                 inputmode="decimal"
                 name="root"
                 pattern="-?[0-9]*(.[0-9]+)?"
@@ -38453,7 +39068,7 @@ exports[`single fields using custom tagName 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r48:::legend"
+        aria-labelledby="fieldset:::r4c:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -38465,7 +39080,7 @@ exports[`single fields using custom tagName 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r49:"
+            id="field:::r4d:"
             role="group"
           >
             <input

--- a/packages/core/test/__snapshots__/FormSnap.test.tsx.snap
+++ b/packages/core/test/__snapshots__/FormSnap.test.tsx.snap
@@ -6542,7 +6542,79 @@ exports[`single fields string field required field with markdown help 1`] = `
 </DocumentFragment>
 `;
 
-exports[`single fields string field with placeholder 1`] = `
+exports[`single fields string field string field with allowClearTextInputs and readonly 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="form-group rjsf-field rjsf-field-string"
+    >
+      <input
+        aria-describedby="root__error root__description root__help"
+        class="form-control"
+        id="root"
+        label=""
+        name="root"
+        placeholder=""
+        readonly=""
+        type="text"
+        value="foo"
+      />
+    </div>
+    <div>
+      <button
+        class="btn btn-info "
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with allowClearTextInputs and value 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="form-group rjsf-field rjsf-field-string"
+    >
+      <input
+        aria-describedby="root__error root__description root__help"
+        class="form-control"
+        id="root"
+        label=""
+        name="root"
+        placeholder=""
+        type="text"
+        value="foo"
+      />
+      <button
+        class="btn btn-default btn-clear col-xs-12"
+        title="clear input"
+        type="button"
+      >
+        <i
+          class="glyphicon glyphicon-remove"
+        />
+      </button>
+    </div>
+    <div>
+      <button
+        class="btn btn-info "
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with placeholder 1`] = `
 <DocumentFragment>
   <form
     class="rjsf"

--- a/packages/daisyui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/daisyui/test/__snapshots__/Form.test.tsx.snap
@@ -13186,7 +13186,159 @@ exports[`single fields string field required field with markdown help 1`] = `
 </DocumentFragment>
 `;
 
-exports[`single fields string field with placeholder 1`] = `
+exports[`single fields string field string field with allowClearTextInputs and readonly 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="flex-grow rjsf-field rjsf-field-string"
+    >
+      <div
+        class="field-template mb-3 rjsf-field rjsf-field-string"
+      >
+        <label
+          class="label"
+          for="root"
+        >
+          <span
+            class="label-text font-medium"
+          />
+        </label>
+        <div
+          class="form-control"
+        >
+          <label
+            class="label hidden"
+            for="root"
+            style="display: none;"
+          >
+            <span
+              class="label-text"
+            />
+          </label>
+          <div
+            style="position: relative;"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              class="input input-bordered w-full"
+              disabled=""
+              id="root"
+              name="root"
+              placeholder=""
+              type="text"
+              value="foo"
+            />
+          </div>
+        </div>
+        <div
+          class="rjsf-field-error-template text-red-600"
+        >
+          <ul
+            class="list-disc list-inside"
+          />
+        </div>
+      </div>
+    </div>
+    <div>
+      <button
+        class="btn btn-primary btn-primary-content "
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with allowClearTextInputs and value 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="flex-grow rjsf-field rjsf-field-string"
+    >
+      <div
+        class="field-template mb-3 rjsf-field rjsf-field-string"
+      >
+        <label
+          class="label"
+          for="root"
+        >
+          <span
+            class="label-text font-medium"
+          />
+        </label>
+        <div
+          class="form-control"
+        >
+          <label
+            class="label hidden"
+            for="root"
+            style="display: none;"
+          >
+            <span
+              class="label-text"
+            />
+          </label>
+          <div
+            style="position: relative;"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              class="input input-bordered w-full"
+              id="root"
+              name="root"
+              placeholder=""
+              type="text"
+              value="foo"
+            />
+            <button
+              aria-label="clear input"
+              title="clear input"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark h-5 w-5"
+                data-icon="xmark"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="rjsf-field-error-template text-red-600"
+        >
+          <ul
+            class="list-disc list-inside"
+          />
+        </div>
+      </div>
+    </div>
+    <div>
+      <button
+        class="btn btn-primary btn-primary-content "
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with placeholder 1`] = `
 <DocumentFragment>
   <form
     class="rjsf"

--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -161,6 +161,36 @@ Will result in:
 </div>
 ```
 
+### allowClearTextInputs
+
+The optional `ui:allowClearTextInputs` uiSchema directive enables a clear/reset button for text-based input widgets.
+When set to true, a clear button will be displayed when the input field has a value and is not readonly or disabled.
+When omitted, no clear button will be displayed for text input fields.
+
+```tsx
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+const schema: RJSFSchema = { type: 'string' };
+const uiSchema: UiSchema = {
+  'ui:allowClearTextInputs': true,
+};
+```
+
+It can also be enabled globally by setting the `allowClearTextInputs` option to `true` in the `ui:globalOptions`
+uiSchema directive.
+
+```tsx
+import { Form } from '@rjsf/core';
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+import validator from '@rjsf/validator-ajv8';
+
+const schema: RJSFSchema = { type: 'string' };
+const uiSchema: UiSchema = {
+  'ui:globalOptions': {
+    allowClearTextInputs: true,
+  },
+};
+```
+
 ### autocomplete
 
 If you want to mark a text input, select or textarea input to use the HTML autocomplete feature, set the `ui:autocomplete` uiSchema directive to a valid [HTML autocomplete value](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values).

--- a/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
@@ -1286,8 +1286,8 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                 >
                   <label
                     class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-                    for="field-r9k__control"
-                    id="field-r9k__label"
+                    for="field-r9m__control"
+                    id="field-r9m__label"
                   >
                     color
                   </label>
@@ -1297,7 +1297,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                     <button
                       aria-describedby="root_color__error root_color__description root_color__help"
                       aria-expanded="false"
-                      aria-labelledby="field-r9k__label"
+                      aria-labelledby="field-r9m__label"
                       class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                       id="root_color"
                       name="root[color]"
@@ -2627,8 +2627,8 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                 >
                   <label
                     class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-                    for="field-rb4__control"
-                    id="field-rb4__label"
+                    for="field-rb6__control"
+                    id="field-rb6__label"
                   >
                     color
                   </label>
@@ -2638,7 +2638,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                     <button
                       aria-describedby="root_color__error root_color__description root_color__help"
                       aria-expanded="false"
-                      aria-labelledby="field-rb4__label"
+                      aria-labelledby="field-rb6__label"
                       class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                       id="root_color"
                       name="root.color"
@@ -4843,8 +4843,8 @@ exports[`single fields optional data controls does not show optional controls wh
                     >
                       <label
                         class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-                        for="field-r47__control"
-                        id="field-r47__label"
+                        for="field-r49__control"
+                        id="field-r49__label"
                       >
                         optionalObjectWithOneofs
                       </label>
@@ -4854,7 +4854,7 @@ exports[`single fields optional data controls does not show optional controls wh
                         <button
                           aria-describedby="root_optionalObjectWithOneofs__oneof_select__error root_optionalObjectWithOneofs__oneof_select__description root_optionalObjectWithOneofs__oneof_select__help"
                           aria-expanded="false"
-                          aria-labelledby="field-r47__label"
+                          aria-labelledby="field-r49__label"
                           class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                           id="root_optionalObjectWithOneofs__oneof_select"
                           name="root_optionalObjectWithOneofs__oneof_select"
@@ -4990,8 +4990,8 @@ exports[`single fields optional data controls does not show optional controls wh
                     >
                       <label
                         class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-                        for="field-r4d__control"
-                        id="field-r4d__label"
+                        for="field-r4f__control"
+                        id="field-r4f__label"
                       >
                         optionalArrayWithAnyofs
                       </label>
@@ -5001,7 +5001,7 @@ exports[`single fields optional data controls does not show optional controls wh
                         <button
                           aria-describedby="root_optionalArrayWithAnyofs__anyof_select__error root_optionalArrayWithAnyofs__anyof_select__description root_optionalArrayWithAnyofs__anyof_select__help"
                           aria-expanded="false"
-                          aria-labelledby="field-r4d__label"
+                          aria-labelledby="field-r4f__label"
                           class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                           id="root_optionalArrayWithAnyofs__anyof_select"
                           name="root_optionalArrayWithAnyofs__anyof_select"
@@ -5759,8 +5759,8 @@ exports[`single fields optional data controls does not show optional controls wh
                     >
                       <label
                         class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-                        for="field-r6p__control"
-                        id="field-r6p__label"
+                        for="field-r6r__control"
+                        id="field-r6r__label"
                       >
                         optionalObjectWithOneofs
                       </label>
@@ -5770,7 +5770,7 @@ exports[`single fields optional data controls does not show optional controls wh
                         <button
                           aria-describedby="root_optionalObjectWithOneofs__oneof_select__error root_optionalObjectWithOneofs__oneof_select__description root_optionalObjectWithOneofs__oneof_select__help"
                           aria-expanded="false"
-                          aria-labelledby="field-r6p__label"
+                          aria-labelledby="field-r6r__label"
                           class="fui-Dropdown__button ___b67tb00_4t2umz0 f122n59 f1c21dwh f3bhgqh f1ewtqcl f1s2aq7o f14mj54c fdrzuqr f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                           disabled=""
                           id="root_optionalObjectWithOneofs__oneof_select"
@@ -5906,8 +5906,8 @@ exports[`single fields optional data controls does not show optional controls wh
                     >
                       <label
                         class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-                        for="field-r6v__control"
-                        id="field-r6v__label"
+                        for="field-r71__control"
+                        id="field-r71__label"
                       >
                         optionalArrayWithAnyofs
                       </label>
@@ -5917,7 +5917,7 @@ exports[`single fields optional data controls does not show optional controls wh
                         <button
                           aria-describedby="root_optionalArrayWithAnyofs__anyof_select__error root_optionalArrayWithAnyofs__anyof_select__description root_optionalArrayWithAnyofs__anyof_select__help"
                           aria-expanded="false"
-                          aria-labelledby="field-r6v__label"
+                          aria-labelledby="field-r71__label"
                           class="fui-Dropdown__button ___b67tb00_4t2umz0 f122n59 f1c21dwh f3bhgqh f1ewtqcl f1s2aq7o f14mj54c fdrzuqr f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                           disabled=""
                           id="root_optionalArrayWithAnyofs__anyof_select"
@@ -8867,8 +8867,8 @@ exports[`single fields select field 1`] = `
         >
           <label
             class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-            for="field-rl__control"
-            id="field-rl__label"
+            for="field-rn__control"
+            id="field-rn__label"
           />
           <div
             class="fui-Dropdown form-control ___y239tk0_6yts2b0 ft85np5 f1ewtqcl ftuwxu6 f1exfvgq f10pi13n fmrv4ls f14a1fxs f3e99gv fhljsf7 f1gw3sf2 f13zj6fq f1mdlcz9 f1a7op3 f1gboi2j f1cjjd47 ffyw7fx f1kp91vd f1ibwz09 f1mnjydx f13evtba f1yk9hq fhwpy7i f14ee0xe f1xhbsuh fv8e3ye ftb5wc6 fjw5xc1 f1xdyd5c fatpbeo fb7uyps f1cmft4k f1x58t8o f1ibeo51 f132nw8t f1htdosj fxugw4r f1c1zstj fhz96rm fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi fvs00aa f1assf6x f1z0osm6 f4ruux4 f1b473iu f381qr8 f1qzcrsd ft4skwv"
@@ -8876,7 +8876,7 @@ exports[`single fields select field 1`] = `
             <button
               aria-describedby="root__error root__description root__help"
               aria-expanded="false"
-              aria-labelledby="field-rl__label"
+              aria-labelledby="field-rn__label"
               class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
               id="root"
               name="root"
@@ -8958,8 +8958,8 @@ exports[`single fields select field multiple choice 1`] = `
         >
           <label
             class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-            for="field-ro__control"
-            id="field-ro__label"
+            for="field-rq__control"
+            id="field-rq__label"
           />
           <div
             class="fui-Dropdown form-control ___y239tk0_6yts2b0 ft85np5 f1ewtqcl ftuwxu6 f1exfvgq f10pi13n fmrv4ls f14a1fxs f3e99gv fhljsf7 f1gw3sf2 f13zj6fq f1mdlcz9 f1a7op3 f1gboi2j f1cjjd47 ffyw7fx f1kp91vd f1ibwz09 f1mnjydx f13evtba f1yk9hq fhwpy7i f14ee0xe f1xhbsuh fv8e3ye ftb5wc6 fjw5xc1 f1xdyd5c fatpbeo fb7uyps f1cmft4k f1x58t8o f1ibeo51 f132nw8t f1htdosj fxugw4r f1c1zstj fhz96rm fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi fvs00aa f1assf6x f1z0osm6 f4ruux4 f1b473iu f381qr8 f1qzcrsd ft4skwv"
@@ -8967,7 +8967,7 @@ exports[`single fields select field multiple choice 1`] = `
             <button
               aria-describedby="root__error root__description root__help"
               aria-expanded="false"
-              aria-labelledby="field-ro__label"
+              aria-labelledby="field-rq__label"
               class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
               id="root"
               name="root"
@@ -9029,8 +9029,8 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
         >
           <label
             class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-            for="field-r1d__control"
-            id="field-r1d__label"
+            for="field-r1f__control"
+            id="field-r1f__label"
           />
           <div
             class="fui-Dropdown form-control ___y239tk0_6yts2b0 ft85np5 f1ewtqcl ftuwxu6 f1exfvgq f10pi13n fmrv4ls f14a1fxs f3e99gv fhljsf7 f1gw3sf2 f13zj6fq f1mdlcz9 f1a7op3 f1gboi2j f1cjjd47 ffyw7fx f1kp91vd f1ibwz09 f1mnjydx f13evtba f1yk9hq fhwpy7i f14ee0xe f1xhbsuh fv8e3ye ftb5wc6 fjw5xc1 f1xdyd5c fatpbeo fb7uyps f1cmft4k f1x58t8o f1ibeo51 f132nw8t f1htdosj fxugw4r f1c1zstj fhz96rm fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi fvs00aa f1assf6x f1z0osm6 f4ruux4 f1b473iu f381qr8 f1qzcrsd ft4skwv"
@@ -9038,7 +9038,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
             <button
               aria-describedby="root__error root__description root__help"
               aria-expanded="false"
-              aria-labelledby="field-r1d__label"
+              aria-labelledby="field-r1f__label"
               class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
               id="root"
               name="root"
@@ -9220,8 +9220,8 @@ exports[`single fields select field multiple choice formData 1`] = `
         >
           <label
             class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-            for="field-r20__control"
-            id="field-r20__label"
+            for="field-r22__control"
+            id="field-r22__label"
           />
           <div
             class="fui-Dropdown form-control ___y239tk0_6yts2b0 ft85np5 f1ewtqcl ftuwxu6 f1exfvgq f10pi13n fmrv4ls f14a1fxs f3e99gv fhljsf7 f1gw3sf2 f13zj6fq f1mdlcz9 f1a7op3 f1gboi2j f1cjjd47 ffyw7fx f1kp91vd f1ibwz09 f1mnjydx f13evtba f1yk9hq fhwpy7i f14ee0xe f1xhbsuh fv8e3ye ftb5wc6 fjw5xc1 f1xdyd5c fatpbeo fb7uyps f1cmft4k f1x58t8o f1ibeo51 f132nw8t f1htdosj fxugw4r f1c1zstj fhz96rm fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi fvs00aa f1assf6x f1z0osm6 f4ruux4 f1b473iu f381qr8 f1qzcrsd ft4skwv"
@@ -9229,7 +9229,7 @@ exports[`single fields select field multiple choice formData 1`] = `
             <button
               aria-describedby="root__error root__description root__help"
               aria-expanded="false"
-              aria-labelledby="field-r20__label"
+              aria-labelledby="field-r22__label"
               class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
               id="root"
               name="root"
@@ -9292,8 +9292,8 @@ exports[`single fields select field multiple choice with labels 1`] = `
         >
           <label
             class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-            for="field-rr__control"
-            id="field-rr__label"
+            for="field-rt__control"
+            id="field-rt__label"
           />
           <div
             class="fui-Dropdown form-control ___y239tk0_6yts2b0 ft85np5 f1ewtqcl ftuwxu6 f1exfvgq f10pi13n fmrv4ls f14a1fxs f3e99gv fhljsf7 f1gw3sf2 f13zj6fq f1mdlcz9 f1a7op3 f1gboi2j f1cjjd47 ffyw7fx f1kp91vd f1ibwz09 f1mnjydx f13evtba f1yk9hq fhwpy7i f14ee0xe f1xhbsuh fv8e3ye ftb5wc6 fjw5xc1 f1xdyd5c fatpbeo fb7uyps f1cmft4k f1x58t8o f1ibeo51 f132nw8t f1htdosj fxugw4r f1c1zstj fhz96rm fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi fvs00aa f1assf6x f1z0osm6 f4ruux4 f1b473iu f381qr8 f1qzcrsd ft4skwv"
@@ -9301,7 +9301,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
             <button
               aria-describedby="root__error root__description root__help"
               aria-expanded="false"
-              aria-labelledby="field-rr__label"
+              aria-labelledby="field-rt__label"
               class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
               id="root"
               name="root"
@@ -9363,8 +9363,8 @@ exports[`single fields select field single choice enumDisabled 1`] = `
         >
           <label
             class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-            for="field-ru__control"
-            id="field-ru__label"
+            for="field-r10__control"
+            id="field-r10__label"
           />
           <div
             class="fui-Dropdown form-control ___y239tk0_6yts2b0 ft85np5 f1ewtqcl ftuwxu6 f1exfvgq f10pi13n fmrv4ls f14a1fxs f3e99gv fhljsf7 f1gw3sf2 f13zj6fq f1mdlcz9 f1a7op3 f1gboi2j f1cjjd47 ffyw7fx f1kp91vd f1ibwz09 f1mnjydx f13evtba f1yk9hq fhwpy7i f14ee0xe f1xhbsuh fv8e3ye ftb5wc6 fjw5xc1 f1xdyd5c fatpbeo fb7uyps f1cmft4k f1x58t8o f1ibeo51 f132nw8t f1htdosj fxugw4r f1c1zstj fhz96rm fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi fvs00aa f1assf6x f1z0osm6 f4ruux4 f1b473iu f381qr8 f1qzcrsd ft4skwv"
@@ -9372,7 +9372,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
             <button
               aria-describedby="root__error root__description root__help"
               aria-expanded="false"
-              aria-labelledby="field-ru__label"
+              aria-labelledby="field-r10__label"
               class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
               id="root"
               name="root"
@@ -9622,8 +9622,8 @@ exports[`single fields select field single choice formData 1`] = `
         >
           <label
             class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-            for="field-r1t__control"
-            id="field-r1t__label"
+            for="field-r1v__control"
+            id="field-r1v__label"
           />
           <div
             class="fui-Dropdown form-control ___y239tk0_6yts2b0 ft85np5 f1ewtqcl ftuwxu6 f1exfvgq f10pi13n fmrv4ls f14a1fxs f3e99gv fhljsf7 f1gw3sf2 f13zj6fq f1mdlcz9 f1a7op3 f1gboi2j f1cjjd47 ffyw7fx f1kp91vd f1ibwz09 f1mnjydx f13evtba f1yk9hq fhwpy7i f14ee0xe f1xhbsuh fv8e3ye ftb5wc6 fjw5xc1 f1xdyd5c fatpbeo fb7uyps f1cmft4k f1x58t8o f1ibeo51 f132nw8t f1htdosj fxugw4r f1c1zstj fhz96rm fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi fvs00aa f1assf6x f1z0osm6 f4ruux4 f1b473iu f381qr8 f1qzcrsd ft4skwv"
@@ -9631,7 +9631,7 @@ exports[`single fields select field single choice formData 1`] = `
             <button
               aria-describedby="root__error root__description root__help"
               aria-expanded="false"
-              aria-labelledby="field-r1t__label"
+              aria-labelledby="field-r1v__label"
               class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
               id="root"
               name="root"
@@ -9798,8 +9798,8 @@ exports[`single fields select widget with description in schema and FieldTemplat
         >
           <label
             class="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-            for="field-r2h__control"
-            id="field-r2h__label"
+            for="field-r2j__control"
+            id="field-r2j__label"
           >
             test
           </label>
@@ -9809,7 +9809,7 @@ exports[`single fields select widget with description in schema and FieldTemplat
             <button
               aria-describedby="root__error root__description root__help"
               aria-expanded="false"
-              aria-labelledby="field-r2h__label"
+              aria-labelledby="field-r2j__label"
               class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
               id="root"
               name="root"
@@ -10396,7 +10396,120 @@ exports[`single fields string field required field with markdown help 1`] = `
 </DocumentFragment>
 `;
 
-exports[`single fields string field with placeholder 1`] = `
+exports[`single fields string field string field with allowClearTextInputs and readonly 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="___r7kt3y0_0000000 fqerorx rjsf-field rjsf-field-string"
+    >
+      <div
+        class="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+      >
+        <label
+          class="fui-Label ___zkh2gz0_1ef3qts fk6fouc f19n0e5 fkhj508 f1i3iumi fq1loh5 futqtb8 f14rdt9"
+          for="root"
+        />
+        <span
+          class="fui-Input r1oeeo9n ___yxsf370_rc74k80 fdrzuqr f1c21dwh f1jj8ep1 f15xbau f4ikngz fy0fskl fg455y9 f1rvyvqg f1cwzwz f14g86mu fhr9occ f99w1ws"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            class="fui-Input__input r12stul0 ___yujd800_1sg4u0d f1s2aq7o f1c21dwh fdrzuqr fahhnxm fly5x3f"
+            disabled=""
+            id="root"
+            name="root"
+            placeholder=""
+            type="text"
+            value="foo"
+          />
+        </span>
+      </div>
+    </div>
+    <div
+      class="___fko12g0_0000000 f1wswflg"
+    >
+      <button
+        class="fui-Button r1alrhcs ___1akj6hk_ih97uj0 ffp7eso f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1phragk f15wkkf3 f1s2uweq fr80ssc f1ukrpxl fecsdlb f1rq72xc fnp9lpt f1h0usnq fs4ktlq f16h9ulv fx2bmrt f1d6v5y2 f1rirnrt f1uu00uk fkvaka8 f1ux7til f9a0qzu f1lkg8j3 fkc42ay fq7113v ff1wgvm fiob0tu f1j6scgf f1x4h75k f4xjyn1 fbgcvur f1ks1yx8 f1o6qegi fcnxywj fmxjhhp f9ddjv3 f17t0x8g f194v5ow f1qgg65p fk7jm04 fhgccpy f32wu9k fu5nqqq f13prjl2 f1czftr5 f1nl83rv f12k37oa fr96u23"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with allowClearTextInputs and value 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="___r7kt3y0_0000000 fqerorx rjsf-field rjsf-field-string"
+    >
+      <div
+        class="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+      >
+        <label
+          class="fui-Label ___zkh2gz0_1ef3qts fk6fouc f19n0e5 fkhj508 f1i3iumi fq1loh5 futqtb8 f14rdt9"
+          for="root"
+        />
+        <span
+          class="fui-Input r1oeeo9n ___1v9icnz_137yv9i fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi f8vnjqi fz1etlk f1klwx88 f1hc16gm"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            class="fui-Input__input r12stul0 ___cqaz2i0_9xw1o20 fly5x3f"
+            id="root"
+            name="root"
+            placeholder=""
+            type="text"
+            value="foo"
+          />
+        </span>
+        <button
+          class="fui-Button r1alrhcs ___1j82qye_10z14xp f18ktai2 fwbmr0d f44c6la"
+          title="clear input"
+          type="button"
+        >
+          <span
+            class="fui-Button__icon rywnvv2"
+          >
+            <svg
+              aria-hidden="true"
+              class="___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
+              fill="currentColor"
+              height="1em"
+              viewBox="0 0 20 20"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      class="___fko12g0_0000000 f1wswflg"
+    >
+      <button
+        class="fui-Button r1alrhcs ___1akj6hk_ih97uj0 ffp7eso f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1phragk f15wkkf3 f1s2uweq fr80ssc f1ukrpxl fecsdlb f1rq72xc fnp9lpt f1h0usnq fs4ktlq f16h9ulv fx2bmrt f1d6v5y2 f1rirnrt f1uu00uk fkvaka8 f1ux7til f9a0qzu f1lkg8j3 fkc42ay fq7113v ff1wgvm fiob0tu f1j6scgf f1x4h75k f4xjyn1 fbgcvur f1ks1yx8 f1o6qegi fcnxywj fmxjhhp f9ddjv3 f17t0x8g f194v5ow f1qgg65p fk7jm04 fhgccpy f32wu9k fu5nqqq f13prjl2 f1czftr5 f1nl83rv f12k37oa fr96u23"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with placeholder 1`] = `
 <DocumentFragment>
   <form
     class="rjsf"

--- a/packages/mantine/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mantine/test/__snapshots__/Form.test.tsx.snap
@@ -31,10 +31,10 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1dp{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1e7{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1dp"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1e7"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -68,7 +68,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1e0"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1ee"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -95,10 +95,10 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-r1e5{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                              .__m__-r1ej{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                             </style>
                             <div
-                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1e5"
+                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1ej"
                               style="margin-bottom: var(--mantine-spacing-sm);"
                             >
                               <div
@@ -321,7 +321,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1es"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1fa"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -348,10 +348,10 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-r1f1{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                              .__m__-r1ff{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                             </style>
                             <div
-                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1f1"
+                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1ff"
                               style="margin-bottom: var(--mantine-spacing-sm);"
                             >
                               <div
@@ -672,10 +672,10 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1cd{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1cr{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1cd"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1cr"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -709,7 +709,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1ck"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1d2"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -882,7 +882,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1d4"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1di"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -1151,10 +1151,10 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1hh{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1hv{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1hh"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1hv"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -1178,7 +1178,7 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
                   role="group"
                 >
                   <div
-                    class="m_8bffd616 mantine-Flex-root __m__-r1hn"
+                    class="m_8bffd616 mantine-Flex-root __m__-r1i5"
                     style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
                   >
                     <div
@@ -1381,10 +1381,10 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1b6{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1bk{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1b6"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1bk"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -1410,10 +1410,10 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r1bb{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r1bp{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1bb"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1bp"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -1515,10 +1515,10 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r1bs{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r1ca{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1bs"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ca"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -1659,10 +1659,10 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1gp{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1h7{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1gp"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1h7"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -1686,7 +1686,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                   role="radiogroup"
                 >
                   <div
-                    class="m_8bffd616 mantine-Flex-root __m__-r1h0"
+                    class="m_8bffd616 mantine-Flex-root __m__-r1he"
                     style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
                   >
                     <div
@@ -1840,10 +1840,10 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1ft{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1gb{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ft"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1gb"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -1943,7 +1943,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1gg:"
+                              id=":r1gu:"
                               role="option"
                               value="0"
                             >
@@ -1955,7 +1955,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1gi:"
+                              id=":r1h0:"
                               role="option"
                               value="1"
                             >
@@ -1967,7 +1967,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1gk:"
+                              id=":r1h2:"
                               role="option"
                               value="2"
                             >
@@ -2057,10 +2057,10 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1ac{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1aq{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ac"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1aq"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -2302,10 +2302,10 @@ exports[`nameGenerator bracketNameGenerator textarea field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1ie{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1is{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ie"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1is"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -2399,10 +2399,10 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1m6{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1mk{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1m6"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1mk"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -2436,7 +2436,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1md"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1mr"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -2463,10 +2463,10 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-r1mi{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                              .__m__-r1n0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                             </style>
                             <div
-                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1mi"
+                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1n0"
                               style="margin-bottom: var(--mantine-spacing-sm);"
                             >
                               <div
@@ -2689,7 +2689,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1n9"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1nn"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -2716,10 +2716,10 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-r1ne{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                              .__m__-r1ns{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                             </style>
                             <div
-                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1ne"
+                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1ns"
                               style="margin-bottom: var(--mantine-spacing-sm);"
                             >
                               <div
@@ -3040,10 +3040,10 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1kq{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1l8{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1kq"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1l8"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -3077,7 +3077,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1l1"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1lf"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -3250,7 +3250,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1lh"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1lv"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -3519,10 +3519,10 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1jj{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1k1{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1jj"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1k1"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -3548,10 +3548,10 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r1jo{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r1k6{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1jo"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1k6"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -3653,10 +3653,10 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r1k9{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r1kn{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1k9"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1kn"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -3797,10 +3797,10 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1oa{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1oo{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1oa"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1oo"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -3900,7 +3900,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1ot:"
+                              id=":r1pb:"
                               role="option"
                               value="0"
                             >
@@ -3912,7 +3912,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1ov:"
+                              id=":r1pd:"
                               role="option"
                               value="1"
                             >
@@ -3924,7 +3924,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1p1:"
+                              id=":r1pf:"
                               role="option"
                               value="2"
                             >
@@ -4014,10 +4014,10 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1ip{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1j7{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ip"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1j7"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -4737,7 +4737,7 @@ exports[`single fields checkboxes field 1`] = `
           role="group"
         >
           <div
-            class="m_8bffd616 mantine-Flex-root __m__-rgq"
+            class="m_8bffd616 mantine-Flex-root __m__-rh8"
             style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
           >
             <div
@@ -4989,7 +4989,7 @@ exports[`single fields checkboxes widget with custom options and labels 1`] = `
           role="group"
         >
           <div
-            class="m_8bffd616 mantine-Flex-root __m__-rav"
+            class="m_8bffd616 mantine-Flex-root __m__-rbd"
             style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: row; margin-top: var(--mantine-spacing-xs);"
           >
             <div
@@ -5204,7 +5204,7 @@ exports[`single fields checkboxes widget with required field 1`] = `
           role="group"
         >
           <div
-            class="m_8bffd616 mantine-Flex-root __m__-rbp"
+            class="m_8bffd616 mantine-Flex-root __m__-rc7"
             style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
           >
             <div
@@ -5403,10 +5403,10 @@ exports[`single fields field with description 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rim{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rj4{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rim"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rj4"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -5510,10 +5510,10 @@ exports[`single fields field with description in uiSchema 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rj2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rjg{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rj2"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rjg"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -5617,10 +5617,10 @@ exports[`single fields field with markdown description 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rje{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rjs{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rje"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rjs"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -5724,10 +5724,10 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rjq{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rk8{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rjq"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rk8"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -6312,10 +6312,10 @@ exports[`single fields hidden field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rih{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-riv{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rih"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-riv"
           style="margin-bottom: var(--mantine-spacing-sm);"
         />
       </div>
@@ -6721,10 +6721,10 @@ exports[`single fields optional data controls does not show optional controls wh
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rll{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rm3{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rll"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rm3"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -6750,10 +6750,10 @@ exports[`single fields optional data controls does not show optional controls wh
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rlq{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rm8{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rlq"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rm8"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -6817,10 +6817,10 @@ exports[`single fields optional data controls does not show optional controls wh
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rm5{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-rmj{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-rm5"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-rmj"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -6888,10 +6888,10 @@ exports[`single fields optional data controls does not show optional controls wh
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rmg{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-rmu{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-rmg"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-rmu"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -7251,10 +7251,10 @@ exports[`single fields optional data controls does not show optional controls wh
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rnn{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-ro5{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rnn"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-ro5"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -7473,7 +7473,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 data-checked="true"
                                 data-combobox-active="true"
                                 data-combobox-option="true"
-                                id=":roo:"
+                                id=":rp6:"
                                 role="option"
                                 value="0"
                               >
@@ -7499,7 +7499,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":roq:"
+                                id=":rp8:"
                                 role="option"
                                 value="1"
                               >
@@ -7511,7 +7511,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":ros:"
+                                id=":rpa:"
                                 role="option"
                                 value="2"
                               >
@@ -7565,10 +7565,10 @@ exports[`single fields optional data controls does not show optional controls wh
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rp0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-rpe{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-rp0"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-rpe"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     >
                       <div
@@ -7720,7 +7720,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 data-checked="true"
                                 data-combobox-active="true"
                                 data-combobox-option="true"
-                                id=":rpq:"
+                                id=":rq8:"
                                 role="option"
                                 value="0"
                               >
@@ -7746,7 +7746,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":rps:"
+                                id=":rqa:"
                                 role="option"
                                 value="1"
                               >
@@ -7758,7 +7758,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":rpu:"
+                                id=":rqc:"
                                 role="option"
                                 value="2"
                               >
@@ -7925,10 +7925,10 @@ exports[`single fields optional data controls does not show optional controls wh
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r119{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r11n{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r119"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r11n"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -7954,10 +7954,10 @@ exports[`single fields optional data controls does not show optional controls wh
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r11e{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r11s{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r11e"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r11s"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -8024,10 +8024,10 @@ exports[`single fields optional data controls does not show optional controls wh
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r11p{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r127{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r11p"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r127"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -8098,10 +8098,10 @@ exports[`single fields optional data controls does not show optional controls wh
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r124{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r12i{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r124"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r12i"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -8472,10 +8472,10 @@ exports[`single fields optional data controls does not show optional controls wh
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r13b{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r13p{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r13b"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r13p"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -8703,7 +8703,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 data-checked="true"
                                 data-combobox-active="true"
                                 data-combobox-option="true"
-                                id=":r14c:"
+                                id=":r14q:"
                                 role="option"
                                 value="0"
                               >
@@ -8729,7 +8729,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":r14e:"
+                                id=":r14s:"
                                 role="option"
                                 value="1"
                               >
@@ -8741,7 +8741,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":r14g:"
+                                id=":r14u:"
                                 role="option"
                                 value="2"
                               >
@@ -8796,10 +8796,10 @@ exports[`single fields optional data controls does not show optional controls wh
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r14k{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-r152{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-r14k"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-r152"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     >
                       <div
@@ -8955,7 +8955,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 data-checked="true"
                                 data-combobox-active="true"
                                 data-combobox-option="true"
-                                id=":r15e:"
+                                id=":r15s:"
                                 role="option"
                                 value="0"
                               >
@@ -8981,7 +8981,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":r15g:"
+                                id=":r15u:"
                                 role="option"
                                 value="1"
                               >
@@ -8993,7 +8993,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":r15i:"
+                                id=":r160:"
                                 role="option"
                                 value="2"
                               >
@@ -9163,10 +9163,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rsm{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rt4{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rsm"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rt4"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -9184,10 +9184,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rsq{--grid-gutter:var(--mantine-spacing-md);}
+                  .__m__-rt8{--grid-gutter:var(--mantine-spacing-md);}
                 </style>
                 <div
-                  class="m_410352e9 mantine-Grid-root __m__-rsq"
+                  class="m_410352e9 mantine-Grid-root __m__-rt8"
                 >
                   <div
                     class="m_dee7bd2f mantine-Grid-inner"
@@ -9195,10 +9195,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rss{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                      .__m__-rta{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                     </style>
                     <div
-                      class="m_96bdd299 mantine-Grid-col __m__-rss"
+                      class="m_96bdd299 mantine-Grid-col __m__-rta"
                     >
                       <h3
                         class="m_8a5d1357 mantine-Title-root"
@@ -9212,10 +9212,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rsv{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                      .__m__-rtd{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                     </style>
                     <div
-                      class="m_96bdd299 mantine-Grid-col __m__-rsv"
+                      class="m_96bdd299 mantine-Grid-col __m__-rtd"
                     >
                       <button
                         class="mantine-focus-auto mantine-active rjsf-remove-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -9261,10 +9261,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rt3{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rth{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rt3"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rth"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -9321,10 +9321,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rtd{--grid-gutter:var(--mantine-spacing-md);}
+                          .__m__-rtr{--grid-gutter:var(--mantine-spacing-md);}
                         </style>
                         <div
-                          class="m_410352e9 mantine-Grid-root __m__-rtd"
+                          class="m_410352e9 mantine-Grid-root __m__-rtr"
                         >
                           <div
                             class="m_dee7bd2f mantine-Grid-inner"
@@ -9332,10 +9332,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-rtf{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                              .__m__-rtt{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                             </style>
                             <div
-                              class="m_96bdd299 mantine-Grid-col __m__-rtf"
+                              class="m_96bdd299 mantine-Grid-col __m__-rtt"
                             >
                               <h3
                                 class="m_8a5d1357 mantine-Title-root"
@@ -9349,10 +9349,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-rti{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                              .__m__-ru0{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                             </style>
                             <div
-                              class="m_96bdd299 mantine-Grid-col __m__-rti"
+                              class="m_96bdd299 mantine-Grid-col __m__-ru0"
                             >
                               <button
                                 class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -9398,10 +9398,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rtm{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-ru4{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-rtm"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-ru4"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         />
                       </div>
@@ -9430,10 +9430,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rtr{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-ru9{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-rtr"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-ru9"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -9567,10 +9567,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-ruc{--grid-gutter:var(--mantine-spacing-md);}
+                            .__m__-ruq{--grid-gutter:var(--mantine-spacing-md);}
                           </style>
                           <div
-                            class="m_410352e9 mantine-Grid-root __m__-ruc"
+                            class="m_410352e9 mantine-Grid-root __m__-ruq"
                           >
                             <div
                               class="m_dee7bd2f mantine-Grid-inner"
@@ -9578,10 +9578,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                               <style
                                 data-mantine-styles="inline"
                               >
-                                .__m__-rue{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                                .__m__-rus{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                               </style>
                               <div
-                                class="m_96bdd299 mantine-Grid-col __m__-rue"
+                                class="m_96bdd299 mantine-Grid-col __m__-rus"
                               >
                                 <h4
                                   class="m_8a5d1357 mantine-Title-root"
@@ -9595,10 +9595,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                               <style
                                 data-mantine-styles="inline"
                               >
-                                .__m__-ruh{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                                .__m__-ruv{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                               </style>
                               <div
-                                class="m_96bdd299 mantine-Grid-col __m__-ruh"
+                                class="m_96bdd299 mantine-Grid-col __m__-ruv"
                               >
                                 <button
                                   class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -9741,10 +9741,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                   <style
                     data-mantine-styles="inline"
                   >
-                    .__m__-ruv{--grid-gutter:var(--mantine-spacing-md);}
+                    .__m__-rvd{--grid-gutter:var(--mantine-spacing-md);}
                   </style>
                   <div
-                    class="m_410352e9 mantine-Grid-root __m__-ruv"
+                    class="m_410352e9 mantine-Grid-root __m__-rvd"
                   >
                     <div
                       class="m_dee7bd2f mantine-Grid-inner"
@@ -9752,10 +9752,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-rv1{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                        .__m__-rvf{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                       </style>
                       <div
-                        class="m_96bdd299 mantine-Grid-col __m__-rv1"
+                        class="m_96bdd299 mantine-Grid-col __m__-rvf"
                       >
                         <h4
                           class="m_8a5d1357 mantine-Title-root"
@@ -9769,10 +9769,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-rv4{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                        .__m__-rvi{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                       </style>
                       <div
-                        class="m_96bdd299 mantine-Grid-col __m__-rv4"
+                        class="m_96bdd299 mantine-Grid-col __m__-rvi"
                       >
                         <button
                           class="mantine-focus-auto mantine-active rjsf-remove-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -9824,7 +9824,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-rva"
+                      class="m_8bffd616 mantine-Flex-root __m__-rvo"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -9990,10 +9990,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rvr{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r109{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rvr"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r109"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -10132,10 +10132,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r10d{--grid-gutter:var(--mantine-spacing-md);}
+                      .__m__-r10r{--grid-gutter:var(--mantine-spacing-md);}
                     </style>
                     <div
-                      class="m_410352e9 mantine-Grid-root __m__-r10d"
+                      class="m_410352e9 mantine-Grid-root __m__-r10r"
                     >
                       <div
                         class="m_dee7bd2f mantine-Grid-inner"
@@ -10143,10 +10143,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r10f{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                          .__m__-r10t{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                         </style>
                         <div
-                          class="m_96bdd299 mantine-Grid-col __m__-r10f"
+                          class="m_96bdd299 mantine-Grid-col __m__-r10t"
                         >
                           <h3
                             class="m_8a5d1357 mantine-Title-root"
@@ -10160,10 +10160,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r10i{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                          .__m__-r110{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                         </style>
                         <div
-                          class="m_96bdd299 mantine-Grid-col __m__-r10i"
+                          class="m_96bdd299 mantine-Grid-col __m__-r110"
                         >
                           <button
                             class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -10209,10 +10209,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r10m{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-r114{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-r10m"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-r114"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     />
                   </div>
@@ -10244,10 +10244,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-r10r{--grid-gutter:var(--mantine-spacing-md);}
+                        .__m__-r119{--grid-gutter:var(--mantine-spacing-md);}
                       </style>
                       <div
-                        class="m_410352e9 mantine-Grid-root __m__-r10r"
+                        class="m_410352e9 mantine-Grid-root __m__-r119"
                       >
                         <div
                           class="m_dee7bd2f mantine-Grid-inner"
@@ -10255,10 +10255,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-r10t{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                            .__m__-r11b{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                           </style>
                           <div
-                            class="m_96bdd299 mantine-Grid-col __m__-r10t"
+                            class="m_96bdd299 mantine-Grid-col __m__-r11b"
                           >
                             <h4
                               class="m_8a5d1357 mantine-Title-root"
@@ -10272,10 +10272,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-r110{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                            .__m__-r11e{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                           </style>
                           <div
-                            class="m_96bdd299 mantine-Grid-col __m__-r110"
+                            class="m_96bdd299 mantine-Grid-col __m__-r11e"
                           >
                             <button
                               class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -10389,10 +10389,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r17a{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r17o{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r17a"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r17o"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -10418,10 +10418,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r17f{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r17t{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r17f"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r17t"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -10489,10 +10489,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r17q{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r188{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r17q"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r188"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <em
@@ -10527,10 +10527,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r17v{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r18d{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r17v"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r18d"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -10796,7 +10796,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r18u"
+                      class="m_8bffd616 mantine-Flex-root __m__-r19c"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -10969,10 +10969,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r19f{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r19t{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r19f"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r19t"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -11124,10 +11124,10 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r1a2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-r1ag{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-r1a2"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-r1ag"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     >
                       <em
@@ -11247,10 +11247,10 @@ exports[`single fields optional data controls shows "add" optional controls when
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rqa{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rqo{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rqa"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rqo"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -11268,10 +11268,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rqe{--grid-gutter:var(--mantine-spacing-md);}
+                  .__m__-rqs{--grid-gutter:var(--mantine-spacing-md);}
                 </style>
                 <div
-                  class="m_410352e9 mantine-Grid-root __m__-rqe"
+                  class="m_410352e9 mantine-Grid-root __m__-rqs"
                 >
                   <div
                     class="m_dee7bd2f mantine-Grid-inner"
@@ -11279,10 +11279,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rqg{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                      .__m__-rqu{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                     </style>
                     <div
-                      class="m_96bdd299 mantine-Grid-col __m__-rqg"
+                      class="m_96bdd299 mantine-Grid-col __m__-rqu"
                     >
                       <h3
                         class="m_8a5d1357 mantine-Title-root"
@@ -11296,10 +11296,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rqj{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                      .__m__-rr1{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                     </style>
                     <div
-                      class="m_96bdd299 mantine-Grid-col __m__-rqj"
+                      class="m_96bdd299 mantine-Grid-col __m__-rr1"
                     >
                       <button
                         class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -11345,10 +11345,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rqn{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rr5{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rqn"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rr5"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 />
               </div>
@@ -11371,10 +11371,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                   <style
                     data-mantine-styles="inline"
                   >
-                    .__m__-rqr{--grid-gutter:var(--mantine-spacing-md);}
+                    .__m__-rr9{--grid-gutter:var(--mantine-spacing-md);}
                   </style>
                   <div
-                    class="m_410352e9 mantine-Grid-root __m__-rqr"
+                    class="m_410352e9 mantine-Grid-root __m__-rr9"
                   >
                     <div
                       class="m_dee7bd2f mantine-Grid-inner"
@@ -11382,10 +11382,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-rqt{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                        .__m__-rrb{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                       </style>
                       <div
-                        class="m_96bdd299 mantine-Grid-col __m__-rqt"
+                        class="m_96bdd299 mantine-Grid-col __m__-rrb"
                       >
                         <h4
                           class="m_8a5d1357 mantine-Title-root"
@@ -11399,10 +11399,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-rr0{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                        .__m__-rre{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                       </style>
                       <div
-                        class="m_96bdd299 mantine-Grid-col __m__-rr0"
+                        class="m_96bdd299 mantine-Grid-col __m__-rre"
                       >
                         <button
                           class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -11475,10 +11475,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rr8{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rrm{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rr8"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rrm"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -11617,10 +11617,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rrq{--grid-gutter:var(--mantine-spacing-md);}
+                      .__m__-rs8{--grid-gutter:var(--mantine-spacing-md);}
                     </style>
                     <div
-                      class="m_410352e9 mantine-Grid-root __m__-rrq"
+                      class="m_410352e9 mantine-Grid-root __m__-rs8"
                     >
                       <div
                         class="m_dee7bd2f mantine-Grid-inner"
@@ -11628,10 +11628,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rrs{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                          .__m__-rsa{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                         </style>
                         <div
-                          class="m_96bdd299 mantine-Grid-col __m__-rrs"
+                          class="m_96bdd299 mantine-Grid-col __m__-rsa"
                         >
                           <h3
                             class="m_8a5d1357 mantine-Title-root"
@@ -11645,10 +11645,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rrv{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                          .__m__-rsd{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                         </style>
                         <div
-                          class="m_96bdd299 mantine-Grid-col __m__-rrv"
+                          class="m_96bdd299 mantine-Grid-col __m__-rsd"
                         >
                           <button
                             class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -11694,10 +11694,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rs3{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-rsh{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-rs3"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-rsh"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     />
                   </div>
@@ -11729,10 +11729,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-rs8{--grid-gutter:var(--mantine-spacing-md);}
+                        .__m__-rsm{--grid-gutter:var(--mantine-spacing-md);}
                       </style>
                       <div
-                        class="m_410352e9 mantine-Grid-root __m__-rs8"
+                        class="m_410352e9 mantine-Grid-root __m__-rsm"
                       >
                         <div
                           class="m_dee7bd2f mantine-Grid-inner"
@@ -11740,10 +11740,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-rsa{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                            .__m__-rso{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                           </style>
                           <div
-                            class="m_96bdd299 mantine-Grid-col __m__-rsa"
+                            class="m_96bdd299 mantine-Grid-col __m__-rso"
                           >
                             <h4
                               class="m_8a5d1357 mantine-Title-root"
@@ -11757,10 +11757,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-rsd{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                            .__m__-rsr{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                           </style>
                           <div
-                            class="m_96bdd299 mantine-Grid-col __m__-rsd"
+                            class="m_96bdd299 mantine-Grid-col __m__-rsr"
                           >
                             <button
                               class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -11874,10 +11874,10 @@ exports[`single fields optional data controls shows "add" optional controls when
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r15u{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r16c{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r15u"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r16c"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -11903,10 +11903,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r163{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r16h{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r163"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r16h"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <em
@@ -11976,10 +11976,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r16c{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r16q{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r16c"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r16q"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -12131,10 +12131,10 @@ exports[`single fields optional data controls shows "add" optional controls when
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r16v{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-r17d{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-r16v"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-r17d"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     >
                       <em
@@ -12347,7 +12347,7 @@ exports[`single fields radio field 1`] = `
           role="radiogroup"
         >
           <div
-            class="m_8bffd616 mantine-Flex-root __m__-rhp"
+            class="m_8bffd616 mantine-Flex-root __m__-ri7"
             style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
           >
             <div
@@ -12503,7 +12503,7 @@ exports[`single fields radio widget with description in schema and FieldTemplate
           role="radiogroup"
         >
           <div
-            class="m_8bffd616 mantine-Flex-root __m__-rfh"
+            class="m_8bffd616 mantine-Flex-root __m__-rfv"
             style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
           >
             <div
@@ -12809,7 +12809,7 @@ exports[`single fields select field 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-Select-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":r4r:"
+                      id=":r59:"
                       role="option"
                       value="0"
                     >
@@ -12821,7 +12821,7 @@ exports[`single fields select field 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-Select-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":r4t:"
+                      id=":r5b:"
                       role="option"
                       value="1"
                     >
@@ -12994,7 +12994,7 @@ exports[`single fields select field multiple choice 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-MultiSelect-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":r5i:"
+                      id=":r60:"
                       role="option"
                       value="0"
                     >
@@ -13006,7 +13006,7 @@ exports[`single fields select field multiple choice 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-MultiSelect-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":r5k:"
+                      id=":r62:"
                       role="option"
                       value="1"
                     >
@@ -13018,7 +13018,7 @@ exports[`single fields select field multiple choice 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-MultiSelect-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":r5m:"
+                      id=":r64:"
                       role="option"
                       value="2"
                     >
@@ -13030,7 +13030,7 @@ exports[`single fields select field multiple choice 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-MultiSelect-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":r5o:"
+                      id=":r66:"
                       role="option"
                       value="3"
                     >
@@ -13203,7 +13203,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-MultiSelect-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":r9k:"
+                      id=":ra2:"
                       role="option"
                       value="0"
                     >
@@ -13216,7 +13216,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
                       class="m_92253aa5 mantine-MultiSelect-option m_390b5f4"
                       data-combobox-disabled="true"
                       data-combobox-option="true"
-                      id=":r9m:"
+                      id=":ra4:"
                       role="option"
                       value="1"
                     >
@@ -13228,7 +13228,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-MultiSelect-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":r9o:"
+                      id=":ra6:"
                       role="option"
                       value="2"
                     >
@@ -13240,7 +13240,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-MultiSelect-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":r9q:"
+                      id=":ra8:"
                       role="option"
                       value="3"
                     >
@@ -13326,7 +13326,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
           role="group"
         >
           <div
-            class="m_8bffd616 mantine-Flex-root __m__-ra0"
+            class="m_8bffd616 mantine-Flex-root __m__-rae"
             style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
           >
             <div
@@ -13732,7 +13732,7 @@ exports[`single fields select field multiple choice formData 1`] = `
                       data-checked="true"
                       data-combobox-active="true"
                       data-combobox-option="true"
-                      id=":rdp:"
+                      id=":re7:"
                       role="option"
                       value="0"
                     >
@@ -13760,7 +13760,7 @@ exports[`single fields select field multiple choice formData 1`] = `
                       data-checked="true"
                       data-combobox-active="true"
                       data-combobox-option="true"
-                      id=":rdr:"
+                      id=":re9:"
                       role="option"
                       value="1"
                     >
@@ -13786,7 +13786,7 @@ exports[`single fields select field multiple choice formData 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-MultiSelect-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":rdt:"
+                      id=":reb:"
                       role="option"
                       value="2"
                     >
@@ -13798,7 +13798,7 @@ exports[`single fields select field multiple choice formData 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-MultiSelect-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":rdv:"
+                      id=":red:"
                       role="option"
                       value="3"
                     >
@@ -13971,7 +13971,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-MultiSelect-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":r6d:"
+                      id=":r6r:"
                       role="option"
                       value="0"
                     >
@@ -13983,7 +13983,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-MultiSelect-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":r6f:"
+                      id=":r6t:"
                       role="option"
                       value="1"
                     >
@@ -13995,7 +13995,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-MultiSelect-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":r6h:"
+                      id=":r6v:"
                       role="option"
                       value="2"
                     >
@@ -14153,7 +14153,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-Select-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":r74:"
+                      id=":r7i:"
                       role="option"
                       value="0"
                     >
@@ -14166,7 +14166,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
                       class="m_92253aa5 mantine-Select-option m_390b5f4"
                       data-combobox-disabled="true"
                       data-combobox-option="true"
-                      id=":r76:"
+                      id=":r7k:"
                       role="option"
                       value="1"
                     >
@@ -14252,7 +14252,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
           role="radiogroup"
         >
           <div
-            class="m_8bffd616 mantine-Flex-root __m__-r7d"
+            class="m_8bffd616 mantine-Flex-root __m__-r7r"
             style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
           >
             <div
@@ -14405,7 +14405,7 @@ exports[`single fields select field single choice form disabled using radio widg
           role="radiogroup"
         >
           <div
-            class="m_8bffd616 mantine-Flex-root __m__-r8j"
+            class="m_8bffd616 mantine-Flex-root __m__-r91"
             style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
           >
             <div
@@ -14629,7 +14629,7 @@ exports[`single fields select field single choice formData 1`] = `
                       aria-selected="false"
                       class="m_92253aa5 mantine-Select-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":rcu:"
+                      id=":rdc:"
                       role="option"
                       value="0"
                     >
@@ -14643,7 +14643,7 @@ exports[`single fields select field single choice formData 1`] = `
                       data-checked="true"
                       data-combobox-active="true"
                       data-combobox-option="true"
-                      id=":rd0:"
+                      id=":rde:"
                       role="option"
                       value="1"
                     >
@@ -14743,7 +14743,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
           role="radiogroup"
         >
           <div
-            class="m_8bffd616 mantine-Flex-root __m__-r80"
+            class="m_8bffd616 mantine-Flex-root __m__-r8e"
             style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
           >
             <div
@@ -14974,7 +14974,7 @@ exports[`single fields select widget with description in schema and FieldTemplat
                       aria-selected="false"
                       class="m_92253aa5 mantine-Select-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":rgh:"
+                      id=":rgv:"
                       role="option"
                       value="0"
                     >
@@ -14986,7 +14986,7 @@ exports[`single fields select widget with description in schema and FieldTemplat
                       aria-selected="false"
                       class="m_92253aa5 mantine-Select-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":rgj:"
+                      id=":rh1:"
                       role="option"
                       value="1"
                     >
@@ -15770,7 +15770,177 @@ exports[`single fields string field required field with markdown help 1`] = `
 </DocumentFragment>
 `;
 
-exports[`single fields string field with placeholder 1`] = `
+exports[`single fields string field string field with allowClearTextInputs and readonly 1`] = `
+<DocumentFragment>
+  <style
+    data-mantine-styles="true"
+  >
+    
+
+
+
+
+  </style>
+  <style
+    data-mantine-styles="classes"
+  >
+    @media (max-width: 35.99375em) {.mantine-visible-from-xs {display: none !important;}}@media (min-width: 36em) {.mantine-hidden-from-xs {display: none !important;}}@media (max-width: 47.99375em) {.mantine-visible-from-sm {display: none !important;}}@media (min-width: 48em) {.mantine-hidden-from-sm {display: none !important;}}@media (max-width: 61.99375em) {.mantine-visible-from-md {display: none !important;}}@media (min-width: 62em) {.mantine-hidden-from-md {display: none !important;}}@media (max-width: 74.99375em) {.mantine-visible-from-lg {display: none !important;}}@media (min-width: 75em) {.mantine-hidden-from-lg {display: none !important;}}@media (max-width: 87.99375em) {.mantine-visible-from-xl {display: none !important;}}@media (min-width: 88em) {.mantine-hidden-from-xl {display: none !important;}}
+  </style>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="m_46b77525 mantine-InputWrapper-root mantine-TextInput-root"
+        data-size="sm"
+      >
+        <div
+          class="m_6c018570 mantine-Input-wrapper mantine-TextInput-wrapper"
+          data-disabled="true"
+          data-size="sm"
+          data-variant="default"
+          style="--input-height: var(--input-height-sm); --input-fz: var(--mantine-font-size-sm);"
+        >
+          <input
+            aria-invalid="false"
+            class="m_8fb7ebe7 mantine-Input-input mantine-TextInput-input"
+            data-disabled="true"
+            data-variant="default"
+            disabled=""
+            id="root"
+            name="root"
+            placeholder=""
+            type="text"
+            value="foo"
+          />
+        </div>
+      </div>
+    </div>
+    <button
+      class="mantine-focus-auto mantine-active m_77c9d27d mantine-Button-root m_87cf2631 mantine-UnstyledButton-root"
+      data-variant="filled"
+      style="--button-bg: var(--mantine-color-blue-filled); --button-hover: var(--mantine-color-blue-filled-hover); --button-color: var(--mantine-color-white); --button-bd: calc(0.0625rem * var(--mantine-scale)) solid transparent;"
+      type="submit"
+    >
+      <span
+        class="m_80f1301b mantine-Button-inner"
+      >
+        <span
+          class="m_811560b9 mantine-Button-label"
+        >
+          Submit
+        </span>
+      </span>
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with allowClearTextInputs and value 1`] = `
+<DocumentFragment>
+  <style
+    data-mantine-styles="true"
+  >
+    
+
+
+
+
+  </style>
+  <style
+    data-mantine-styles="classes"
+  >
+    @media (max-width: 35.99375em) {.mantine-visible-from-xs {display: none !important;}}@media (min-width: 36em) {.mantine-hidden-from-xs {display: none !important;}}@media (max-width: 47.99375em) {.mantine-visible-from-sm {display: none !important;}}@media (min-width: 48em) {.mantine-hidden-from-sm {display: none !important;}}@media (max-width: 61.99375em) {.mantine-visible-from-md {display: none !important;}}@media (min-width: 62em) {.mantine-hidden-from-md {display: none !important;}}@media (max-width: 74.99375em) {.mantine-visible-from-lg {display: none !important;}}@media (min-width: 75em) {.mantine-hidden-from-lg {display: none !important;}}@media (max-width: 87.99375em) {.mantine-visible-from-xl {display: none !important;}}@media (min-width: 88em) {.mantine-hidden-from-xl {display: none !important;}}
+  </style>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="m_46b77525 mantine-InputWrapper-root mantine-TextInput-root"
+        data-size="sm"
+      >
+        <div
+          class="m_6c018570 mantine-Input-wrapper mantine-TextInput-wrapper"
+          data-size="sm"
+          data-variant="default"
+          style="--input-height: var(--input-height-sm); --input-fz: var(--mantine-font-size-sm);"
+        >
+          <input
+            aria-invalid="false"
+            class="m_8fb7ebe7 mantine-Input-input mantine-TextInput-input"
+            data-variant="default"
+            id="root"
+            name="root"
+            placeholder=""
+            type="text"
+            value="foo"
+          />
+        </div>
+      </div>
+      <button
+        class="mantine-focus-auto mantine-active m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
+        data-size="sm"
+        data-variant="subtle"
+        style="--ai-size: var(--ai-size-sm); --ai-bg: transparent; --ai-hover: var(--mantine-color-blue-light-hover); --ai-color: var(--mantine-color-blue-light-color); --ai-bd: calc(0.0625rem * var(--mantine-scale)) solid transparent;"
+        title="clear input"
+        type="button"
+      >
+        <span
+          class="m_8d3afb97 mantine-ActionIcon-icon"
+        >
+          <svg
+            class="icon icon-tabler icons-tabler-outline icon-tabler-x"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+              stroke="none"
+            />
+            <path
+              d="M18 6l-12 12"
+            />
+            <path
+              d="M6 6l12 12"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+    <button
+      class="mantine-focus-auto mantine-active m_77c9d27d mantine-Button-root m_87cf2631 mantine-UnstyledButton-root"
+      data-variant="filled"
+      style="--button-bg: var(--mantine-color-blue-filled); --button-hover: var(--mantine-color-blue-filled-hover); --button-color: var(--mantine-color-white); --button-bd: calc(0.0625rem * var(--mantine-scale)) solid transparent;"
+      type="submit"
+    >
+      <span
+        class="m_80f1301b mantine-Button-inner"
+      >
+        <span
+          class="m_811560b9 mantine-Button-label"
+        >
+          Submit
+        </span>
+      </span>
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with placeholder 1`] = `
 <DocumentFragment>
   <style
     data-mantine-styles="true"
@@ -15936,10 +16106,10 @@ exports[`single fields title field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rk7{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rkl{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rk7"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rkl"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div

--- a/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -51,23 +51,28 @@ export default function BaseInputTemplate<
     errorSchema,
     registry,
     InputLabelProps,
+    InputProps,
+    slotProps,
     ...textFieldProps
   } = props;
   const { ClearButton } = registry.templates.ButtonTemplates;
-  const inputProps = getInputProps<T, S, F>(schema, type, options);
   // Now we need to pull out the step, min, max into an inner `inputProps` for material-ui
-  const { step, min, max, accept, ...rest } = inputProps;
-  const htmlInputProps = { step, min, max, accept, ...(schema.examples ? { list: examplesId(id) } : undefined) };
+  const { step, min, max, accept, ...rest } = getInputProps<T, S, F>(schema, type, options);
+  const htmlInputProps = {
+    ...slotProps?.htmlInput,
+    step,
+    min,
+    max,
+    accept,
+    ...(schema.examples ? { list: examplesId(id) } : undefined),
+  };
   const _onChange = ({ target: { value } }: ChangeEvent<HTMLInputElement>) =>
     onChange(value === '' ? options.emptyValue : value);
   const _onBlur = ({ target }: FocusEvent<HTMLInputElement>) => onBlur(id, target && target.value);
   const _onFocus = ({ target }: FocusEvent<HTMLInputElement>) => onFocus(id, target && target.value);
   const DisplayInputLabelProps = TYPES_THAT_SHRINK_LABEL.includes(type)
-    ? {
-        ...InputLabelProps,
-        shrink: true,
-      }
-    : InputLabelProps;
+    ? { ...slotProps?.inputLabel, ...InputLabelProps, shrink: true }
+    : { ...slotProps?.inputLabel, ...InputLabelProps };
   const _onClear = useCallback(
     (e: MouseEvent) => {
       e.preventDefault();
@@ -76,6 +81,22 @@ export default function BaseInputTemplate<
     },
     [onChange, options.emptyValue],
   );
+  const inputProps = { ...InputProps, ...slotProps?.input };
+  if (options.allowClearTextInputs && value && !readonly && !disabled) {
+    const clearAdornment = (
+      <InputAdornment position='end'>
+        <ClearButton registry={registry} onClick={_onClear} />
+      </InputAdornment>
+    );
+    inputProps.endAdornment = !inputProps.endAdornment ? (
+      clearAdornment
+    ) : (
+      <>
+        {inputProps.endAdornment}
+        {clearAdornment}
+      </>
+    );
+  }
 
   return (
     <>
@@ -87,7 +108,12 @@ export default function BaseInputTemplate<
         autoFocus={autofocus}
         required={required}
         disabled={disabled || readonly}
-        slotProps={{ htmlInput: htmlInputProps, inputLabel: DisplayInputLabelProps }}
+        slotProps={{
+          ...slotProps,
+          input: inputProps,
+          htmlInput: htmlInputProps,
+          inputLabel: DisplayInputLabelProps,
+        }}
         {...rest}
         value={value || value === 0 ? value : ''}
         error={rawErrors.length > 0}
@@ -96,15 +122,6 @@ export default function BaseInputTemplate<
         onFocus={_onFocus}
         {...(textFieldProps as TextFieldProps)}
         aria-describedby={ariaDescribedByIds(id, !!schema.examples)}
-        InputProps={{
-          ...textFieldProps.InputProps,
-          endAdornment:
-            options.allowClearTextInputs && value && !readonly && !disabled ? (
-              <InputAdornment position='end'>
-                <ClearButton registry={registry} onClick={_onClear} />
-              </InputAdornment>
-            ) : undefined,
-        }}
       />
       {Array.isArray(schema.examples) && (
         <datalist id={examplesId(id)}>

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -42703,7 +42703,931 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-4:focus::-ms-input-p
 </DocumentFragment>
 `;
 
-exports[`single fields string field with placeholder 1`] = `
+exports[`single fields string field string field with allowClearTextInputs and readonly 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.emotion-1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+}
+
+.emotion-2 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+}
+
+.emotion-2.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-2:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-2:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-2.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-width: 2px;
+}
+
+.emotion-2.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+}
+
+.emotion-2.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-2.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-3 {
+  font: inherit;
+  letter-spacing: inherit;
+  color: currentColor;
+  padding: 4px 0 5px;
+  border: 0;
+  box-sizing: content-box;
+  background: none;
+  height: 1.4375em;
+  margin: 0;
+  -webkit-tap-highlight-color: transparent;
+  display: block;
+  min-width: 0;
+  width: 100%;
+  -webkit-animation-name: mui-auto-fill-cancel;
+  animation-name: mui-auto-fill-cancel;
+  -webkit-animation-duration: 10ms;
+  animation-duration: 10ms;
+  padding: 16.5px 14px;
+}
+
+.emotion-3::-webkit-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3::-moz-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3::-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3:focus {
+  outline: 0;
+}
+
+.emotion-3:invalid {
+  box-shadow: none;
+}
+
+.emotion-3::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-webkit-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-moz-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-ms-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-webkit-input-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-moz-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-placeholder {
+  opacity: 0.42;
+}
+
+.emotion-3.Mui-disabled {
+  opacity: 1;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-3:-webkit-autofill {
+  -webkit-animation-duration: 5000s;
+  animation-duration: 5000s;
+  -webkit-animation-name: mui-auto-fill;
+  animation-name: mui-auto-fill;
+}
+
+.emotion-3:-webkit-autofill {
+  border-radius: inherit;
+}
+
+.emotion-4 {
+  text-align: left;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  top: -5px;
+  left: 0;
+  margin: 0;
+  padding: 0 8px;
+  pointer-events: none;
+  border-radius: inherit;
+  border-style: solid;
+  border-width: 1px;
+  overflow: hidden;
+  min-width: 0%;
+  border-color: rgba(0, 0, 0, 0.23);
+}
+
+.emotion-5 {
+  float: unset;
+  width: auto;
+  overflow: hidden;
+  padding: 0;
+  line-height: 11px;
+  -webkit-transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+}
+
+.emotion-6 {
+  margin-top: 24px;
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border: 0;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: var(--variant-containedColor);
+  background-color: var(--variant-containedBg);
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  --variant-textColor: #1976d2;
+  --variant-outlinedColor: #1976d2;
+  --variant-outlinedBorder: rgba(25, 118, 210, 0.5);
+  --variant-containedColor: #fff;
+  --variant-containedBg: #1976d2;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-7.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-7 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-7:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-7.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-7:hover {
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-7:hover {
+    box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  }
+}
+
+.emotion-7:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-7.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-7.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+@media (hover: hover) {
+  .emotion-7:hover {
+    --variant-containedBg: #1565c0;
+    --variant-textBg: rgba(25, 118, 210, 0.04);
+    --variant-outlinedBorder: #1976d2;
+    --variant-outlinedBg: rgba(25, 118, 210, 0.04);
+  }
+}
+
+.emotion-7.MuiButton-loading {
+  color: transparent;
+}
+
+<form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+      >
+        <div
+          aria-describedby="root__error root__description root__help"
+          class="MuiFormControl-root MuiTextField-root emotion-1"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl emotion-2"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled emotion-3"
+              disabled=""
+              id="root"
+              name="root"
+              placeholder=""
+              type="text"
+              value="foo"
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline emotion-4"
+            >
+              <legend
+                class="emotion-5"
+              >
+                <span
+                  aria-hidden="true"
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root emotion-6"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary emotion-7"
+        tabindex="0"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with allowClearTextInputs and value 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.emotion-1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+}
+
+.emotion-2 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+  padding-right: 14px;
+}
+
+.emotion-2.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-2:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-2:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-2.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-width: 2px;
+}
+
+.emotion-2.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+}
+
+.emotion-2.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-2.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-3 {
+  font: inherit;
+  letter-spacing: inherit;
+  color: currentColor;
+  padding: 4px 0 5px;
+  border: 0;
+  box-sizing: content-box;
+  background: none;
+  height: 1.4375em;
+  margin: 0;
+  -webkit-tap-highlight-color: transparent;
+  display: block;
+  min-width: 0;
+  width: 100%;
+  -webkit-animation-name: mui-auto-fill-cancel;
+  animation-name: mui-auto-fill-cancel;
+  -webkit-animation-duration: 10ms;
+  animation-duration: 10ms;
+  padding: 16.5px 14px;
+  padding-right: 0;
+}
+
+.emotion-3::-webkit-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3::-moz-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3::-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3:focus {
+  outline: 0;
+}
+
+.emotion-3:invalid {
+  box-shadow: none;
+}
+
+.emotion-3::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-webkit-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-moz-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-ms-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-webkit-input-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-moz-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-placeholder {
+  opacity: 0.42;
+}
+
+.emotion-3.Mui-disabled {
+  opacity: 1;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-3:-webkit-autofill {
+  -webkit-animation-duration: 5000s;
+  animation-duration: 5000s;
+  -webkit-animation-name: mui-auto-fill;
+  animation-name: mui-auto-fill;
+}
+
+.emotion-3:-webkit-autofill {
+  border-radius: inherit;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  max-height: 2em;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  white-space: nowrap;
+  color: rgba(0, 0, 0, 0.54);
+  margin-left: 8px;
+}
+
+.emotion-5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  text-align: center;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  font-size: 1.5rem;
+  padding: 8px;
+  border-radius: 50%;
+  color: rgba(0, 0, 0, 0.54);
+  -webkit-transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  --IconButton-hoverBg: rgba(0, 0, 0, 0.04);
+  padding: 5px;
+  font-size: 1.125rem;
+}
+
+.emotion-5::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-5.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-5 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-5:hover {
+  background-color: var(--IconButton-hoverBg);
+}
+
+@media (hover: none) {
+  .emotion-5:hover {
+    background-color: transparent;
+  }
+}
+
+.emotion-5.Mui-disabled {
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-5.MuiIconButton-loading {
+  color: transparent;
+}
+
+.emotion-6 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  fill: currentColor;
+  font-size: 1.25rem;
+}
+
+.emotion-7 {
+  text-align: left;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  top: -5px;
+  left: 0;
+  margin: 0;
+  padding: 0 8px;
+  pointer-events: none;
+  border-radius: inherit;
+  border-style: solid;
+  border-width: 1px;
+  overflow: hidden;
+  min-width: 0%;
+  border-color: rgba(0, 0, 0, 0.23);
+}
+
+.emotion-8 {
+  float: unset;
+  width: auto;
+  overflow: hidden;
+  padding: 0;
+  line-height: 11px;
+  -webkit-transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+}
+
+.emotion-9 {
+  margin-top: 24px;
+}
+
+.emotion-10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border: 0;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: var(--variant-containedColor);
+  background-color: var(--variant-containedBg);
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  --variant-textColor: #1976d2;
+  --variant-outlinedColor: #1976d2;
+  --variant-outlinedBorder: rgba(25, 118, 210, 0.5);
+  --variant-containedColor: #fff;
+  --variant-containedBg: #1976d2;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-10::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-10.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-10 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-10:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-10.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-10:hover {
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-10:hover {
+    box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  }
+}
+
+.emotion-10:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-10.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-10.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+@media (hover: hover) {
+  .emotion-10:hover {
+    --variant-containedBg: #1565c0;
+    --variant-textBg: rgba(25, 118, 210, 0.04);
+    --variant-outlinedBorder: #1976d2;
+    --variant-outlinedBg: rgba(25, 118, 210, 0.04);
+  }
+}
+
+.emotion-10.MuiButton-loading {
+  color: transparent;
+}
+
+<form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+      >
+        <div
+          aria-describedby="root__error root__description root__help"
+          class="MuiFormControl-root MuiTextField-root emotion-1"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-2"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd emotion-3"
+              id="root"
+              name="root"
+              placeholder=""
+              type="text"
+              value="foo"
+            />
+            <div
+              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-4"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-5"
+                tabindex="0"
+                title="clear input"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-6"
+                  data-testid="ClearIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </button>
+            </div>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline emotion-7"
+            >
+              <legend
+                class="emotion-8"
+              >
+                <span
+                  aria-hidden="true"
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root emotion-9"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary emotion-10"
+        tabindex="0"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with placeholder 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: -webkit-inline-box;

--- a/packages/primereact/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/primereact/test/__snapshots__/Form.test.tsx.snap
@@ -4605,13 +4605,13 @@ exports[`single fields optional data controls does not show optional controls wh
               class="p-fieldset p-component"
               data-pc-name="fieldset"
               data-pc-section="root"
-              id="pr_id_19"
+              id="pr_id_21"
             >
               <div
-                aria-labelledby="pr_id_19_header"
+                aria-labelledby="pr_id_21_header"
                 class="p-toggleable-content"
                 data-pc-section="toggleablecontent"
-                id="pr_id_19_content"
+                id="pr_id_21_content"
                 role="region"
               >
                 <div
@@ -4703,13 +4703,13 @@ exports[`single fields optional data controls does not show optional controls wh
               class="p-fieldset p-component"
               data-pc-name="fieldset"
               data-pc-section="root"
-              id="pr_id_20"
+              id="pr_id_22"
             >
               <div
-                aria-labelledby="pr_id_20_header"
+                aria-labelledby="pr_id_22_header"
                 class="p-toggleable-content"
                 data-pc-section="toggleablecontent"
-                id="pr_id_20_content"
+                id="pr_id_22_content"
                 role="region"
               >
                 <div
@@ -5378,13 +5378,13 @@ exports[`single fields optional data controls does not show optional controls wh
               class="p-fieldset p-component"
               data-pc-name="fieldset"
               data-pc-section="root"
-              id="pr_id_69"
+              id="pr_id_71"
             >
               <div
-                aria-labelledby="pr_id_69_header"
+                aria-labelledby="pr_id_71_header"
                 class="p-toggleable-content"
                 data-pc-section="toggleablecontent"
-                id="pr_id_69_content"
+                id="pr_id_71_content"
                 role="region"
               >
                 <div
@@ -5477,13 +5477,13 @@ exports[`single fields optional data controls does not show optional controls wh
               class="p-fieldset p-component"
               data-pc-name="fieldset"
               data-pc-section="root"
-              id="pr_id_70"
+              id="pr_id_72"
             >
               <div
-                aria-labelledby="pr_id_70_header"
+                aria-labelledby="pr_id_72_header"
                 class="p-toggleable-content"
                 data-pc-section="toggleablecontent"
-                id="pr_id_70_content"
+                id="pr_id_72_content"
                 role="region"
               >
                 <div
@@ -6270,13 +6270,13 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
               class="p-fieldset p-component"
               data-pc-name="fieldset"
               data-pc-section="root"
-              id="pr_id_50"
+              id="pr_id_52"
             >
               <div
-                aria-labelledby="pr_id_50_header"
+                aria-labelledby="pr_id_52_header"
                 class="p-toggleable-content"
                 data-pc-section="toggleablecontent"
-                id="pr_id_50_content"
+                id="pr_id_52_content"
                 role="region"
               >
                 <div
@@ -6362,13 +6362,13 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
               class="p-fieldset p-component"
               data-pc-name="fieldset"
               data-pc-section="root"
-              id="pr_id_51"
+              id="pr_id_53"
             >
               <div
-                aria-labelledby="pr_id_51_header"
+                aria-labelledby="pr_id_53_header"
                 class="p-toggleable-content"
                 data-pc-section="toggleablecontent"
-                id="pr_id_51_content"
+                id="pr_id_53_content"
                 role="region"
               >
                 <div
@@ -7053,13 +7053,13 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
               class="p-fieldset p-component"
               data-pc-name="fieldset"
               data-pc-section="root"
-              id="pr_id_86"
+              id="pr_id_88"
             >
               <div
-                aria-labelledby="pr_id_86_header"
+                aria-labelledby="pr_id_88_header"
                 class="p-toggleable-content"
                 data-pc-section="toggleablecontent"
-                id="pr_id_86_content"
+                id="pr_id_88_content"
                 role="region"
               >
                 <div
@@ -7119,13 +7119,13 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
               class="p-fieldset p-component"
               data-pc-name="fieldset"
               data-pc-section="root"
-              id="pr_id_87"
+              id="pr_id_89"
             >
               <div
-                aria-labelledby="pr_id_87_header"
+                aria-labelledby="pr_id_89_header"
                 class="p-toggleable-content"
                 data-pc-section="toggleablecontent"
-                id="pr_id_87_content"
+                id="pr_id_89_content"
                 role="region"
               >
                 <div
@@ -7486,13 +7486,13 @@ exports[`single fields optional data controls shows "add" optional controls when
               class="p-fieldset p-component"
               data-pc-name="fieldset"
               data-pc-section="root"
-              id="pr_id_32"
+              id="pr_id_34"
             >
               <div
-                aria-labelledby="pr_id_32_header"
+                aria-labelledby="pr_id_34_header"
                 class="p-toggleable-content"
                 data-pc-section="toggleablecontent"
-                id="pr_id_32_content"
+                id="pr_id_34_content"
                 role="region"
               >
                 <div
@@ -7578,13 +7578,13 @@ exports[`single fields optional data controls shows "add" optional controls when
               class="p-fieldset p-component"
               data-pc-name="fieldset"
               data-pc-section="root"
-              id="pr_id_33"
+              id="pr_id_35"
             >
               <div
-                aria-labelledby="pr_id_33_header"
+                aria-labelledby="pr_id_35_header"
                 class="p-toggleable-content"
                 data-pc-section="toggleablecontent"
-                id="pr_id_33_content"
+                id="pr_id_35_content"
                 role="region"
               >
                 <div
@@ -7921,13 +7921,13 @@ exports[`single fields optional data controls shows "add" optional controls when
               class="p-fieldset p-component"
               data-pc-name="fieldset"
               data-pc-section="root"
-              id="pr_id_78"
+              id="pr_id_80"
             >
               <div
-                aria-labelledby="pr_id_78_header"
+                aria-labelledby="pr_id_80_header"
                 class="p-toggleable-content"
                 data-pc-section="toggleablecontent"
-                id="pr_id_78_content"
+                id="pr_id_80_content"
                 role="region"
               >
                 <div
@@ -7987,13 +7987,13 @@ exports[`single fields optional data controls shows "add" optional controls when
               class="p-fieldset p-component"
               data-pc-name="fieldset"
               data-pc-section="root"
-              id="pr_id_79"
+              id="pr_id_81"
             >
               <div
-                aria-labelledby="pr_id_79_header"
+                aria-labelledby="pr_id_81_header"
                 class="p-toggleable-content"
                 data-pc-section="toggleablecontent"
-                id="pr_id_79_content"
+                id="pr_id_81_content"
                 role="region"
               >
                 <div
@@ -9710,7 +9710,109 @@ exports[`single fields string field required field with markdown help 1`] = `
 </DocumentFragment>
 `;
 
-exports[`single fields string field with placeholder 1`] = `
+exports[`single fields string field string field with allowClearTextInputs and readonly 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;"
+      >
+        <input
+          aria-describedby="root__error root__description root__help"
+          class="p-inputtext p-component p-disabled p-filled"
+          data-pc-name="inputtext"
+          data-pc-section="root"
+          disabled=""
+          id="root"
+          name="root"
+          placeholder=""
+          type="text"
+          value="foo"
+        />
+      </div>
+    </div>
+    <button
+      aria-label="Submit"
+      class="p-button p-component"
+      data-pc-name="button"
+      data-pc-section="root"
+      type="submit"
+    >
+      <span
+        class="p-button-label p-c"
+        data-pc-section="label"
+      >
+        Submit
+      </span>
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with allowClearTextInputs and value 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;"
+      >
+        <input
+          aria-describedby="root__error root__description root__help"
+          class="p-inputtext p-component p-filled"
+          data-pc-name="inputtext"
+          data-pc-section="root"
+          id="root"
+          name="root"
+          placeholder=""
+          type="text"
+          value="foo"
+        />
+        <button
+          class="p-button p-component p-button-icon-only p-button-text p-button-rounded p-button-secondary"
+          data-pc-name="button"
+          data-pc-section="root"
+          title="clear input"
+        >
+          <span
+            class="p-button-icon p-c pi pi-times"
+            data-pc-section="icon"
+          />
+          <span
+            class="p-button-label p-c"
+            data-pc-section="label"
+          >
+             
+          </span>
+        </button>
+      </div>
+    </div>
+    <button
+      aria-label="Submit"
+      class="p-button p-component"
+      data-pc-name="button"
+      data-pc-section="root"
+      type="submit"
+    >
+      <span
+        class="p-button-label p-c"
+        data-pc-section="label"
+      >
+        Submit
+      </span>
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with placeholder 1`] = `
 <DocumentFragment>
   <form
     class="rjsf"

--- a/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
@@ -10095,7 +10095,99 @@ exports[`single fields string field required field with markdown help 1`] = `
 </DocumentFragment>
 `;
 
-exports[`single fields string field with placeholder 1`] = `
+exports[`single fields string field string field with allowClearTextInputs and readonly 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div>
+        <label
+          class="form-label"
+          for="root"
+        />
+        <input
+          aria-describedby="root__error root__description root__help"
+          class="form-control"
+          id="root"
+          name="root"
+          placeholder=""
+          readonly=""
+          type="text"
+          value="foo"
+        />
+      </div>
+    </div>
+    <div>
+      <button
+        class="btn btn-primary"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with allowClearTextInputs and value 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div>
+        <label
+          class="form-label"
+          for="root"
+        />
+        <input
+          aria-describedby="root__error root__description root__help"
+          class="form-control"
+          id="root"
+          name="root"
+          placeholder=""
+          type="text"
+          value="foo"
+        />
+        <button
+          class="btn btn-light btn-sm"
+          title="clear input"
+          type="button"
+        >
+          <svg
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 512 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M405 136.798L375.202 107 256 226.202 136.798 107 107 136.798 226.202 256 107 375.202 136.798 405 256 285.798 375.202 405 405 375.202 285.798 256z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div>
+      <button
+        class="btn btn-primary"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with placeholder 1`] = `
 <DocumentFragment>
   <form
     class="rjsf"

--- a/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
@@ -8344,7 +8344,96 @@ exports[`single fields string field required field with markdown help 1`] = `
 </DocumentFragment>
 `;
 
-exports[`single fields string field with placeholder 1`] = `
+exports[`single fields string field string field with allowClearTextInputs and readonly 1`] = `
+<DocumentFragment>
+  <form
+    class="ui form rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="grouped equal width fields"
+      >
+        <div
+          class="disabled field"
+        >
+          <div
+            class="ui disabled fluid input"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              disabled=""
+              id="root"
+              name="root"
+              placeholder=""
+              tabindex="-1"
+              type="text"
+              value="foo"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <button
+      class="ui primary button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with allowClearTextInputs and value 1`] = `
+<DocumentFragment>
+  <form
+    class="ui form rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="grouped equal width fields"
+      >
+        <div
+          class="field"
+        >
+          <div
+            class="ui fluid input"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              id="root"
+              name="root"
+              placeholder=""
+              type="text"
+              value="foo"
+            />
+          </div>
+        </div>
+        <button
+          class="ui icon button"
+          title="clear input"
+        >
+          <i
+            aria-hidden="true"
+            class="close icon"
+          />
+        </button>
+      </div>
+    </div>
+    <button
+      class="ui primary button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with placeholder 1`] = `
 <DocumentFragment>
   <form
     class="ui form rjsf"

--- a/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
@@ -12192,7 +12192,123 @@ exports[`single fields string field required field with markdown help 1`] = `
 </DocumentFragment>
 `;
 
-exports[`single fields string field with placeholder 1`] = `
+exports[`single fields string field string field with allowClearTextInputs and readonly 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="flex flex-col gap-2"
+      >
+        <label
+          class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          for="root"
+        />
+        <div
+          class="p-0.5"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            class="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
+            data-slot="input"
+            id="root"
+            name="root"
+            placeholder=""
+            readonly=""
+            type="text"
+            value="foo"
+          />
+        </div>
+      </div>
+    </div>
+    <div>
+      <button
+        class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3 my-2"
+        data-slot="button"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with allowClearTextInputs and value 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="flex flex-col gap-2"
+      >
+        <label
+          class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          for="root"
+        />
+        <div
+          class="p-0.5"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            class="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
+            data-slot="input"
+            id="root"
+            name="root"
+            placeholder=""
+            type="text"
+            value="foo"
+          />
+          <button
+            class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 size-9"
+            data-slot="button"
+            title="clear input"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-x"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M18 6 6 18"
+              />
+              <path
+                d="m6 6 12 12"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div>
+      <button
+        class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3 my-2"
+        data-slot="button"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields string field string field with placeholder 1`] = `
 <DocumentFragment>
   <form
     class="rjsf"

--- a/packages/snapshot-tests/src/formTests.tsx
+++ b/packages/snapshot-tests/src/formTests.tsx
@@ -107,16 +107,41 @@ export function formTests(Form: ComponentType<FormProps>) {
         const { asFragment } = render(<Form schema={schema} uiSchema={uiSchema} validator={validator} formData={{}} />);
         expect(asFragment()).toMatchSnapshot();
       });
-    });
-    test('string field with placeholder', async () => {
-      const schema: RJSFSchema = {
-        type: 'string',
-      };
-      const uiSchema = {
-        'ui:placeholder': 'placeholder',
-      };
-      const { asFragment } = render(<Form schema={schema} validator={validator} uiSchema={uiSchema} />);
-      expect(asFragment()).toMatchSnapshot();
+      test('string field with placeholder', async () => {
+        const schema: RJSFSchema = {
+          type: 'string',
+        };
+        const uiSchema = {
+          'ui:placeholder': 'placeholder',
+        };
+        const { asFragment } = render(<Form schema={schema} validator={validator} uiSchema={uiSchema} />);
+        expect(asFragment()).toMatchSnapshot();
+      });
+      test('string field with allowClearTextInputs and value', async () => {
+        const schema: RJSFSchema = {
+          type: 'string',
+        };
+        const uiSchema = {
+          'ui:allowClearTextInputs': true,
+        };
+        const { asFragment } = render(
+          <Form schema={schema} validator={validator} uiSchema={uiSchema} formData='foo' />,
+        );
+        expect(asFragment()).toMatchSnapshot();
+      });
+      test('string field with allowClearTextInputs and readonly', async () => {
+        const schema: RJSFSchema = {
+          type: 'string',
+        };
+        const uiSchema = {
+          'ui:readonly': true,
+          'ui:allowClearTextInputs': true,
+        };
+        const { asFragment } = render(
+          <Form schema={schema} validator={validator} uiSchema={uiSchema} formData='foo' />,
+        );
+        expect(asFragment()).toMatchSnapshot();
+      });
     });
     test('number field', async () => {
       const schema: RJSFSchema = {


### PR DESCRIPTION
### Reasons for making this change

Fixes #4938 by updating the `@rjsf/mui` `BaseInputTemplate` to properly handle existing `endAdornment`s when the `allowClearTextInputs` flag is true
- In `@rjsf/mui`, updated `BaseInputTemplate` to properly handle `slotProps` and `InputProps` with existing `endAdornment`s when the `allowClearTextInputs` flag is true
- In `snapshot-tests` added tests for `allowClearTextInputs` with data as well as readonly to test the feature
  - Updated the snapshots accordingly
- Updated the `uiSchema.md` to add documetation for `allowClearTextInputs`
- Updated `CHANGELOG.md` accordingly

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
