### PR TITLE
Feat/UI initial value and required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 7.0.0
+
+## @rjsf/utils
+
+- Extended `ui:emptyValue` to apply whenever a field is blank (initial render, reset, or user clearing), not just on widget clear ([#4983](https://github.com/rjsf-team/react-jsonschema-form/issues/4983))
+- Added `ui:initialValue` to pre-fill fields on render/reset, taking priority over `schema.default` ([#4983](https://github.com/rjsf-team/react-jsonschema-form/issues/4983))
+- Added `ui:required` to override schema required status from uiSchema ([#4983](https://github.com/rjsf-team/react-jsonschema-form/issues/4983))
+
+## @rjsf/core
+
+- Updated `Form` to pass `uiSchema` through `getDefaultFormState` for `ui:emptyValue` and `ui:initialValue` support ([#4983](https://github.com/rjsf-team/react-jsonschema-form/issues/4983))
+- Updated `SchemaField` and `LayoutGridField` to respect `ui:required` override ([#4983](https://github.com/rjsf-team/react-jsonschema-form/issues/4983))
+
+## Dev / docs / playground
+
+- Added documentation and playground examples for `ui:emptyValue` (extended), `ui:initialValue`, and `ui:required` ([#4983](https://github.com/rjsf-team/react-jsonschema-form/issues/4983))
+
 # 6.4.2
 
 ## @rjsf/core

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -592,6 +592,7 @@ export default class Form<
       defaultsFormData,
       false,
       state.initialDefaultsGenerated,
+      uiSchema,
     ) as T;
     const _retrievedSchema = this.updateRetrievedSchema(
       retrievedSchema ?? schemaUtils.retrieveSchema(rootSchema, formData),

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -1,5 +1,6 @@
 import { Component, ElementType, FormEvent, ReactNode, Ref, RefObject, createRef } from 'react';
 import {
+  augmentSchemaWithUiRequired,
   createSchemaUtils,
   CustomValidator,
   deepEquals,
@@ -720,9 +721,10 @@ export default class Form<
     const schemaUtils = altSchemaUtils ? altSchemaUtils : this.state.schemaUtils;
     const { customValidate, transformErrors, uiSchema } = this.props;
     const resolvedSchema = retrievedSchema ?? schemaUtils.retrieveSchema(schema, formData);
+    const effectiveSchema = augmentSchemaWithUiRequired<T, S>(resolvedSchema, uiSchema);
     return schemaUtils
       .getValidator()
-      .validateFormData(formData, resolvedSchema, customValidate, transformErrors, uiSchema);
+      .validateFormData(formData, effectiveSchema, customValidate, transformErrors, uiSchema);
   }
 
   /** Renders any errors contained in the `state` in using the `ErrorList`, if not disabled by `showErrorList`. */

--- a/packages/core/src/components/fields/LayoutGridField.tsx
+++ b/packages/core/src/components/fields/LayoutGridField.tsx
@@ -681,6 +681,8 @@ function LayoutGridFieldComponent<T = any, S extends StrictRJSFSchema = RJSFSche
     // the `Form` via the prop passed to `LayoutGridField` we need to make sure the uiSchema always has a true value
     // when it is needed
     const { fieldUiSchema, uiReadonly } = computeFieldUiSchema<T, S, F>(name, uiProps, uiSchema, isReadonly, readonly);
+    const fieldUiOptions = getUiOptions<T, S, F>(fieldUiSchema);
+    const effectiveRequired = fieldUiOptions.required !== undefined ? Boolean(fieldUiOptions.required) : isRequired;
 
     return (
       <Field
@@ -691,7 +693,7 @@ function LayoutGridFieldComponent<T = any, S extends StrictRJSFSchema = RJSFSche
         }
         {...otherProps}
         name={name}
-        required={isRequired}
+        required={effectiveRequired}
         readonly={uiReadonly}
         schema={schema}
         uiSchema={fieldUiSchema}

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -135,6 +135,18 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   const FieldComponent = getFieldComponent<T, S, F>(schema, uiOptions, registry);
   const disabled = Boolean(uiOptions.disabled ?? props.disabled);
   const readonly = Boolean(uiOptions.readonly ?? (props.readonly || props.schema.readOnly || schema.readOnly));
+  const effectiveRequired = uiOptions.required !== undefined ? Boolean(uiOptions.required) : required;
+  if (
+    uiOptions.required === false &&
+    required &&
+    uiOptions.initialValue === undefined &&
+    uiOptions.emptyValue === undefined
+  ) {
+    console.warn(
+      `ui:required is false for a schema-required field "${name}" but no ui:initialValue or ui:emptyValue is set. ` +
+        'The UI will show this field as optional but schema validation will still fail if left empty.',
+    );
+  }
   const uiSchemaHideError = uiOptions.hideError;
   // Set hideError to the value provided in the uiSchema, otherwise stick with the prop to propagate to children
   const hideError = uiSchemaHideError === undefined ? props.hideError : Boolean(uiSchemaHideError);
@@ -167,7 +179,7 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
       );
     }
     // When the anyOf/oneOf is an optional data control render AND it does not have form data, hide the label
-    const isOptionalRender = shouldRenderOptionalField<T, S, F>(registry, schema, required, uiSchema);
+    const isOptionalRender = shouldRenderOptionalField<T, S, F>(registry, schema, effectiveRequired, uiSchema);
     const hasFormData = isFormDataAvailable<T>(formData);
     displayLabel = displayLabel && (!isOptionalRender || hasFormData);
     fieldPathIdProps = {
@@ -274,7 +286,7 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
     onKeyRename,
     onKeyRenameBlur,
     onRemoveProperty,
-    required,
+    required: effectiveRequired,
     disabled,
     readonly,
     hideError,

--- a/packages/core/test/uiSchema.test.tsx
+++ b/packages/core/test/uiSchema.test.tsx
@@ -2865,4 +2865,100 @@ describe('uiSchema', () => {
       expect(node.querySelectorAll("input[placeholder='Node name']")).toHaveLength(5);
     });
   });
+
+  describe('ui:required', () => {
+    it('shows required asterisk on non-required field when ui:required is true', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          foo: { type: 'string' },
+        },
+      };
+      const uiSchema: UiSchema = {
+        foo: { 'ui:required': true },
+      };
+      const { node } = createFormComponent({ schema, uiSchema });
+      expect(node.querySelector('.rjsf-field-string label span.required')).not.toBeNull();
+    });
+
+    it('hides required asterisk on schema-required field when ui:required is false', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        required: ['foo'],
+        properties: {
+          foo: { type: 'string' },
+        },
+      };
+      const uiSchema: UiSchema = {
+        foo: { 'ui:required': false, 'ui:initialValue': 'fallback' },
+      };
+      const { node } = createFormComponent({ schema, uiSchema });
+      expect(node.querySelector('.rjsf-field-string label span.required')).toBeNull();
+    });
+
+    it('produces validation error when ui:required is true and field is empty', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          foo: { type: 'string' },
+        },
+      };
+      const uiSchema: UiSchema = {
+        foo: { 'ui:required': true },
+      };
+      const { node, onSubmit } = createFormComponent({ schema, uiSchema });
+      submitForm(node);
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('does not suppress schema validation when ui:required is false', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        required: ['foo'],
+        properties: {
+          foo: { type: 'string' },
+        },
+      };
+      const uiSchema: UiSchema = {
+        foo: { 'ui:required': false },
+      };
+      const { node, onSubmit } = createFormComponent({ schema, uiSchema });
+      submitForm(node);
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('emits console.warn for ui:required false without initialValue or emptyValue', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        required: ['foo'],
+        properties: {
+          foo: { type: 'string' },
+        },
+      };
+      const uiSchema: UiSchema = {
+        foo: { 'ui:required': false },
+      };
+      createFormComponent({ schema, uiSchema });
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('ui:required is false for a schema-required field'),
+      );
+    });
+
+    it('does not emit console.warn for ui:required false with initialValue set', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        required: ['foo'],
+        properties: {
+          foo: { type: 'string' },
+        },
+      };
+      const uiSchema: UiSchema = {
+        foo: { 'ui:required': false, 'ui:initialValue': 'x' },
+      };
+      createFormComponent({ schema, uiSchema });
+      expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('ui:required is false for a schema-required field'),
+      );
+    });
+  });
 });

