### PR TITLE
fix: ArrayAsMultiSelect should pass `items` UI schema when retrieving enumOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+
+# 6.3.2
+
+## @rjsf/core
+
+- Updated multi-select ArrayFields to properly use the `items` uiSchema for enumerated options, fixing [#4955](https://github.com/rjsf-team/react-jsonschema-form/issues/4955)
+
 # 6.3.1
 
 ## Dev / docs / playground
@@ -80,7 +87,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/mui
 
-- Updated `BaseInputTemplate` to properly handle `slotProps` and `InputProps` (deprecated by MUI) with existing `endAdornment`s when the `allowClearTextInputs` flag is true, fixing [#4938](https://github.com/rjsf-team/react-jsonschema-form/issues/4938) 
+- Updated `BaseInputTemplate` to properly handle `slotProps` and `InputProps` (deprecated by MUI) with existing `endAdornment`s when the `allowClearTextInputs` flag is true, fixing [#4938](https://github.com/rjsf-team/react-jsonschema-form/issues/4938)
 
 ## Dev / docs / playground
 

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -199,7 +199,8 @@ function ArrayAsMultiSelect<T = any, S extends StrictRJSFSchema = RJSFSchema, F 
   } = props;
   const { widgets, schemaUtils, globalFormOptions, globalUiOptions } = registry;
   const itemsSchema = schemaUtils.retrieveSchema(schema.items as S, items);
-  const enumOptions = optionsList<T[], S, F>(itemsSchema, uiSchema);
+  const itemsUiSchema = (uiSchema?.items ?? {}) as UiSchema<T[], S, F>;
+  const enumOptions = optionsList<T[], S, F>(itemsSchema, itemsUiSchema);
   const { widget = 'select', title: uiTitle, ...options } = getUiOptions<T[], S, F>(uiSchema, globalUiOptions);
   const Widget = getWidget<T[], S, F>(schema, widget, widgets);
   const label = uiTitle ?? schema.title ?? name;

--- a/packages/core/test/ArrayField.test.tsx
+++ b/packages/core/test/ArrayField.test.tsx
@@ -1345,6 +1345,30 @@ describe('ArrayField', () => {
 
         expect(node.querySelector("option[value='1']")).toBeDisabled(); // use index
       });
+
+      it('should use ui:enumNames from items uiSchema as option labels', () => {
+        const enumSchema: RJSFSchema = {
+          title: 'Demo',
+          type: 'array',
+          items: {
+            type: 'integer',
+            enum: [1, 2, 3],
+          },
+          uniqueItems: true,
+        };
+        const enumUiSchema: UiSchema = {
+          items: {
+            'ui:enumNames': ['A', 'B', 'C'],
+          },
+        };
+        const { node } = createFormComponent({ schema: enumSchema, uiSchema: enumUiSchema });
+
+        const options = node.querySelectorAll('select option');
+        expect(options).toHaveLength(3);
+        expect(options[0]).toHaveTextContent('A');
+        expect(options[1]).toHaveTextContent('B');
+        expect(options[2]).toHaveTextContent('C');
+      });
     });
 
     describe('CheckboxesWidget', () => {


### PR DESCRIPTION


### Reasons for making this change

Fixes #4955

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
