### PR TITLE
import antt design icons using @ant-design/icons

### DIFF
--- a/packages/antd/src/templates/ErrorList/index.tsx
+++ b/packages/antd/src/templates/ErrorList/index.tsx
@@ -1,5 +1,5 @@
 import { Alert, List, Space } from 'antd';
-import ExclamationCircleOutlined from '@ant-design/icons/ExclamationCircleOutlined';
+import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { ErrorListProps, FormContextType, RJSFSchema, StrictRJSFSchema, TranslatableString } from '@rjsf/utils';
 
 /** The `ErrorList` component is the template that renders the all the errors associated with the fields in the `Form`

--- a/packages/antd/src/templates/IconButton/index.tsx
+++ b/packages/antd/src/templates/IconButton/index.tsx
@@ -1,10 +1,12 @@
 import { Button, ButtonProps } from 'antd';
-import ArrowDownOutlined from '@ant-design/icons/ArrowDownOutlined';
-import ArrowUpOutlined from '@ant-design/icons/ArrowUpOutlined';
-import CopyOutlined from '@ant-design/icons/CopyOutlined';
-import DeleteOutlined from '@ant-design/icons/DeleteOutlined';
-import PlusCircleOutlined from '@ant-design/icons/PlusCircleOutlined';
-import CloseOutlined from '@ant-design/icons/CloseOutlined';
+import {
+  ArrowDownOutlined,
+  ArrowUpOutlined,
+  CopyOutlined,
+  DeleteOutlined,
+  PlusCircleOutlined,
+  CloseOutlined,
+} from '@ant-design/icons';
 import {
   getUiOptions,
   FormContextType,


### PR DESCRIPTION
### Reasons for making this change

this is the simplest fix to #4953, although depending on build tooling (tree shaking) it might lead to larger bundle sizes.

It looks like in the history of this project the SVG icons were converted to use the direct-imports approach [here](https://github.com/rjsf-team/react-jsonschema-form/pull/1900) as part of an optimization effort.

For what it's worth, the [`@antd-design/icons` readme on npm](https://www.npmjs.com/package/@ant-design/icons#Install) suggests that the imports should work both ways, so most likely there's something esoteric going on w/ how this project is bundling not being compatible w/ the default vite setup.

---

I've got a PR on my bug reproduction project to demonstrating this PR fixes the issue https://github.com/pseudo-su/vite-antd-rjsf-repro-4953/pull/1

fixes #4953

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