--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -485,7 +485,25 @@ render(
 
 ### emptyValue
 
-The `ui:emptyValue` uiSchema directive provides the default value to use when an input for a field is empty
+The `ui:emptyValue` uiSchema directive provides the default value to use when a field is empty. This applies whenever the field is blank, whether from initial render, a form reset, or the user clearing the input.
+
+```tsx
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+
+const schema: RJSFSchema = {
+  type: 'object',
+  required: ['name'],
+  properties: {
+    name: { type: 'string' },
+  },
+};
+
+const uiSchema: UiSchema = {
+  name: {
+    'ui:emptyValue': '',
+  },
+};
+```
 
 ### enumDisabled
 
@@ -588,6 +606,28 @@ If you need to enable the default error display of a child in the hierarchy afte
 
 This is useful when you have a custom field or widget that utilizes either the `rawErrors` or the `errorSchema` to manipulate and/or show the error(s) for the field/widget itself.
 
+### initialValue
+
+The `ui:initialValue` uiSchema directive pre-fills a field on initial render and after a form reset. It takes priority over `schema.default` but does not override user-provided `formData`. Useful for hidden fields that need a fixed value.
+
+```tsx
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+
+const schema: RJSFSchema = {
+  type: 'object',
+  properties: {
+    country: { type: 'string' },
+  },
+};
+
+const uiSchema: UiSchema = {
+  country: {
+    'ui:initialValue': 'US',
+    'ui:widget': 'hidden',
+  },
+};
+```
+
 ### inputType
 
 To change the input type (for example, `tel` or `email`) you can specify the `inputType` in the `ui:options` uiSchema directive.
@@ -681,6 +721,10 @@ render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, docum
 The `ui:readonly` uiSchema directive will mark all child widgets from a given field as read-only. This is equivalent to setting the `readOnly` property in the schema.
 
 > Note: If you're wondering about the difference between a `disabled` field and a `readonly` one: Marking a field as read-only will render it greyed out, but its text value will be selectable. Disabling it will prevent its value to be selected at all.
+
+### required
+
+The `ui:required` uiSchema directive overrides the schema's `required` status for a field. Setting `ui:required` to `true` shows the required indicator and produces a validation error if the field is left empty. Setting it to `false` hides the required indicator, but does not suppress schema-level validation. A `console.warn` is emitted when `ui:required` is `false` on a schema-required field without `ui:initialValue` or `ui:emptyValue` set.
 
 ### rows
 

--- a/packages/playground/src/samples/options.ts
+++ b/packages/playground/src/samples/options.ts
@@ -21,6 +21,14 @@ const optionsSample: Sample = {
         title: 'Telephone',
         minLength: 10,
       },
+      country: {
+        type: 'string',
+        title: 'Country',
+      },
+      email: {
+        type: 'string',
+        title: 'Email',
+      },
     },
   },
   uiSchema: {
@@ -41,6 +49,7 @@ const optionsSample: Sample = {
       'ui:title': 'Surname',
       'ui:emptyValue': '',
       'ui:autocomplete': 'given-name',
+      'ui:required': false,
     },
     age: {
       'ui:widget': 'updown',
@@ -61,6 +70,13 @@ const optionsSample: Sample = {
       'ui:options': {
         inputType: 'tel',
       },
+    },
+    country: {
+      'ui:initialValue': 'US',
+      'ui:widget': 'hidden',
+    },
+    email: {
+      'ui:required': true,
     },
   },
   formData: {

--- a/packages/utils/src/augmentSchemaWithUiRequired.ts
+++ b/packages/utils/src/augmentSchemaWithUiRequired.ts
@@ -1,0 +1,59 @@
+import get from 'lodash/get';
+
+import getUiOptions from './getUiOptions';
+import { FormContextType, RJSFSchema, StrictRJSFSchema, UiSchema } from './types';
+
+/** Recursively walks a schema and uiSchema, adding fields marked `ui:required: true` to the schema's `required`
+ * arrays. Returns a new schema without mutating the original.
+ *
+ * @param schema - The schema to augment
+ * @param [uiSchema] - The uiSchema containing ui:required overrides
+ * @returns A new schema with ui:required fields added to required arrays
+ */
+export default function augmentSchemaWithUiRequired<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+>(schema: S, uiSchema?: UiSchema<T, S, F>): S {
+  if (!uiSchema || schema.type !== 'object' || !schema.properties) {
+    return schema;
+  }
+
+  const existingRequired = schema.required || [];
+  const additionalRequired: string[] = [];
+  let propertiesChanged = false;
+  const newProperties: Record<string, unknown> = {};
+
+  for (const key of Object.keys(schema.properties)) {
+    const fieldUiSchema = get(uiSchema, [key]);
+    const propertySchema = schema.properties[key] as S;
+
+    if (fieldUiSchema) {
+      const { required: uiRequired } = getUiOptions<T, S, F>(fieldUiSchema);
+      if (uiRequired === true && !existingRequired.includes(key)) {
+        additionalRequired.push(key);
+      }
+    }
+
+    // Recurse into nested objects
+    if (propertySchema && propertySchema.type === 'object' && fieldUiSchema) {
+      const augmented = augmentSchemaWithUiRequired<T, S, F>(propertySchema, fieldUiSchema);
+      if (augmented !== propertySchema) {
+        propertiesChanged = true;
+        newProperties[key] = augmented;
+        continue;
+      }
+    }
+    newProperties[key] = propertySchema;
+  }
+
+  if (additionalRequired.length === 0 && !propertiesChanged) {
+    return schema;
+  }
+
+  return {
+    ...schema,
+    ...(propertiesChanged ? { properties: newProperties } : {}),
+    ...(additionalRequired.length > 0 ? { required: [...existingRequired, ...additionalRequired] } : {}),
+  };
+}

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -169,6 +169,7 @@ class SchemaUtils<
    *          If "excludeObjectChildren", pass `includeUndefinedValues` as false when computing defaults for any nested
    *          object properties.
    * @param initialDefaultsGenerated - Indicates whether or not initial defaults have been generated
+   * @param [uiSchema] - Optional uiSchema, used to apply ui:emptyValue and ui:initialValue as defaults
    * @returns - The resulting `formData` with all the defaults provided
    */
   getDefaultFormState(
@@ -176,6 +177,7 @@ class SchemaUtils<
     formData?: T,
     includeUndefinedValues: boolean | 'excludeObjectChildren' = false,
     initialDefaultsGenerated?: boolean,
+    uiSchema?: UiSchema<T, S, F>,
   ): T | T[] | undefined {
     return getDefaultFormState<T, S, F>(
       this.validator,
@@ -186,6 +188,7 @@ class SchemaUtils<
       this.experimental_defaultFormStateBehavior,
       this.experimental_customMergeAllOf,
       initialDefaultsGenerated,
+      uiSchema,
     );
   }
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,6 @@
 import allowAdditionalItems from './allowAdditionalItems';
 import asNumber from './asNumber';
+import augmentSchemaWithUiRequired from './augmentSchemaWithUiRequired';
 import canExpand from './canExpand';
 import createErrorHandler from './createErrorHandler';
 import createSchemaUtils from './createSchemaUtils';
@@ -97,6 +98,7 @@ export {
   allowAdditionalItems,
   ariaDescribedByIds,
   asNumber,
+  augmentSchemaWithUiRequired,
   buttonId,
   canExpand,
   createErrorHandler,

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -395,10 +395,12 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
     defaults = schema.default as unknown as T;
   }
 
-  // Apply ui:emptyValue as a fallback when no other default is available
+  // Apply uiSchema defaults: initialValue overrides schema.default, emptyValue is the fallback for blank fields
   if (uiSchema) {
-    const { emptyValue } = getUiOptions(uiSchema);
-    if (defaults === undefined && emptyValue !== undefined) {
+    const { initialValue, emptyValue } = getUiOptions(uiSchema);
+    if (initialValue !== undefined) {
+      defaults = initialValue as unknown as T;
+    } else if (defaults === undefined && emptyValue !== undefined) {
       defaults = emptyValue as unknown as T;
     }
   }

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -29,8 +29,10 @@ import {
   GenericObjectType,
   RJSFSchema,
   StrictRJSFSchema,
+  UiSchema,
   ValidatorType,
 } from '../types';
+import getUiOptions from '../getUiOptions';
 import isMultiSelect from './isMultiSelect';
 import isSelect from './isSelect';
 import retrieveSchema, { resolveDependencies } from './retrieveSchema';
@@ -183,7 +185,7 @@ function maybeAddDefaultToObject<T = any>(
   }
 }
 
-interface ComputeDefaultsProps<T = any, S extends StrictRJSFSchema = RJSFSchema> {
+interface ComputeDefaultsProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any> {
   /** Any defaults provided by the parent field in the schema */
   parentDefaults?: T;
   /** The options root schema, used to primarily to look up `$ref`s */
@@ -211,6 +213,8 @@ interface ComputeDefaultsProps<T = any, S extends StrictRJSFSchema = RJSFSchema>
   shouldMergeDefaultsIntoFormData?: boolean;
   /** Indicates whether initial defaults have been generated */
   initialDefaultsGenerated?: boolean;
+  /** Optional uiSchema, used to apply ui:emptyValue and ui:initialValue as defaults */
+  uiSchema?: UiSchema<T, S, F>;
 }
 
 /** Computes the defaults for the current `schema` given the `rawFormData` and `parentDefaults` if any. This drills into
@@ -224,7 +228,7 @@ interface ComputeDefaultsProps<T = any, S extends StrictRJSFSchema = RJSFSchema>
 export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   validator: ValidatorType<T, S, F>,
   rawSchema: S,
-  computeDefaultsProps: ComputeDefaultsProps<T, S> = {},
+  computeDefaultsProps: ComputeDefaultsProps<T, S, F> = {},
 ): T | T[] | undefined {
   const {
     parentDefaults,
@@ -237,6 +241,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
     required,
     shouldMergeDefaultsIntoFormData = false,
     initialDefaultsGenerated,
+    uiSchema,
   } = computeDefaultsProps;
   let formData: T = (isObject(rawFormData) ? rawFormData : {}) as T;
   const schema: S = isObject(rawSchema) ? rawSchema : ({} as S);
@@ -307,7 +312,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
     schemaToCompute = resolvedSchema[0]; // pick the first element from resolve dependencies
   } else if (isFixedItems(schema)) {
     defaults = (schema.items! as S[]).map((itemSchema: S, idx: number) =>
-      computeDefaults<T, S>(validator, itemSchema, {
+      computeDefaults<T, S, F>(validator, itemSchema, {
         rootSchema,
         includeUndefinedValues,
         _recurseList,
@@ -381,12 +386,21 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       required,
       shouldMergeDefaultsIntoFormData,
       initialDefaultsGenerated,
+      uiSchema,
     });
   }
 
   // No defaults defined for this node, fallback to generic typed ones.
   if (defaults === undefined) {
     defaults = schema.default as unknown as T;
+  }
+
+  // Apply ui:emptyValue as a fallback when no other default is available
+  if (uiSchema) {
+    const { emptyValue } = getUiOptions(uiSchema);
+    if (defaults === undefined && emptyValue !== undefined) {
+      defaults = emptyValue as unknown as T;
+    }
   }
 
   const defaultBasedOnSchemaType = getDefaultBasedOnSchemaType(validator, schema, computeDefaultsProps, defaults);
@@ -482,7 +496,8 @@ export function getObjectDefaults<T = any, S extends StrictRJSFSchema = RJSFSche
     required,
     shouldMergeDefaultsIntoFormData,
     initialDefaultsGenerated,
-  }: ComputeDefaultsProps<T, S> = {},
+    uiSchema,
+  }: ComputeDefaultsProps<T, S, F> = {},
   defaults?: T | T[],
 ): T {
   {
@@ -522,6 +537,7 @@ export function getObjectDefaults<T = any, S extends StrictRJSFSchema = RJSFSche
           required: retrievedSchema.required?.includes(key),
           shouldMergeDefaultsIntoFormData,
           initialDefaultsGenerated,
+          uiSchema: get(uiSchema, [key]),
         });
 
         maybeAddDefaultToObject<T>(
@@ -571,6 +587,7 @@ export function getObjectDefaults<T = any, S extends StrictRJSFSchema = RJSFSche
           required: retrievedSchema.required?.includes(key),
           shouldMergeDefaultsIntoFormData,
           initialDefaultsGenerated,
+          uiSchema: get(uiSchema, [key]),
         });
         // Since these are additional properties we don't need to add the `experimental_defaultFormStateBehavior` prop
         maybeAddDefaultToObject<T>(
@@ -761,6 +778,7 @@ export function getDefaultBasedOnSchemaType<
  * @param [experimental_defaultFormStateBehavior] Optional configuration object, if provided, allows users to override default form state behavior
  * @param [experimental_customMergeAllOf] - Optional function that allows for custom merging of `allOf` schemas
  * @param initialDefaultsGenerated - Optional flag, indicates whether or not initial defaults have been generated
+ * @param [uiSchema] - Optional uiSchema, used to apply ui:emptyValue and ui:initialValue as defaults
  * @returns - The resulting `formData` with all the defaults provided
  */
 export default function getDefaultFormState<
@@ -776,6 +794,7 @@ export default function getDefaultFormState<
   experimental_defaultFormStateBehavior?: Experimental_DefaultFormStateBehavior,
   experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>,
   initialDefaultsGenerated?: boolean,
+  uiSchema?: UiSchema<T, S, F>,
 ) {
   if (!isObject(theSchema)) {
     throw new Error('Invalid schema: ' + theSchema);
@@ -794,6 +813,7 @@ export default function getDefaultFormState<
     shouldMergeDefaultsIntoFormData: true,
     initialDefaultsGenerated,
     requiredAsRoot: true,
+    uiSchema,
   });
 
   if (schema.type !== 'object' && isObject(schema.default)) {

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1073,6 +1073,8 @@ type UIOptionsBaseType<T = any, S extends StrictRJSFSchema = RJSFSchema, F exten
     disabled?: boolean;
     /** The default value to use when an input for a field is empty */
     emptyValue?: any;
+    /** Pre-fills the field on initial render and after reset, takes priority over schema default */
+    initialValue?: any;
     /** Will disable any of the enum options specified in the array (by value) */
     enumDisabled?: EnumValue[];
     /** Allows a user to provide a list of labels for enum values in the schema.

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1329,6 +1329,7 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
     formData?: T,
     includeUndefinedValues?: boolean | 'excludeObjectChildren',
     initialDefaultsGenerated?: boolean,
+    uiSchema?: UiSchema<T, S, F>,
   ): T | T[] | undefined;
   /** Determines whether the combination of `schema` and `uiSchema` properties indicates that the label for the `schema`
    * should be displayed in a UI.

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1075,6 +1075,8 @@ type UIOptionsBaseType<T = any, S extends StrictRJSFSchema = RJSFSchema, F exten
     emptyValue?: any;
     /** Pre-fills the field on initial render and after reset, takes priority over schema default */
     initialValue?: any;
+    /** Overrides the schema's required for a field: true adds required, false hides the indicator */
+    required?: boolean;
     /** Will disable any of the enum options specified in the array (by value) */
     enumDisabled?: EnumValue[];
     /** Allows a user to provide a list of labels for enum values in the schema.

--- a/packages/utils/test/augmentSchemaWithUiRequired.test.ts
+++ b/packages/utils/test/augmentSchemaWithUiRequired.test.ts
@@ -1,0 +1,107 @@
+import { augmentSchemaWithUiRequired, RJSFSchema, UiSchema } from '../src';
+
+describe('augmentSchemaWithUiRequired', () => {
+  it('returns the same schema when no uiSchema is provided', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+    };
+    expect(augmentSchemaWithUiRequired(schema)).toBe(schema);
+  });
+
+  it('returns the same schema when no ui:required fields exist', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+    };
+    const uiSchema: UiSchema = { foo: { 'ui:widget': 'textarea' } };
+    expect(augmentSchemaWithUiRequired(schema, uiSchema)).toBe(schema);
+  });
+
+  it('adds ui:required: true field to required array', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: { foo: { type: 'string' }, bar: { type: 'string' } },
+    };
+    const uiSchema: UiSchema = { foo: { 'ui:required': true } };
+    const result = augmentSchemaWithUiRequired(schema, uiSchema);
+    expect(result.required).toEqual(['foo']);
+    expect(result).not.toBe(schema);
+  });
+
+  it('does not duplicate existing required fields', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      required: ['foo'],
+      properties: { foo: { type: 'string' } },
+    };
+    const uiSchema: UiSchema = { foo: { 'ui:required': true } };
+    const result = augmentSchemaWithUiRequired(schema, uiSchema);
+    expect(result).toBe(schema);
+  });
+
+  it('preserves existing required and adds new ones', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      required: ['foo'],
+      properties: { foo: { type: 'string' }, bar: { type: 'string' } },
+    };
+    const uiSchema: UiSchema = { bar: { 'ui:required': true } };
+    const result = augmentSchemaWithUiRequired(schema, uiSchema);
+    expect(result.required).toEqual(['foo', 'bar']);
+  });
+
+  it('handles nested objects', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        address: {
+          type: 'object',
+          properties: {
+            city: { type: 'string' },
+          },
+        },
+      },
+    };
+    const uiSchema: UiSchema = {
+      address: { city: { 'ui:required': true } },
+    };
+    const result = augmentSchemaWithUiRequired(schema, uiSchema);
+    expect((result.properties!.address as RJSFSchema).required).toEqual(['city']);
+  });
+
+  it('does not mutate the original schema', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+    };
+    const uiSchema: UiSchema = { foo: { 'ui:required': true } };
+    augmentSchemaWithUiRequired(schema, uiSchema);
+    expect(schema.required).toBeUndefined();
+  });
+
+  it('returns same schema when nested object has uiSchema but no ui:required changes', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        address: {
+          type: 'object',
+          properties: {
+            city: { type: 'string' },
+          },
+        },
+      },
+    };
+    const uiSchema: UiSchema = {
+      address: { city: { 'ui:widget': 'textarea' } },
+    };
+    const result = augmentSchemaWithUiRequired(schema, uiSchema);
+    expect(result).toBe(schema);
+  });
+
+  it('returns schema as-is for non-object types', () => {
+    const schema: RJSFSchema = { type: 'string' };
+    const uiSchema: UiSchema = { 'ui:required': true };
+    expect(augmentSchemaWithUiRequired(schema, uiSchema)).toBe(schema);
+  });
+});

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -5814,5 +5814,172 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(getDefaultFormState(testValidator, schema, undefined, schema)).toEqual({});
       });
     });
+
+    describe('ui:initialValue in getDefaultFormState', () => {
+      it('uses initialValue as default when no formData and no schema default', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            country: { type: 'string' },
+          },
+        };
+        const uiSchema = {
+          country: { 'ui:initialValue': 'US' },
+        };
+        expect(
+          getDefaultFormState(
+            testValidator,
+            schema,
+            undefined,
+            schema,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            uiSchema,
+          ),
+        ).toEqual({
+          country: 'US',
+        });
+      });
+      it('overrides schema default with initialValue', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            country: { type: 'string', default: 'UK' },
+          },
+        };
+        const uiSchema = {
+          country: { 'ui:initialValue': 'US' },
+        };
+        expect(
+          getDefaultFormState(
+            testValidator,
+            schema,
+            undefined,
+            schema,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            uiSchema,
+          ),
+        ).toEqual({
+          country: 'US',
+        });
+      });
+      it('does not override provided formData', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            country: { type: 'string' },
+          },
+        };
+        const uiSchema = {
+          country: { 'ui:initialValue': 'US' },
+        };
+        expect(
+          getDefaultFormState(
+            testValidator,
+            schema,
+            { country: 'FR' },
+            schema,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            uiSchema,
+          ),
+        ).toEqual({
+          country: 'FR',
+        });
+      });
+      it('takes priority over emptyValue', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            country: { type: 'string' },
+          },
+        };
+        const uiSchema = {
+          country: { 'ui:initialValue': 'US', 'ui:emptyValue': '' },
+        };
+        expect(
+          getDefaultFormState(
+            testValidator,
+            schema,
+            undefined,
+            schema,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            uiSchema,
+          ),
+        ).toEqual({
+          country: 'US',
+        });
+      });
+      it('applies initialValue in nested objects', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            address: {
+              type: 'object',
+              properties: {
+                country: { type: 'string' },
+                city: { type: 'string' },
+              },
+            },
+          },
+        };
+        const uiSchema = {
+          address: {
+            country: { 'ui:initialValue': 'US' },
+          },
+        };
+        expect(
+          getDefaultFormState(
+            testValidator,
+            schema,
+            undefined,
+            schema,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            uiSchema,
+          ),
+        ).toEqual({
+          address: { country: 'US' },
+        });
+      });
+      it('applies initialValue on reset (undefined formData)', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+        };
+        const uiSchema = {
+          name: { 'ui:initialValue': 'default name' },
+        };
+        expect(
+          getDefaultFormState(
+            testValidator,
+            schema,
+            undefined,
+            schema,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            uiSchema,
+          ),
+        ).toEqual({
+          name: 'default name',
+        });
+      });
+    });
   });
 }

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -5691,5 +5691,128 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect((result![0] as any).nested).not.toBe((result![1] as any).nested);
       });
     });
+
+    describe('ui:emptyValue in getDefaultFormState', () => {
+      it('uses emptyValue as default when no schema default and no formData', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+        };
+        const uiSchema = {
+          name: { 'ui:emptyValue': '' },
+        };
+        expect(
+          getDefaultFormState(
+            testValidator,
+            schema,
+            undefined,
+            schema,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            uiSchema,
+          ),
+        ).toEqual({
+          name: '',
+        });
+      });
+      it('does not use emptyValue when schema default exists', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            name: { type: 'string', default: 'hello' },
+          },
+        };
+        const uiSchema = {
+          name: { 'ui:emptyValue': '' },
+        };
+        expect(
+          getDefaultFormState(
+            testValidator,
+            schema,
+            undefined,
+            schema,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            uiSchema,
+          ),
+        ).toEqual({
+          name: 'hello',
+        });
+      });
+      it('does not use emptyValue when formData is provided', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+        };
+        const uiSchema = {
+          name: { 'ui:emptyValue': '' },
+        };
+        expect(
+          getDefaultFormState(
+            testValidator,
+            schema,
+            { name: 'world' },
+            schema,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            uiSchema,
+          ),
+        ).toEqual({
+          name: 'world',
+        });
+      });
+      it('applies emptyValue in nested objects', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            address: {
+              type: 'object',
+              properties: {
+                city: { type: 'string' },
+              },
+            },
+          },
+        };
+        const uiSchema = {
+          address: {
+            city: { 'ui:emptyValue': '' },
+          },
+        };
+        expect(
+          getDefaultFormState(
+            testValidator,
+            schema,
+            undefined,
+            schema,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            uiSchema,
+          ),
+        ).toEqual({
+          address: { city: '' },
+        });
+      });
+      it('behaves unchanged when uiSchema is not passed', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+        };
+        expect(getDefaultFormState(testValidator, schema, undefined, schema)).toEqual({});
+      });
+    });
   });
 }


### PR DESCRIPTION
### Reasons for making this change

Fixes #4983

`ui:emptyValue` only applies when the user actively clears a field. If the user never touches it, or the form is reset, there is no equivalent. This is a gap when the JSON schema is auto-generated and a separate uiSchema layer controls the UX.

This PR:
- Extends `ui:emptyValue` to apply whenever a field is blank, regardless of the reason (initial render, reset, or user clearing), by threading `uiSchema` through the [`getDefaultFormState`](packages/utils/src/schema/getDefaultFormState.ts) pipeline
- Adds `ui:initialValue` to pre-fill a field on render/reset, taking priority over `schema.default` (useful for hidden fields that need a fixed value)
- Adds `ui:required` to override the schema's required status for a field. `true` adds the indicator and validation, `false` hides the indicator but does not suppress schema validation. Emits `console.warn` for misleading configurations

The `ui:emptyValue` extension is a breaking change (previously only fired on explicit clear), hence the major version bump to **7.0.0**.

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature