### PR TITLE
feat:Replace extraErrorsBlockSubmit with extraErrorsAreWarnings

### DIFF
--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -173,8 +173,8 @@ export interface FormProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
    * still submit the form when these are the only errors displayed to the user.
    */
   extraErrors?: ErrorSchema<T>;
-  /** If set to true, causes the `extraErrors` to become blocking when the form is submitted */
-  extraErrorsBlockSubmit?: boolean;
+  /** If set to true, treats `extraErrors` as warnings instead of blocking form submission */
+  extraErrorsAreWarnings?: boolean;
   /** If set to true, turns off HTML5 validation on the form; Set to `false` by default */
   noHtml5Validate?: boolean;
   /** If set to true, turns off all validation. Set to `false` by default
@@ -1216,14 +1216,14 @@ export default class Form<
    * @returns - True if the form is valid, false otherwise.
    */
   validateFormWithFormData = (formData?: T): boolean => {
-    const { extraErrors, extraErrorsBlockSubmit, focusOnFirstError, onError } = this.props;
+    const { extraErrors, focusOnFirstError, onError, extraErrorsAreWarnings } = this.props;
     const { errors: prevErrors } = this.state;
     const schemaValidation = this.validate(formData);
     let errors = schemaValidation.errors;
     let errorSchema = schemaValidation.errorSchema;
     const schemaValidationErrors = errors;
     const schemaValidationErrorSchema = errorSchema;
-    const hasError = errors.length > 0 || (extraErrors && extraErrorsBlockSubmit);
+    const hasError = errors.length > 0 || (extraErrors && extraErrorsAreWarnings !== true);
     if (hasError) {
       if (extraErrors) {
         const merged = validationDataMerge(schemaValidation, extraErrors);

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -1223,7 +1223,7 @@ export default class Form<
     let errorSchema = schemaValidation.errorSchema;
     const schemaValidationErrors = errors;
     const schemaValidationErrorSchema = errorSchema;
-    const hasError = errors.length > 0 || (extraErrors && extraErrorsAreWarnings !== true);
+    const hasError = errors.length > 0 || (extraErrors && !extraErrorsAreWarnings);
     if (hasError) {
       if (extraErrors) {
         const merged = validationDataMerge(schemaValidation, extraErrors);

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -2567,7 +2567,7 @@ describeRepeated('Form common', (createFormComponent) => {
           onError,
           focusOnFirstError,
           extraErrors,
-          extraErrorsBlockSubmit: true,
+          extraErrorsAreWarnings: false,
         });
 
         const input = node.querySelector<HTMLInputElement>('input[type=text]')!;
@@ -4471,9 +4471,29 @@ describe('Async errors', () => {
       },
     } as unknown as ErrorSchema;
 
-    const { node, onSubmit } = createFormComponent({ schema, extraErrors });
+    const { node, onSubmit } = createFormComponent({ schema, extraErrors, extraErrorsAreWarnings: true });
     fireEvent.submit(node);
     expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should block submit by default when extraErrors are present', () => {
+    const onError = jest.fn();
+    const onSubmit = jest.fn();
+    const extraErrors = {
+      __errors: ['blocking error'],
+    } as ErrorSchema;
+
+    const { node } = createFormComponent({
+      schema: {},
+      onError,
+      onSubmit,
+      extraErrors,
+      // No extraErrorsAreWarnings prop, so should block by default
+    });
+
+    fireEvent.submit(node);
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalled();
   });
 
   it('should reset when props extraErrors changes and noValidate is true', () => {


### PR DESCRIPTION
### Reasons for making this change

Replaced `extraErrorsBlockSubmit` with `extraErrorsAreWarnings`

fixes : #4964 

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
