### PR TITLE
Restore array -> enum uiSchema behavior (#4985)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 6.4.2
+
+## @rjsf/core
+
+- Fixed a breaking change introduced in v6.4.0 where array properties with enum items no longer used `ui:enumNames` from the array property's uiSchema ([#4985](https://github.com/rjsf-team/react-jsonschema-form/issues/4985))
+
 # 6.4.1
 
 ## Dev / docs / playground
@@ -29,7 +35,6 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `extraErrors` not displaying on first async set after submit, fixing [#4965](https://github.com/rjsf-team/react-jsonschema-form/issues/4965)
 - Updated multi-select ArrayFields to properly use the `items` uiSchema for enumerated options, fixing [#4955](https://github.com/rjsf-team/react-jsonschema-form/issues/4955)
 - Fixed `validateForm()` clearing `extraErrors` from state when schema validation passes, fixing [#4962](https://github.com/rjsf-team/react-jsonschema-form/issues/4962)
-
 
 ## @rjsf/utils
 

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -199,7 +199,9 @@ function ArrayAsMultiSelect<T = any, S extends StrictRJSFSchema = RJSFSchema, F 
   } = props;
   const { widgets, schemaUtils, globalFormOptions, globalUiOptions } = registry;
   const itemsSchema = schemaUtils.retrieveSchema(schema.items as S, items);
-  const itemsUiSchema = (uiSchema?.items ?? {}) as UiSchema<T[], S, F>;
+  // For computing `enumOptions`, fallback to the array property's uiSchema if there is no `items` schema
+  // Avoids a breaking change reported in https://github.com/rjsf-team/react-jsonschema-form/issues/4985
+  const itemsUiSchema = (uiSchema?.items ?? uiSchema) as UiSchema<T[], S, F>;
   const enumOptions = optionsList<T[], S, F>(itemsSchema, itemsUiSchema);
   const { widget = 'select', title: uiTitle, ...options } = getUiOptions<T[], S, F>(uiSchema, globalUiOptions);
   const Widget = getWidget<T[], S, F>(schema, widget, widgets);

--- a/packages/core/test/ArrayField.test.tsx
+++ b/packages/core/test/ArrayField.test.tsx
@@ -1369,6 +1369,28 @@ describe('ArrayField', () => {
         expect(options[1]).toHaveTextContent('B');
         expect(options[2]).toHaveTextContent('C');
       });
+
+      it("falls back to ui:enumNames from array's uiSchema as option labels (#4985)", () => {
+        const enumSchema: RJSFSchema = {
+          title: 'Demo',
+          type: 'array',
+          items: {
+            type: 'integer',
+            enum: [1, 2, 3],
+          },
+          uniqueItems: true,
+        };
+        const enumUiSchema: UiSchema = {
+          'ui:enumNames': ['A', 'B', 'C'],
+        };
+        const { node } = createFormComponent({ schema: enumSchema, uiSchema: enumUiSchema });
+
+        const options = node.querySelectorAll('select option');
+        expect(options).toHaveLength(3);
+        expect(options[0]).toHaveTextContent('A');
+        expect(options[1]).toHaveTextContent('B');
+        expect(options[2]).toHaveTextContent('C');
+      });
     });
 
     describe('CheckboxesWidget', () => {

--- a/packages/playground/src/samples/enumObjects.ts
+++ b/packages/playground/src/samples/enumObjects.ts
@@ -72,11 +72,15 @@ const enumObjects: Sample = {
       ...ENUM_NAMES,
     },
     multiSelect: {
-      ...ENUM_NAMES,
+      items: {
+        ...ENUM_NAMES,
+      },
     },
     checkboxes: {
       'ui:widget': 'CheckboxesWidget',
-      ...ENUM_NAMES,
+      items: {
+        ...ENUM_NAMES,
+      },
     },
     rating: {
       'ui:enumNames': {


### PR DESCRIPTION
- Fixed a breaking change introduced in v6.4.0 where array properties with enum items no longer used `ui:enumNames` from the array property's uiSchema ([#4985](https://github.com/rjsf-team/react-jsonschema-form/issues/4985))

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
