### PR TITLE
feat(mui): add support for MUI-specific props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Added `key={label}` to key input in `WrapIfAdditionalTemplate` to reset input value after duplicate key rename ([#4999](https://github.com/rjsf-team/react-jsonschema-form/issues/4999))
 
+## @rjsf/mui
+
+- Added support for passing MUI-specific props (e.g., `sx`, `slotProps`, `variant`) directly through `uiSchema` or `formContext` for all templates and widgets, fixing [#4996](https://github.com/rjsf-team/react-jsonschema-form/issues/4996)
+
 ## @rjsf/utils
 
 - Added `removeOptionalEmptyObjects` utility function to recursively strip fully empty optional objects based on their parent's `required` properties, fixing [#4954](https://github.com/rjsf-team/react-jsonschema-form/issues/4954)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/mui
 
-- Added support for passing MUI-specific props (e.g., `sx`, `slotProps`, `variant`) directly through `uiSchema` for all templates and widgets, fixing [#4996](https://github.com/rjsf-team/react-jsonschema-form/issues/4996)
+- Added support for passing MUI-specific props (e.g., `sx`, `rjsfSlotProps`, `variant`) directly through `uiSchema` for all templates and widgets, fixing [#4996](https://github.com/rjsf-team/react-jsonschema-form/issues/4996)
 
 ## @rjsf/utils
 
@@ -93,7 +93,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## Dev / Docs / Playground
 
-- Added comprehensive documentation for `@rjsf/mui` customization via `uiSchema` (including `slotProps` usage).
+- Added comprehensive documentation for `@rjsf/mui` customization via `uiSchema` (including `rjsfSlotProps` usage).
 
 # 6.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/mui
 
-- Added support for passing MUI-specific props (e.g., `sx`, `slotProps`, `variant`) directly through `uiSchema` or `formContext` for all templates and widgets, fixing [#4996](https://github.com/rjsf-team/react-jsonschema-form/issues/4996)
+- Added support for passing MUI-specific props (e.g., `sx`, `slotProps`, `variant`) directly through `uiSchema` for all templates and widgets, fixing [#4996](https://github.com/rjsf-team/react-jsonschema-form/issues/4996)
 
 ## @rjsf/utils
 
@@ -90,6 +90,10 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated References playground sample to demonstrate `oneOf` with `ui:title` at recursive depth, related to [#4986](https://github.com/rjsf-team/react-jsonschema-form/issues/4986)
 - Updated the building of the `mantine` theme to properly support ESM, fixing [#5025](https://github.com/rjsf-team/react-jsonschema-form/issues/5025)
 - Updated the `validator-ajv8.md` and `validation.md` documetation for the new `suppressDuplicateFiltering` configuration prop
+
+## Dev / Docs / Playground
+
+- Added comprehensive documentation for `@rjsf/mui` customization via `uiSchema` (including `slotProps` usage).
 
 # 6.4.2
 

--- a/packages/docs/docs/api-reference/themes/mui/uiSchema.md
+++ b/packages/docs/docs/api-reference/themes/mui/uiSchema.md
@@ -4,7 +4,7 @@ You can customize the underlying Material UI (MUI) components used by `@rjsf/mui
 
 ## Basic Usage
 
-The `@rjsf/mui` package looks for an `mui` key inside the `ui:options` of your `uiSchema`. Any top-level properties defined here will be applied to the primary MUI wrapper component for that field (e.g. `TextField` for inputs, `FormGroup` for checkboxes, `Paper`/`Grid` for object/array wrappers).
+The `@rjsf/mui` package looks for a `mui` key inside the `ui:options` of your `uiSchema`. Any top-level properties defined here will be applied to the primary MUI wrapper component for that field (e.g. `TextField` for inputs, `FormGroup` for checkboxes, `Paper`/`Grid` for object/array wrappers).
 
 ```json
 {
@@ -23,11 +23,14 @@ The `@rjsf/mui` package looks for an `mui` key inside the `ui:options` of your `
 }
 ```
 
-## `slotProps` (Targeting nested components)
+## `slotProps` vs `rjsfSlotProps`
 
-Many RJSF templates and widgets are composed of several nested MUI components. To prevent unintended property "leakage" (e.g., passing a `TextField` prop onto an outer `FormControl`), `@rjsf/mui` uses a **Root-plus-Slot** pattern.
+`@rjsf/mui` distinguishes between two kinds of slot customization:
 
-Top-level standard MUI props are applied to the primary component. To pass custom props to specific nested components, use the `slotProps` key within the `mui` object.
+- **`slotProps`**: Passed directly to MUI's native `slotProps` API on a component (e.g., `TextField`'s `htmlInput`, `input`, `inputLabel` targets). These are standard MUI customization points.
+- **`rjsfSlotProps`**: Used by RJSF template components (e.g., `ArrayFieldTemplate`, `ObjectFieldTemplate`) to target their specific sub-components (e.g., `paper`, `grid`, `box`). This key is explicitly extracted before spreading, which **prevents prop bleeding** — ensuring configuration is not accidentally passed to unintended child components.
+
+### Using `slotProps` (for MUI widgets like `BaseInputTemplate`)
 
 ```json
 {
@@ -45,20 +48,14 @@ Top-level standard MUI props are applied to the primary component. To pass custo
 }
 ```
 
-## Customizing Templates (e.g. Object and Array wrappers)
-
-MUI theme customizations are natively passed down into both your standard fields and their wrapping structural templates (like `ArrayFieldTemplate` or `ObjectFieldTemplate`) (see [table below](#components-and-their-slotprops-targets)).
-
-Because RJSF funnels the `uiSchema` dynamically into these templates, you can manipulate structural properties effortlessly.
-
-For example, to customize the structural rendering of an array template—such as raising the elevation of the Material UI `<Paper>` container—you place the `mui` property at the field's `ui:options`:
+### Using `rjsfSlotProps` (for structural templates)
 
 ```json
 {
   "myArrayField": {
     "ui:options": {
       "mui": {
-        "slotProps": {
+        "rjsfSlotProps": {
           "paper": {
             "elevation": 10
           }
@@ -69,6 +66,10 @@ For example, to customize the structural rendering of an array template—such a
 }
 ```
 
+## Customizing Templates (e.g. Object and Array wrappers)
+
+MUI theme customizations are natively passed down into both your standard fields and their wrapping structural templates (like `ArrayFieldTemplate` or `ObjectFieldTemplate`) (see [table below](#components-and-their-rjsfslotprops-targets)).
+
 If you wish to specifically target the _individual array items_ handled by `ArrayFieldItemTemplate` instead of the whole array container, you nest these overrides by targeting the `items` inside the schema:
 
 ```json
@@ -77,9 +78,8 @@ If you wish to specifically target the _individual array items_ handled by `Arra
     "items": {
       "ui:options": {
         "mui": {
-          "slotProps": {
-            "grid": {
-              "container": true,
+          "rjsfSlotProps": {
+            "gridContainer": {
               "spacing": 2
             }
           }
@@ -90,41 +90,63 @@ If you wish to specifically target the _individual array items_ handled by `Arra
 }
 ```
 
-### Components and their `slotProps` targets
+### Components and their `rjsfSlotProps` targets
 
-Different templates and widgets expose different `slotProps` targets based on their underlying MUI composition.
+Different templates and widgets expose different `rjsfSlotProps` targets based on their underlying MUI composition.
 
-| RJSF Component               | `slotProps` targets available | Description                                                                          |
-| ---------------------------- | ----------------------------- | ------------------------------------------------------------------------------------ |
-| **BaseInputTemplate**        | `htmlInput`                   | Props passed to the base native HTML `<input>` or `<textarea>` element.              |
-|                              | `input`                       | Props passed to the MUI `Input` element, useful for `endAdornment`/`startAdornment`. |
-| **FieldTemplate**            | `formControl`                 | Props passed to the outer `FormControl` wrapper.                                     |
-|                              | `typography`                  | Props passed to the `Typography` component used for the description.                 |
-| **ObjectFieldTemplate**      | `grid`                        | Props passed to the various outer and inner `Grid` container elements.               |
-| **ArrayFieldTemplate**       | `box`                         | Props passed to the inner `Box` container holding the array items.                   |
-|                              | `paper`                       | Props passed to the outer `Paper` wrapper.                                           |
-| **ArrayFieldItemTemplate**   | `grid`                        | Props passed to the `Grid` container wrapping the individual array item row.         |
-| **CheckboxesWidget**         | `checkbox`                    | Props passed to individual `Checkbox` components.                                    |
-|                              | `formControlLabel`            | Props passed to the `FormControlLabel` components wrapping each checkbox.            |
-| **CheckboxWidget**           | `checkbox`                    | Props passed to the single `Checkbox` component.                                     |
-|                              | `formControlLabel`            | Props passed to the `FormControlLabel` component wrapping the checkbox.              |
-| **RadioWidget**              | `radio`                       | Props passed to the individual `Radio` components.                                   |
-|                              | `formControlLabel`            | Props passed to the `FormControlLabel` components wrapping each radio.               |
-| **SelectWidget**             | `inputLabel`                  | Props passed to the native MUI `InputLabel` component.                               |
-|                              | `select`                      | Props passed to the native MUI `Select` component.                                   |
-| **ErrorList**                | `box`                         | Props passed to the inner `Box`.                                                     |
-|                              | `list`                        | Props passed to the `List` container.                                                |
-|                              | `listItem`                    | Props passed to individual `ListItem` components wrapping each error.                |
-|                              | `listItemIcon`                | Props passed to the `ListItemIcon` next to each error.                               |
-|                              | `paper`                       | Props passed to the outer `Paper` wrapper.                                           |
-|                              | `typography`                  | Props passed to the `Typography` displaying the "Errors" title.                      |
-| **FieldErrorTemplate**       | `list`                        | Props passed to the `List` container.                                                |
-|                              | `listItem`                    | Props passed to individual `ListItem` components.                                    |
-|                              | `formHelperText`              | Props passed to the `FormHelperText` displaying the error text.                      |
-| **TitleField**               | `typography`                  | Props passed to the `Typography` component used for the title.                       |
-|                              | `grid`                        | Props passed to `Grid` structures when rendering titles with optional data controls. |
-| **MultiSchemaFieldTemplate** | `box`                         | Props passed to the wrapper `Box`.                                                   |
-|                              | `formControl`                 | Props passed to the wrapper `FormControl`.                                           |
-| **SubmitButton**             | `box`                         | Props passed to the `Box` wrapping the submit button.                                |
-
-_(Note: Simple text components like `FieldHelpTemplate` and `DescriptionField` do not use `slotProps`. Top-level `mui` props are passed directly to their main `FormHelperText` or `Typography` elements.)_
+| RJSF Component               | `rjsfSlotProps` targets available | Description                                                                           |
+| ---------------------------- | --------------------------------- | ------------------------------------------------------------------------------------- |
+| **BaseInputTemplate**        | _(uses native `slotProps`)_       | Uses MUI's `slotProps.htmlInput`, `slotProps.input`, `slotProps.inputLabel` directly. |
+| **FieldTemplate**            | `formControl`                     | Props passed to the outer `FormControl` wrapper.                                      |
+|                              | `typography`                      | Props passed to the `Typography` component used for the description.                  |
+| **ObjectFieldTemplate**      | `gridContainer`                   | Props passed to the outer `Grid` container.                                           |
+|                              | `gridItem`                        | Props passed to each property's `Grid` item.                                          |
+|                              | `addButtonGridContainer`          | Props passed to the `Grid` container adjacent to the Add button.                      |
+|                              | `addButtonGridItem`               | Props passed to the `Grid` item wrapping the Add button.                              |
+| **ArrayFieldTemplate**       | `box`                             | Props passed to the inner `Box` container holding the array items.                    |
+|                              | `paper`                           | Props passed to the outer `Paper` wrapper.                                            |
+|                              | `addButtonGridContainer`          | Props passed to the `Grid` container adjacent to the Add button.                      |
+|                              | `addButtonGridItem`               | Props passed to the `Grid` item wrapping the Add button.                              |
+|                              | `addButtonBox`                    | Props passed to the `Box` wrapping the Add button.                                    |
+| **ArrayFieldItemTemplate**   | `gridContainer`                   | Props passed to the outer `Grid` container for the item row.                          |
+|                              | `gridItem`                        | Props passed to the content `Grid` item.                                              |
+|                              | `outerBox`                        | Props passed to the outer `Box`.                                                      |
+|                              | `paper`                           | Props passed to the `Paper` elevation component.                                      |
+|                              | `innerBox`                        | Props passed to the inner `Box` holding the children.                                 |
+|                              | `toolbarGrid`                     | Props passed to the `Grid` holding the toolbar buttons.                               |
+| **CheckboxesWidget**         | `formGroup`                       | Props passed to the `FormGroup` container.                                            |
+|                              | `checkbox`                        | Props passed to individual `Checkbox` components.                                     |
+|                              | `formControlLabel`                | Props passed to the `FormControlLabel` components wrapping each checkbox.             |
+| **CheckboxWidget**           | `checkbox`                        | Props passed to the single `Checkbox` component.                                      |
+|                              | `formControlLabel`                | Props passed to the `FormControlLabel` component wrapping the checkbox.               |
+| **RadioWidget**              | `radioGroup`                      | Props passed to the `RadioGroup` component.                                           |
+|                              | `radio`                           | Props passed to the individual `Radio` components.                                    |
+|                              | `formControlLabel`                | Props passed to the `FormControlLabel` components wrapping each radio.                |
+| **SelectWidget**             | `inputLabel`                      | Props passed to the native MUI `InputLabel` component.                                |
+|                              | `select`                          | Props passed to the native MUI `Select` component.                                    |
+| **ErrorList**                | `box`                             | Props passed to the inner `Box`.                                                      |
+|                              | `list`                            | Props passed to the `List` container.                                                 |
+|                              | `listItem`                        | Props passed to individual `ListItem` components wrapping each error.                 |
+|                              | `listItemIcon`                    | Props passed to the `ListItemIcon` next to each error.                                |
+|                              | `listItemText`                    | Props passed to the `ListItemText` displaying the error.                              |
+|                              | `paper`                           | Props passed to the outer `Paper` wrapper.                                            |
+|                              | `typography`                      | Props passed to the `Typography` displaying the "Errors" title.                       |
+| **FieldErrorTemplate**       | `list`                            | Props passed to the `List` container.                                                 |
+|                              | `listItem`                        | Props passed to individual `ListItem` components.                                     |
+|                              | `formHelperText`                  | Props passed to the `FormHelperText` displaying the error text.                       |
+| **FieldHelpTemplate**        | `formHelperText`                  | Props passed to the `FormHelperText` used for help text.                              |
+| **DescriptionField**         | `typography`                      | Props passed to the `Typography` component.                                           |
+| **TitleField**               | `box`                             | Props passed to the outer `Box` wrapper.                                              |
+|                              | `divider`                         | Props passed to the `Divider` element.                                                |
+|                              | `typography`                      | Props passed to the `Typography` component used for the title.                        |
+|                              | `gridContainer`                   | Props passed to `Grid` container when title has optional data controls.               |
+|                              | `gridItem`                        | Props passed to the `Grid` item containing the title.                                 |
+|                              | `optionalDataGridItem`            | Props passed to the `Grid` item containing the optional data control.                 |
+| **MultiSchemaFieldTemplate** | `box`                             | Props passed to the wrapper `Box`.                                                    |
+|                              | `formControl`                     | Props passed to the wrapper `FormControl`.                                            |
+| **SubmitButton**             | `box`                             | Props passed to the `Box` wrapping the submit button.                                 |
+|                              | `button`                          | Props passed to the `Button` element.                                                 |
+| **WrapIfAdditionalTemplate** | `gridContainer`                   | Props passed to the outer `Grid` container.                                           |
+|                              | `keyGridItem`                     | Props passed to the `Grid` item containing the key `TextField`.                       |
+|                              | `childrenGridItem`                | Props passed to the `Grid` item containing the field children.                        |
+|                              | `removeButtonGridItem`            | Props passed to the `Grid` item containing the remove button.                         |

--- a/packages/docs/docs/api-reference/themes/mui/uiSchema.md
+++ b/packages/docs/docs/api-reference/themes/mui/uiSchema.md
@@ -56,7 +56,7 @@ The `@rjsf/mui` package looks for a `mui` key inside the `ui:options` of your `u
     "ui:options": {
       "mui": {
         "rjsfSlotProps": {
-          "paper": {
+          "arrayPaper": {
             "elevation": 10
           }
         }
@@ -79,7 +79,7 @@ If you wish to specifically target the _individual array items_ handled by `Arra
       "ui:options": {
         "mui": {
           "rjsfSlotProps": {
-            "gridContainer": {
+            "arrayItemGridContainer": {
               "spacing": 2
             }
           }
@@ -97,23 +97,23 @@ Different templates and widgets expose different `rjsfSlotProps` targets based o
 | RJSF Component               | `rjsfSlotProps` targets available | Description                                                                           |
 | ---------------------------- | --------------------------------- | ------------------------------------------------------------------------------------- |
 | **BaseInputTemplate**        | _(uses native `slotProps`)_       | Uses MUI's `slotProps.htmlInput`, `slotProps.input`, `slotProps.inputLabel` directly. |
-| **FieldTemplate**            | `formControl`                     | Props passed to the outer `FormControl` wrapper.                                      |
-|                              | `typography`                      | Props passed to the `Typography` component used for the description.                  |
-| **ObjectFieldTemplate**      | `gridContainer`                   | Props passed to the outer `Grid` container.                                           |
-|                              | `gridItem`                        | Props passed to each property's `Grid` item.                                          |
-|                              | `addButtonGridContainer`          | Props passed to the `Grid` container adjacent to the Add button.                      |
-|                              | `addButtonGridItem`               | Props passed to the `Grid` item wrapping the Add button.                              |
-| **ArrayFieldTemplate**       | `box`                             | Props passed to the inner `Box` container holding the array items.                    |
-|                              | `paper`                           | Props passed to the outer `Paper` wrapper.                                            |
-|                              | `addButtonGridContainer`          | Props passed to the `Grid` container adjacent to the Add button.                      |
-|                              | `addButtonGridItem`               | Props passed to the `Grid` item wrapping the Add button.                              |
-|                              | `addButtonBox`                    | Props passed to the `Box` wrapping the Add button.                                    |
-| **ArrayFieldItemTemplate**   | `gridContainer`                   | Props passed to the outer `Grid` container for the item row.                          |
-|                              | `gridItem`                        | Props passed to the content `Grid` item.                                              |
-|                              | `outerBox`                        | Props passed to the outer `Box`.                                                      |
-|                              | `paper`                           | Props passed to the `Paper` elevation component.                                      |
-|                              | `innerBox`                        | Props passed to the inner `Box` holding the children.                                 |
-|                              | `toolbarGrid`                     | Props passed to the `Grid` holding the toolbar buttons.                               |
+| **FieldTemplate**            | `fieldFormControl`                | Props passed to the outer `FormControl` wrapper.                                      |
+|                              | `fieldTypography`                 | Props passed to the `Typography` component used for the description.                  |
+| **ObjectFieldTemplate**      | `objectGridContainer`             | Props passed to the outer `Grid` container.                                           |
+|                              | `objectGridItem`                  | Props passed to each property's `Grid` item.                                          |
+|                              | `objectAddButtonGridContainer`    | Props passed to the `Grid` container adjacent to the Add button.                      |
+|                              | `objectAddButtonGridItem`         | Props passed to the `Grid` item wrapping the Add button.                              |
+| **ArrayFieldTemplate**       | `arrayBox`                        | Props passed to the inner `Box` container holding the array items.                    |
+|                              | `arrayPaper`                      | Props passed to the outer `Paper` wrapper.                                            |
+|                              | `arrayAddButtonGridContainer`     | Props passed to the `Grid` container adjacent to the Add button.                      |
+|                              | `arrayAddButtonGridItem`          | Props passed to the `Grid` item wrapping the Add button.                              |
+|                              | `arrayAddButtonBox`               | Props passed to the `Box` wrapping the Add button.                                    |
+| **ArrayFieldItemTemplate**   | `arrayItemGridContainer`          | Props passed to the outer `Grid` container for the item row.                          |
+|                              | `arrayItemGridItem`               | Props passed to the content `Grid` item.                                              |
+|                              | `arrayItemOuterBox`               | Props passed to the outer `Box`.                                                      |
+|                              | `arrayItemPaper`                  | Props passed to the `Paper` elevation component.                                      |
+|                              | `arrayItemInnerBox`               | Props passed to the inner `Box` holding the children.                                 |
+|                              | `arrayItemToolbarGrid`            | Props passed to the `Grid` holding the toolbar buttons.                               |
 | **CheckboxesWidget**         | `formGroup`                       | Props passed to the `FormGroup` container.                                            |
 |                              | `checkbox`                        | Props passed to individual `Checkbox` components.                                     |
 |                              | `formControlLabel`                | Props passed to the `FormControlLabel` components wrapping each checkbox.             |
@@ -124,29 +124,29 @@ Different templates and widgets expose different `rjsfSlotProps` targets based o
 |                              | `formControlLabel`                | Props passed to the `FormControlLabel` components wrapping each radio.                |
 | **SelectWidget**             | `inputLabel`                      | Props passed to the native MUI `InputLabel` component.                                |
 |                              | `select`                          | Props passed to the native MUI `Select` component.                                    |
-| **ErrorList**                | `box`                             | Props passed to the inner `Box`.                                                      |
-|                              | `list`                            | Props passed to the `List` container.                                                 |
-|                              | `listItem`                        | Props passed to individual `ListItem` components wrapping each error.                 |
-|                              | `listItemIcon`                    | Props passed to the `ListItemIcon` next to each error.                                |
-|                              | `listItemText`                    | Props passed to the `ListItemText` displaying the error.                              |
-|                              | `paper`                           | Props passed to the outer `Paper` wrapper.                                            |
-|                              | `typography`                      | Props passed to the `Typography` displaying the "Errors" title.                       |
-| **FieldErrorTemplate**       | `list`                            | Props passed to the `List` container.                                                 |
-|                              | `listItem`                        | Props passed to individual `ListItem` components.                                     |
-|                              | `formHelperText`                  | Props passed to the `FormHelperText` displaying the error text.                       |
-| **FieldHelpTemplate**        | `formHelperText`                  | Props passed to the `FormHelperText` used for help text.                              |
-| **DescriptionField**         | `typography`                      | Props passed to the `Typography` component.                                           |
-| **TitleField**               | `box`                             | Props passed to the outer `Box` wrapper.                                              |
-|                              | `divider`                         | Props passed to the `Divider` element.                                                |
-|                              | `typography`                      | Props passed to the `Typography` component used for the title.                        |
-|                              | `gridContainer`                   | Props passed to `Grid` container when title has optional data controls.               |
-|                              | `gridItem`                        | Props passed to the `Grid` item containing the title.                                 |
-|                              | `optionalDataGridItem`            | Props passed to the `Grid` item containing the optional data control.                 |
-| **MultiSchemaFieldTemplate** | `box`                             | Props passed to the wrapper `Box`.                                                    |
-|                              | `formControl`                     | Props passed to the wrapper `FormControl`.                                            |
-| **SubmitButton**             | `box`                             | Props passed to the `Box` wrapping the submit button.                                 |
-|                              | `button`                          | Props passed to the `Button` element.                                                 |
-| **WrapIfAdditionalTemplate** | `gridContainer`                   | Props passed to the outer `Grid` container.                                           |
-|                              | `keyGridItem`                     | Props passed to the `Grid` item containing the key `TextField`.                       |
-|                              | `childrenGridItem`                | Props passed to the `Grid` item containing the field children.                        |
-|                              | `removeButtonGridItem`            | Props passed to the `Grid` item containing the remove button.                         |
+| **ErrorList**                | `errorBox`                        | Props passed to the inner `Box`.                                                      |
+|                              | `errorList`                       | Props passed to the `List` container.                                                 |
+|                              | `errorListItem`                   | Props passed to individual `ListItem` components wrapping each error.                 |
+|                              | `errorListItemIcon`               | Props passed to the `ListItemIcon` next to each error.                                |
+|                              | `errorListItemText`               | Props passed to the `ListItemText` displaying the error.                              |
+|                              | `errorPaper`                      | Props passed to the outer `Paper` wrapper.                                            |
+|                              | `errorTypography`                 | Props passed to the `Typography` displaying the "Errors" title.                       |
+| **FieldErrorTemplate**       | `fieldErrorList`                  | Props passed to the `List` container.                                                 |
+|                              | `fieldErrorListItem`              | Props passed to individual `ListItem` components.                                     |
+|                              | `fieldErrorFormHelperText`        | Props passed to the `FormHelperText` displaying the error text.                       |
+| **FieldHelpTemplate**        | `helpFormHelperText`              | Props passed to the `FormHelperText` used for help text.                              |
+| **DescriptionField**         | `descTypography`                  | Props passed to the `Typography` component.                                           |
+| **TitleField**               | `titleBox`                        | Props passed to the outer `Box` wrapper.                                              |
+|                              | `titleDivider`                    | Props passed to the `Divider` element.                                                |
+|                              | `titleTypography`                 | Props passed to the `Typography` component used for the title.                        |
+|                              | `titleGridContainer`              | Props passed to `Grid` container when title has optional data controls.               |
+|                              | `titleGridItem`                   | Props passed to the `Grid` item containing the title.                                 |
+|                              | `titleOptionalDataGridItem`       | Props passed to the `Grid` item containing the optional data control.                 |
+| **MultiSchemaFieldTemplate** | `multiBox`                        | Props passed to the wrapper `Box`.                                                    |
+|                              | `multiFormControl`                | Props passed to the wrapper `FormControl`.                                            |
+| **SubmitButton**             | `submitBox`                       | Props passed to the `Box` wrapping the submit button.                                 |
+|                              | `submitButton`                    | Props passed to the `Button` element.                                                 |
+| **WrapIfAdditionalTemplate** | `wrapGridContainer`               | Props passed to the outer `Grid` container.                                           |
+|                              | `wrapKeyGridItem`                 | Props passed to the `Grid` item containing the key `TextField`.                       |
+|                              | `wrapChildrenGridItem`            | Props passed to the `Grid` item containing the field children.                        |
+|                              | `wrapRemoveButtonGridItem`        | Props passed to the `Grid` item containing the remove button.                         |

--- a/packages/docs/docs/api-reference/themes/mui/uiSchema.md
+++ b/packages/docs/docs/api-reference/themes/mui/uiSchema.md
@@ -45,6 +45,49 @@ Top-level standard MUI props are applied to the primary component. To pass custo
 }
 ```
 
+## Customizing Templates (e.g. Object and Array wrappers)
+
+MUI theme customizations are natively passed down into both your standard fields and their wrapping structural templates (like `ArrayFieldTemplate` or `ObjectFieldTemplate`). Because RJSF funnels the `uiSchema` dynamically into these templates, you can manipulate structural properties effortlessly.
+
+For example, to customize the structural rendering of an array template—such as raising the elevation of the Material UI `<Paper>` container—you place the `mui` property at the field's `ui:options`:
+
+```json
+{
+  "myArrayField": {
+    "ui:options": {
+      "mui": {
+        "slotProps": {
+          "paper": {
+            "elevation": 10
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+If you wish to specifically target the _individual array items_ handled by `ArrayFieldItemTemplate` instead of the whole array container, you nest these overrides by targeting the `items` inside the schema:
+
+```json
+{
+  "myArrayField": {
+    "items": {
+      "ui:options": {
+        "mui": {
+          "slotProps": {
+            "grid": {
+              "container": true,
+              "spacing": 2
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ### Components and their `slotProps` targets
 
 Different templates and widgets expose different `slotProps` targets based on their underlying MUI composition.

--- a/packages/docs/docs/api-reference/themes/mui/uiSchema.md
+++ b/packages/docs/docs/api-reference/themes/mui/uiSchema.md
@@ -47,7 +47,9 @@ Top-level standard MUI props are applied to the primary component. To pass custo
 
 ## Customizing Templates (e.g. Object and Array wrappers)
 
-MUI theme customizations are natively passed down into both your standard fields and their wrapping structural templates (like `ArrayFieldTemplate` or `ObjectFieldTemplate`). Because RJSF funnels the `uiSchema` dynamically into these templates, you can manipulate structural properties effortlessly.
+MUI theme customizations are natively passed down into both your standard fields and their wrapping structural templates (like `ArrayFieldTemplate` or `ObjectFieldTemplate`) (see [table below](#components-and-their-slotprops-targets)).
+
+Because RJSF funnels the `uiSchema` dynamically into these templates, you can manipulate structural properties effortlessly.
 
 For example, to customize the structural rendering of an array template—such as raising the elevation of the Material UI `<Paper>` container—you place the `mui` property at the field's `ui:options`:
 

--- a/packages/docs/docs/api-reference/themes/mui/uiSchema.md
+++ b/packages/docs/docs/api-reference/themes/mui/uiSchema.md
@@ -1,0 +1,85 @@
+# MUI Customization
+
+You can customize the underlying Material UI (MUI) components used by `@rjsf/mui` by passing props directly through the `uiSchema`. This is extremely useful for applying simple customizations (like adding an `endAdornment` to an input field, tweaking margins, or changing variants) without having to build a completely custom Widget or Template.
+
+## Basic Usage
+
+The `@rjsf/mui` package looks for an `mui` key inside the `ui:options` of your `uiSchema`. Any top-level properties defined here will be applied to the primary MUI wrapper component for that field (e.g. `TextField` for inputs, `FormGroup` for checkboxes, `Paper`/`Grid` for object/array wrappers).
+
+```json
+{
+  "myField": {
+    "ui:options": {
+      "mui": {
+        "variant": "filled",
+        "fullWidth": false,
+        "sx": {
+          "backgroundColor": "background.paper",
+          "padding": 2
+        }
+      }
+    }
+  }
+}
+```
+
+## `slotProps` (Targeting nested components)
+
+Many RJSF templates and widgets are composed of several nested MUI components. To prevent unintended property "leakage" (e.g., passing a `TextField` prop onto an outer `FormControl`), `@rjsf/mui` uses a **Root-plus-Slot** pattern.
+
+Top-level standard MUI props are applied to the primary component. To pass custom props to specific nested components, use the `slotProps` key within the `mui` object.
+
+```json
+{
+  "myPriceField": {
+    "ui:options": {
+      "mui": {
+        "slotProps": {
+          "input": {
+            "startAdornment": "$"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Components and their `slotProps` targets
+
+Different templates and widgets expose different `slotProps` targets based on their underlying MUI composition.
+
+| RJSF Component               | `slotProps` targets available | Description                                                                          |
+| ---------------------------- | ----------------------------- | ------------------------------------------------------------------------------------ |
+| **BaseInputTemplate**        | `htmlInput`                   | Props passed to the base native HTML `<input>` or `<textarea>` element.              |
+|                              | `input`                       | Props passed to the MUI `Input` element, useful for `endAdornment`/`startAdornment`. |
+| **FieldTemplate**            | `formControl`                 | Props passed to the outer `FormControl` wrapper.                                     |
+|                              | `typography`                  | Props passed to the `Typography` component used for the description.                 |
+| **ObjectFieldTemplate**      | `grid`                        | Props passed to the various outer and inner `Grid` container elements.               |
+| **ArrayFieldTemplate**       | `box`                         | Props passed to the inner `Box` container holding the array items.                   |
+|                              | `paper`                       | Props passed to the outer `Paper` wrapper.                                           |
+| **ArrayFieldItemTemplate**   | `grid`                        | Props passed to the `Grid` container wrapping the individual array item row.         |
+| **CheckboxesWidget**         | `checkbox`                    | Props passed to individual `Checkbox` components.                                    |
+|                              | `formControlLabel`            | Props passed to the `FormControlLabel` components wrapping each checkbox.            |
+| **CheckboxWidget**           | `checkbox`                    | Props passed to the single `Checkbox` component.                                     |
+|                              | `formControlLabel`            | Props passed to the `FormControlLabel` component wrapping the checkbox.              |
+| **RadioWidget**              | `radio`                       | Props passed to the individual `Radio` components.                                   |
+|                              | `formControlLabel`            | Props passed to the `FormControlLabel` components wrapping each radio.               |
+| **SelectWidget**             | `inputLabel`                  | Props passed to the native MUI `InputLabel` component.                               |
+|                              | `select`                      | Props passed to the native MUI `Select` component.                                   |
+| **ErrorList**                | `box`                         | Props passed to the inner `Box`.                                                     |
+|                              | `list`                        | Props passed to the `List` container.                                                |
+|                              | `listItem`                    | Props passed to individual `ListItem` components wrapping each error.                |
+|                              | `listItemIcon`                | Props passed to the `ListItemIcon` next to each error.                               |
+|                              | `paper`                       | Props passed to the outer `Paper` wrapper.                                           |
+|                              | `typography`                  | Props passed to the `Typography` displaying the "Errors" title.                      |
+| **FieldErrorTemplate**       | `list`                        | Props passed to the `List` container.                                                |
+|                              | `listItem`                    | Props passed to individual `ListItem` components.                                    |
+|                              | `formHelperText`              | Props passed to the `FormHelperText` displaying the error text.                      |
+| **TitleField**               | `typography`                  | Props passed to the `Typography` component used for the title.                       |
+|                              | `grid`                        | Props passed to `Grid` structures when rendering titles with optional data controls. |
+| **MultiSchemaFieldTemplate** | `box`                         | Props passed to the wrapper `Box`.                                                   |
+|                              | `formControl`                 | Props passed to the wrapper `FormControl`.                                           |
+| **SubmitButton**             | `box`                         | Props passed to the `Box` wrapping the submit button.                                |
+
+_(Note: Simple text components like `FieldHelpTemplate` and `DescriptionField` do not use `slotProps`. Top-level `mui` props are passed directly to their main `FormHelperText` or `Typography` elements.)_

--- a/packages/mui/README.md
+++ b/packages/mui/README.md
@@ -104,6 +104,45 @@ import { Theme } from '@rjsf/mui';
 const Form = withTheme(Theme);
 ```
 
+### Customizing MUI-specific props
+
+You can pass MUI-specific props (like `sx`, `slotProps`, `variant`, etc.) directly to any MUI component rendered by a Template or Widget. This can be done globally via `formContext` or specifically for a field via `ui:options` in the `uiSchema`.
+
+#### Via `uiSchema`
+
+```json
+"myField": {
+  "ui:options": {
+    "mui": {
+      "variant": "filled",
+      "sx": {
+        "backgroundColor": "background.paper"
+      },
+      "slotProps": {
+        "input": {
+          "endAdornment": "kg"
+        }
+      }
+    }
+  }
+}
+```
+
+#### Via `formContext`
+
+```json
+const formContext = {
+  mui: {
+    variant: "outlined",
+    fullWidth: true
+  }
+};
+
+<Form schema={schema} formContext={formContext} />
+```
+
+Local `uiSchema` props will override global `formContext` props.
+
 <!-- ROADMAP -->
 
 ## Roadmap

--- a/packages/mui/README.md
+++ b/packages/mui/README.md
@@ -106,7 +106,7 @@ const Form = withTheme(Theme);
 
 ### Customizing MUI-specific props
 
-You can pass MUI-specific props (like `sx`, `slotProps`, `variant`, etc.) directly to any MUI component rendered by a Template or Widget via `ui:options` in the `uiSchema`.
+You can pass MUI-specific props (like `sx`, `rjsfSlotProps`, `variant`, etc.) directly to any MUI component rendered by a Template or Widget via `ui:options` in the `uiSchema`.
 
 ```json
 "myField": {
@@ -116,7 +116,7 @@ You can pass MUI-specific props (like `sx`, `slotProps`, `variant`, etc.) direct
       "sx": {
         "backgroundColor": "background.paper"
       },
-      "slotProps": {
+      "rjsfSlotProps": {
         "input": {
           "endAdornment": "kg"
         }
@@ -126,7 +126,7 @@ You can pass MUI-specific props (like `sx`, `slotProps`, `variant`, etc.) direct
 }
 ```
 
-For more details on available properties and `slotProps` targets, see the [Material UI Customization Documentation](https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/themes/mui/uiSchema/).
+For more details on available properties and `rjsfSlotProps` targets, see the [Material UI Customization Documentation](https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/themes/mui/uiSchema/).
 
 
 <!-- ROADMAP -->

--- a/packages/mui/README.md
+++ b/packages/mui/README.md
@@ -106,9 +106,7 @@ const Form = withTheme(Theme);
 
 ### Customizing MUI-specific props
 
-You can pass MUI-specific props (like `sx`, `slotProps`, `variant`, etc.) directly to any MUI component rendered by a Template or Widget. This can be done globally via `formContext` or specifically for a field via `ui:options` in the `uiSchema`.
-
-#### Via `uiSchema`
+You can pass MUI-specific props (like `sx`, `slotProps`, `variant`, etc.) directly to any MUI component rendered by a Template or Widget via `ui:options` in the `uiSchema`.
 
 ```json
 "myField": {
@@ -128,20 +126,8 @@ You can pass MUI-specific props (like `sx`, `slotProps`, `variant`, etc.) direct
 }
 ```
 
-#### Via `formContext`
+For more details on available properties and `slotProps` targets, see the [Material UI Customization Documentation](https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/themes/mui/uiSchema/).
 
-```json
-const formContext = {
-  mui: {
-    variant: "outlined",
-    fullWidth: true
-  }
-};
-
-<Form schema={schema} formContext={formContext} />
-```
-
-Local `uiSchema` props will override global `formContext` props.
 
 <!-- ROADMAP -->
 

--- a/packages/mui/src/AddButton/AddButton.tsx
+++ b/packages/mui/src/AddButton/AddButton.tsx
@@ -1,6 +1,14 @@
 import AddIcon from '@mui/icons-material/Add';
-import IconButton from '@mui/material/IconButton';
-import { FormContextType, IconButtonProps, RJSFSchema, StrictRJSFSchema, TranslatableString } from '@rjsf/utils';
+import IconButton, { IconButtonProps as MuiIconButtonProps } from '@mui/material/IconButton';
+import {
+  FormContextType,
+  getUiOptions,
+  IconButtonProps,
+  RJSFSchema,
+  StrictRJSFSchema,
+  TranslatableString,
+} from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `AddButton` renders a button that represent the `Add` action on a form
  */
@@ -10,8 +18,20 @@ export default function AddButton<T = any, S extends StrictRJSFSchema = RJSFSche
   ...props
 }: IconButtonProps<T, S, F>) {
   const { translateString } = registry;
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options: uiOptions,
+  });
+
   return (
-    <IconButton title={translateString(TranslatableString.AddItemButton)} {...props} color='primary'>
+    <IconButton
+      title={translateString(TranslatableString.AddItemButton)}
+      {...props}
+      color='primary'
+      {...(muiProps as MuiIconButtonProps)}
+    >
       <AddIcon />
     </IconButton>
   );

--- a/packages/mui/src/AddButton/AddButton.tsx
+++ b/packages/mui/src/AddButton/AddButton.tsx
@@ -19,7 +19,14 @@ export default function AddButton<T = any, S extends StrictRJSFSchema = RJSFSche
 }: IconButtonProps<T, S, F>) {
   const { translateString } = registry;
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F, MuiIconButtonProps>(uiOptions);
+  const muiProps = getMuiProps<T, S, F, MuiIconButtonProps>(uiOptions, [
+    'color',
+    'disableFocusRipple',
+    'disableRipple',
+    'edge',
+    'size',
+    'sx',
+  ]);
 
   return (
     <IconButton

--- a/packages/mui/src/AddButton/AddButton.tsx
+++ b/packages/mui/src/AddButton/AddButton.tsx
@@ -19,11 +19,7 @@ export default function AddButton<T = any, S extends StrictRJSFSchema = RJSFSche
 }: IconButtonProps<T, S, F>) {
   const { translateString } = registry;
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options: uiOptions,
-  });
+  const muiProps = getMuiProps<T, S, F, MuiIconButtonProps>(uiOptions);
 
   return (
     <IconButton

--- a/packages/mui/src/AddButton/AddButton.tsx
+++ b/packages/mui/src/AddButton/AddButton.tsx
@@ -29,12 +29,7 @@ export default function AddButton<T = any, S extends StrictRJSFSchema = RJSFSche
   ]);
 
   return (
-    <IconButton
-      title={translateString(TranslatableString.AddItemButton)}
-      {...props}
-      color='primary'
-      {...(muiProps as MuiIconButtonProps)}
-    >
+    <IconButton title={translateString(TranslatableString.AddItemButton)} {...props} color='primary' {...muiProps}>
       <AddIcon />
     </IconButton>
   );

--- a/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -1,7 +1,7 @@
 import { CSSProperties } from 'react';
-import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid';
-import Paper from '@mui/material/Paper';
+import Box, { BoxProps } from '@mui/material/Box';
+import Grid, { GridProps } from '@mui/material/Grid';
+import Paper, { PaperProps } from '@mui/material/Paper';
 import {
   ArrayFieldItemTemplateProps,
   FormContextType,
@@ -10,6 +10,7 @@ import {
   RJSFSchema,
   StrictRJSFSchema,
 } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `ArrayFieldItemTemplate` component is the template used to render an items of an array.
  *
@@ -34,17 +35,31 @@ export default function ArrayFieldItemTemplate<
     fontWeight: 'bold',
     minWidth: 0,
   };
+
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options: uiOptions,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   return (
-    <Grid container={true} alignItems='center'>
-      <Grid size={{ xs: 8, sm: 9, md: 10, lg: 11, xl: 11.25 }} style={{ overflow: 'auto' }}>
-        <Box mb={2}>
-          <Paper elevation={2}>
-            <Box p={2}>{children}</Box>
+    <Grid container={true} alignItems='center' {...(otherMuiProps as GridProps)} {...(muiSlotProps?.grid as GridProps)}>
+      <Grid
+        size={{ xs: 8, sm: 9, md: 10, lg: 11, xl: 11.25 }}
+        style={{ overflow: 'auto' }}
+        {...(muiSlotProps?.grid as GridProps)}
+      >
+        <Box mb={2} {...(muiSlotProps?.box as BoxProps)}>
+          <Paper elevation={2} {...(muiSlotProps?.paper as PaperProps)}>
+            <Box p={2} {...(muiSlotProps?.box as BoxProps)}>
+              {children}
+            </Box>
           </Paper>
         </Box>
       </Grid>
       {hasToolbar && (
-        <Grid sx={{ mt: hasDescription ? -5 : -1.5 }}>
+        <Grid sx={{ mt: hasDescription ? -5 : -1.5 }} {...(muiSlotProps?.grid as GridProps)}>
           <ArrayFieldItemButtonsTemplate {...buttonsProps} style={btnStyle} />
         </Grid>
       )}

--- a/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -13,10 +13,10 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the ArrayFieldItemTemplate. */
+/** Properties available for the `rjsfSlotProps` target of the ArrayFieldItemTemplate. */
 export interface ArrayFieldItemTemplateMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the ArrayFieldItemTemplate. */
+  rjsfSlotProps?: {
     /** Props applied to the outermost `Grid` container. */
     gridContainer?: GridProps;
     /** Props applied to the `Grid` item wrapping the item's content. */
@@ -56,11 +56,10 @@ export default function ArrayFieldItemTemplate<
     minWidth: 0,
   };
 
-  const muiProps = getMuiProps<T, S, F, ArrayFieldItemTemplateMuiProps>(uiOptions);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps } = getMuiProps<T, S, F, ArrayFieldItemTemplateMuiProps>(uiOptions);
 
   return (
-    <Grid container={true} alignItems='center' {...otherMuiProps} {...muiSlotProps?.gridContainer}>
+    <Grid container={true} alignItems='center' {...muiSlotProps?.gridContainer}>
       <Grid size={{ xs: 8, sm: 9, md: 10, lg: 11, xl: 11.25 }} style={{ overflow: 'auto' }} {...muiSlotProps?.gridItem}>
         <Box mb={2} {...muiSlotProps?.outerBox}>
           <Paper elevation={2} {...muiSlotProps?.paper}>

--- a/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -36,11 +36,7 @@ export default function ArrayFieldItemTemplate<
     minWidth: 0,
   };
 
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options: uiOptions,
-  });
+  const muiProps = getMuiProps<T, S, F>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (

--- a/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -18,17 +18,17 @@ export interface ArrayFieldItemTemplateMuiProps extends GenericObjectType {
   /** RJSF-specific slot props for targeting child elements of the ArrayFieldItemTemplate. */
   rjsfSlotProps?: {
     /** Props applied to the outermost `Grid` container. */
-    gridContainer?: GridProps;
+    arrayItemGridContainer?: GridProps;
     /** Props applied to the `Grid` item wrapping the item's content. */
-    gridItem?: GridProps;
+    arrayItemGridItem?: GridProps;
     /** Props applied to the outer `Box` container. */
-    outerBox?: BoxProps;
+    arrayItemOuterBox?: BoxProps;
     /** Props applied to the `Paper` elevation component. */
-    paper?: PaperProps;
+    arrayItemPaper?: PaperProps;
     /** Props applied to the inner `Box` containing the actual children. */
-    innerBox?: BoxProps;
+    arrayItemInnerBox?: BoxProps;
     /** Props applied to the `Grid` containing the item's buttons. */
-    toolbarGrid?: GridProps;
+    arrayItemToolbarGrid?: GridProps;
   };
 }
 
@@ -59,18 +59,22 @@ export default function ArrayFieldItemTemplate<
   const { rjsfSlotProps: muiSlotProps } = getMuiProps<T, S, F, ArrayFieldItemTemplateMuiProps>(uiOptions);
 
   return (
-    <Grid container={true} alignItems='center' {...muiSlotProps?.gridContainer}>
-      <Grid size={{ xs: 8, sm: 9, md: 10, lg: 11, xl: 11.25 }} style={{ overflow: 'auto' }} {...muiSlotProps?.gridItem}>
-        <Box mb={2} {...muiSlotProps?.outerBox}>
-          <Paper elevation={2} {...muiSlotProps?.paper}>
-            <Box p={2} {...muiSlotProps?.innerBox}>
+    <Grid container={true} alignItems='center' {...muiSlotProps?.arrayItemGridContainer}>
+      <Grid
+        size={{ xs: 8, sm: 9, md: 10, lg: 11, xl: 11.25 }}
+        style={{ overflow: 'auto' }}
+        {...muiSlotProps?.arrayItemGridItem}
+      >
+        <Box mb={2} {...muiSlotProps?.arrayItemOuterBox}>
+          <Paper elevation={2} {...muiSlotProps?.arrayItemPaper}>
+            <Box p={2} {...muiSlotProps?.arrayItemInnerBox}>
               {children}
             </Box>
           </Paper>
         </Box>
       </Grid>
       {hasToolbar && (
-        <Grid sx={{ mt: hasDescription ? -5 : -1.5 }} {...muiSlotProps?.toolbarGrid}>
+        <Grid sx={{ mt: hasDescription ? -5 : -1.5 }} {...muiSlotProps?.arrayItemToolbarGrid}>
           <ArrayFieldItemButtonsTemplate {...buttonsProps} style={btnStyle} />
         </Grid>
       )}

--- a/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -9,8 +9,28 @@ import {
   getTemplate,
   RJSFSchema,
   StrictRJSFSchema,
+  GenericObjectType,
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the ArrayFieldItemTemplate. */
+export interface ArrayFieldItemTemplateMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the outermost `Grid` container. */
+    gridContainer?: GridProps;
+    /** Props applied to the `Grid` item wrapping the item's content. */
+    gridItem?: GridProps;
+    /** Props applied to the outer `Box` container. */
+    outerBox?: BoxProps;
+    /** Props applied to the `Paper` elevation component. */
+    paper?: PaperProps;
+    /** Props applied to the inner `Box` containing the actual children. */
+    innerBox?: BoxProps;
+    /** Props applied to the `Grid` containing the item's buttons. */
+    toolbarGrid?: GridProps;
+  };
+}
 
 /** The `ArrayFieldItemTemplate` component is the template used to render an items of an array.
  *
@@ -36,26 +56,22 @@ export default function ArrayFieldItemTemplate<
     minWidth: 0,
   };
 
-  const muiProps = getMuiProps<T, S, F>(uiOptions);
+  const muiProps = getMuiProps<T, S, F, ArrayFieldItemTemplateMuiProps>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
-    <Grid container={true} alignItems='center' {...(otherMuiProps as GridProps)} {...(muiSlotProps?.grid as GridProps)}>
-      <Grid
-        size={{ xs: 8, sm: 9, md: 10, lg: 11, xl: 11.25 }}
-        style={{ overflow: 'auto' }}
-        {...(muiSlotProps?.grid as GridProps)}
-      >
-        <Box mb={2} {...(muiSlotProps?.box as BoxProps)}>
-          <Paper elevation={2} {...(muiSlotProps?.paper as PaperProps)}>
-            <Box p={2} {...(muiSlotProps?.box as BoxProps)}>
+    <Grid container={true} alignItems='center' {...otherMuiProps} {...muiSlotProps?.gridContainer}>
+      <Grid size={{ xs: 8, sm: 9, md: 10, lg: 11, xl: 11.25 }} style={{ overflow: 'auto' }} {...muiSlotProps?.gridItem}>
+        <Box mb={2} {...muiSlotProps?.outerBox}>
+          <Paper elevation={2} {...muiSlotProps?.paper}>
+            <Box p={2} {...muiSlotProps?.innerBox}>
               {children}
             </Box>
           </Paper>
         </Box>
       </Grid>
       {hasToolbar && (
-        <Grid sx={{ mt: hasDescription ? -5 : -1.5 }} {...(muiSlotProps?.grid as GridProps)}>
+        <Grid sx={{ mt: hasDescription ? -5 : -1.5 }} {...muiSlotProps?.toolbarGrid}>
           <ArrayFieldItemButtonsTemplate {...buttonsProps} style={btnStyle} />
         </Grid>
       )}

--- a/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -1,6 +1,6 @@
-import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid';
-import Paper from '@mui/material/Paper';
+import Box, { BoxProps } from '@mui/material/Box';
+import Grid, { GridProps } from '@mui/material/Grid';
+import Paper, { PaperProps } from '@mui/material/Paper';
 import {
   getTemplate,
   getUiOptions,
@@ -10,6 +10,7 @@ import {
   StrictRJSFSchema,
   buttonId,
 } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `ArrayFieldTemplate` component is the template used to render all items in an array.
  *
@@ -50,9 +51,17 @@ export default function ArrayFieldTemplate<
   const {
     ButtonTemplates: { AddButton },
   } = registry.templates;
+
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options: uiOptions,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   return (
-    <Paper elevation={2}>
-      <Box p={2}>
+    <Paper elevation={2} {...(otherMuiProps as PaperProps)} {...(muiSlotProps?.paper as PaperProps)}>
+      <Box p={2} {...(muiSlotProps?.box as BoxProps)}>
         <ArrayFieldTitleTemplate
           fieldPathId={fieldPathId}
           title={uiOptions.title || title}
@@ -72,9 +81,9 @@ export default function ArrayFieldTemplate<
         {!showOptionalDataControlInTitle ? optionalDataControl : undefined}
         {items}
         {canAdd && (
-          <Grid container justifyContent='flex-end'>
-            <Grid>
-              <Box mt={2}>
+          <Grid container justifyContent='flex-end' {...(muiSlotProps?.grid as GridProps)}>
+            <Grid {...(muiSlotProps?.grid as GridProps)}>
+              <Box mt={2} {...(muiSlotProps?.box as BoxProps)}>
                 <AddButton
                   id={buttonId(fieldPathId, 'add')}
                   className='rjsf-array-item-add'

--- a/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -52,11 +52,7 @@ export default function ArrayFieldTemplate<
     ButtonTemplates: { AddButton },
   } = registry.templates;
 
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options: uiOptions,
-  });
+  const muiProps = getMuiProps<T, S, F>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (

--- a/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -9,8 +9,26 @@ import {
   RJSFSchema,
   StrictRJSFSchema,
   buttonId,
+  GenericObjectType,
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the ArrayFieldTemplate. */
+export interface ArrayFieldTemplateMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the wrapper `Paper` material. */
+    paper?: PaperProps;
+    /** Props applied to the primary `Box` container. */
+    box?: BoxProps;
+    /** Props applied to the wrapper `Grid` container next to the Add Button. */
+    addButtonGridContainer?: GridProps;
+    /** Props applied to the `Grid` item containing the Add Button. */
+    addButtonGridItem?: GridProps;
+    /** Props applied to the `Box` containing the Add Button. */
+    addButtonBox?: BoxProps;
+  };
+}
 
 /** The `ArrayFieldTemplate` component is the template used to render all items in an array.
  *
@@ -52,12 +70,12 @@ export default function ArrayFieldTemplate<
     ButtonTemplates: { AddButton },
   } = registry.templates;
 
-  const muiProps = getMuiProps<T, S, F>(uiOptions);
+  const muiProps = getMuiProps<T, S, F, ArrayFieldTemplateMuiProps>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
-    <Paper elevation={2} {...(otherMuiProps as PaperProps)} {...(muiSlotProps?.paper as PaperProps)}>
-      <Box p={2} {...(muiSlotProps?.box as BoxProps)}>
+    <Paper elevation={2} {...otherMuiProps} {...muiSlotProps?.paper}>
+      <Box p={2} {...muiSlotProps?.box}>
         <ArrayFieldTitleTemplate
           fieldPathId={fieldPathId}
           title={uiOptions.title || title}
@@ -77,9 +95,9 @@ export default function ArrayFieldTemplate<
         {!showOptionalDataControlInTitle ? optionalDataControl : undefined}
         {items}
         {canAdd && (
-          <Grid container justifyContent='flex-end' {...(muiSlotProps?.grid as GridProps)}>
-            <Grid {...(muiSlotProps?.grid as GridProps)}>
-              <Box mt={2} {...(muiSlotProps?.box as BoxProps)}>
+          <Grid container justifyContent='flex-end' {...muiSlotProps?.addButtonGridContainer}>
+            <Grid {...muiSlotProps?.addButtonGridItem}>
+              <Box mt={2} {...muiSlotProps?.addButtonBox}>
                 <AddButton
                   id={buttonId(fieldPathId, 'add')}
                   className='rjsf-array-item-add'

--- a/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -18,15 +18,15 @@ export interface ArrayFieldTemplateMuiProps extends GenericObjectType {
   /** RJSF-specific slot props for targeting child elements of the ArrayFieldTemplate. */
   rjsfSlotProps?: {
     /** Props applied to the wrapper `Paper` material. */
-    paper?: PaperProps;
+    arrayPaper?: PaperProps;
     /** Props applied to the primary `Box` container. */
-    box?: BoxProps;
+    arrayBox?: BoxProps;
     /** Props applied to the wrapper `Grid` container next to the Add Button. */
-    addButtonGridContainer?: GridProps;
+    arrayAddButtonGridContainer?: GridProps;
     /** Props applied to the `Grid` item containing the Add Button. */
-    addButtonGridItem?: GridProps;
+    arrayAddButtonGridItem?: GridProps;
     /** Props applied to the `Box` containing the Add Button. */
-    addButtonBox?: BoxProps;
+    arrayAddButtonBox?: BoxProps;
   };
 }
 
@@ -73,8 +73,8 @@ export default function ArrayFieldTemplate<
   const { rjsfSlotProps: muiSlotProps } = getMuiProps<T, S, F, ArrayFieldTemplateMuiProps>(uiOptions);
 
   return (
-    <Paper elevation={2} {...muiSlotProps?.paper}>
-      <Box p={2} {...muiSlotProps?.box}>
+    <Paper elevation={2} {...muiSlotProps?.arrayPaper}>
+      <Box p={2} {...muiSlotProps?.arrayBox}>
         <ArrayFieldTitleTemplate
           fieldPathId={fieldPathId}
           title={uiOptions.title || title}
@@ -94,9 +94,9 @@ export default function ArrayFieldTemplate<
         {!showOptionalDataControlInTitle ? optionalDataControl : undefined}
         {items}
         {canAdd && (
-          <Grid container justifyContent='flex-end' {...muiSlotProps?.addButtonGridContainer}>
-            <Grid {...muiSlotProps?.addButtonGridItem}>
-              <Box mt={2} {...muiSlotProps?.addButtonBox}>
+          <Grid container justifyContent='flex-end' {...muiSlotProps?.arrayAddButtonGridContainer}>
+            <Grid {...muiSlotProps?.arrayAddButtonGridItem}>
+              <Box mt={2} {...muiSlotProps?.arrayAddButtonBox}>
                 <AddButton
                   id={buttonId(fieldPathId, 'add')}
                   className='rjsf-array-item-add'

--- a/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -13,10 +13,10 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the ArrayFieldTemplate. */
+/** Properties available for the `rjsfSlotProps` target of the ArrayFieldTemplate. */
 export interface ArrayFieldTemplateMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the ArrayFieldTemplate. */
+  rjsfSlotProps?: {
     /** Props applied to the wrapper `Paper` material. */
     paper?: PaperProps;
     /** Props applied to the primary `Box` container. */
@@ -70,11 +70,10 @@ export default function ArrayFieldTemplate<
     ButtonTemplates: { AddButton },
   } = registry.templates;
 
-  const muiProps = getMuiProps<T, S, F, ArrayFieldTemplateMuiProps>(uiOptions);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps } = getMuiProps<T, S, F, ArrayFieldTemplateMuiProps>(uiOptions);
 
   return (
-    <Paper elevation={2} {...otherMuiProps} {...muiSlotProps?.paper}>
+    <Paper elevation={2} {...muiSlotProps?.paper}>
       <Box p={2} {...muiSlotProps?.box}>
         <ArrayFieldTitleTemplate
           fieldPathId={fieldPathId}

--- a/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -13,6 +13,7 @@ import {
   StrictRJSFSchema,
 } from '@rjsf/utils';
 import { SchemaExamples } from '@rjsf/core';
+import { getMuiProps } from '../util';
 
 const TYPES_THAT_SHRINK_LABEL = ['date', 'datetime-local', 'file', 'time'];
 
@@ -59,8 +60,17 @@ export default function BaseInputTemplate<
   const { ClearButton } = registry.templates.ButtonTemplates;
   // Now we need to pull out the step, min, max into an inner `inputProps` for material-ui
   const { step, min, max, accept, ...rest } = getInputProps<T, S, F>(schema, type, options);
+
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   const htmlInputProps = {
     ...slotProps?.htmlInput,
+    ...muiSlotProps?.htmlInput,
     step,
     min,
     max,
@@ -72,8 +82,8 @@ export default function BaseInputTemplate<
   const _onBlur = ({ target }: FocusEvent<HTMLInputElement>) => onBlur(id, target && target.value);
   const _onFocus = ({ target }: FocusEvent<HTMLInputElement>) => onFocus(id, target && target.value);
   const DisplayInputLabelProps = TYPES_THAT_SHRINK_LABEL.includes(type)
-    ? { ...slotProps?.inputLabel, ...InputLabelProps, shrink: true }
-    : { ...slotProps?.inputLabel, ...InputLabelProps };
+    ? { ...slotProps?.inputLabel, ...muiSlotProps?.inputLabel, ...InputLabelProps, shrink: true }
+    : { ...slotProps?.inputLabel, ...muiSlotProps?.inputLabel, ...InputLabelProps };
   const _onClear = useCallback(
     (e: MouseEvent) => {
       e.preventDefault();
@@ -82,7 +92,7 @@ export default function BaseInputTemplate<
     },
     [onChange, options.emptyValue],
   );
-  const inputProps = { ...InputProps, ...slotProps?.input };
+  const inputProps = { ...InputProps, ...slotProps?.input, ...muiSlotProps?.input };
   if (options.allowClearTextInputs && value && !readonly && !disabled) {
     const clearAdornment = (
       <InputAdornment position='end'>
@@ -111,6 +121,7 @@ export default function BaseInputTemplate<
         disabled={disabled || readonly}
         slotProps={{
           ...slotProps,
+          ...muiSlotProps,
           input: inputProps,
           htmlInput: htmlInputProps,
           inputLabel: DisplayInputLabelProps,
@@ -121,6 +132,7 @@ export default function BaseInputTemplate<
         onChange={onChangeOverride || _onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        {...otherMuiProps}
         {...(textFieldProps as TextFieldProps)}
         aria-describedby={ariaDescribedByIds(id, !!schema.examples)}
       />

--- a/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -1,7 +1,8 @@
 import { ChangeEvent, FocusEvent, MouseEvent, useCallback } from 'react';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
-
+import { InputProps as MuiInputProps } from '@mui/material/Input';
+import { InputLabelProps as MuiInputLabelProps } from '@mui/material/InputLabel';
 import {
   ariaDescribedByIds,
   BaseInputTemplateProps,
@@ -9,11 +10,25 @@ import {
   getInputProps,
   labelValue,
   FormContextType,
+  GenericObjectType,
   RJSFSchema,
   StrictRJSFSchema,
 } from '@rjsf/utils';
 import { SchemaExamples } from '@rjsf/core';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the BaseInputTemplate. */
+export interface BaseInputTemplateMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the base native HTML `<input>` or `<textarea>` element. */
+    htmlInput?: React.HTMLAttributes<HTMLInputElement | HTMLTextAreaElement>;
+    /** Props applied to the MUI `Input` element, useful for `endAdornment`/`startAdornment`. */
+    input?: MuiInputProps;
+    /** Props applied to the MUI `InputLabel` element. */
+    inputLabel?: MuiInputLabelProps;
+  };
+}
 
 const TYPES_THAT_SHRINK_LABEL = ['date', 'datetime-local', 'file', 'time'];
 
@@ -61,7 +76,7 @@ export default function BaseInputTemplate<
   // Now we need to pull out the step, min, max into an inner `inputProps` for material-ui
   const { step, min, max, accept, ...rest } = getInputProps<T, S, F>(schema, type, options);
 
-  const muiProps = getMuiProps<T, S, F>(options);
+  const muiProps = getMuiProps<T, S, F, BaseInputTemplateMuiProps>(options);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   const htmlInputProps = {
@@ -128,8 +143,7 @@ export default function BaseInputTemplate<
         onChange={onChangeOverride || _onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
-        {...otherMuiProps}
-        {...(textFieldProps as TextFieldProps)}
+        {...({ ...otherMuiProps, ...textFieldProps } as TextFieldProps)}
         aria-describedby={ariaDescribedByIds(id, !!schema.examples)}
       />
       <SchemaExamples id={id} schema={schema} />

--- a/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -61,11 +61,7 @@ export default function BaseInputTemplate<
   // Now we need to pull out the step, min, max into an inner `inputProps` for material-ui
   const { step, min, max, accept, ...rest } = getInputProps<T, S, F>(schema, type, options);
 
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options,
-  });
+  const muiProps = getMuiProps<T, S, F>(options);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   const htmlInputProps = {

--- a/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -17,9 +17,11 @@ import {
 import { SchemaExamples } from '@rjsf/core';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the BaseInputTemplate. */
+/** Properties available for the MUI `ui:options` of the BaseInputTemplate.
+ *  Unlike RJSF templates, `slotProps` here maps directly to MUI's native `TextField` `slotProps`,
+ *  enabling type-safe customization of the underlying MUI sub-components. */
 export interface BaseInputTemplateMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
+  /** Native MUI `TextField` slotProps for targeting specific sub-components. */
   slotProps?: {
     /** Props applied to the base native HTML `<input>` or `<textarea>` element. */
     htmlInput?: React.HTMLAttributes<HTMLInputElement | HTMLTextAreaElement>;

--- a/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -1,5 +1,5 @@
-import Checkbox from '@mui/material/Checkbox';
-import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox, { CheckboxProps } from '@mui/material/Checkbox';
+import FormControlLabel, { FormControlLabelProps } from '@mui/material/FormControlLabel';
 import {
   ariaDescribedByIds,
   descriptionId,
@@ -11,6 +11,7 @@ import {
   StrictRJSFSchema,
   WidgetProps,
 } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `CheckBoxWidget` is a widget for rendering boolean properties.
  *  It is typically used to represent a boolean.
@@ -54,6 +55,12 @@ export default function CheckboxWidget<
   const _onFocus: React.FocusEventHandler<HTMLButtonElement> = () => onFocus(id, value);
   const description = options.description ?? schema.description;
 
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options,
+  });
+
   return (
     <>
       {!hideLabel && description && (
@@ -66,6 +73,7 @@ export default function CheckboxWidget<
         />
       )}
       <FormControlLabel
+        {...(muiProps as FormControlLabelProps)}
         control={
           <Checkbox
             id={id}
@@ -78,6 +86,7 @@ export default function CheckboxWidget<
             onBlur={_onBlur}
             onFocus={_onFocus}
             aria-describedby={ariaDescribedByIds(id)}
+            {...(muiProps as CheckboxProps)}
           />
         }
         label={labelValue(label, hideLabel, false)}

--- a/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -14,10 +14,10 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the CheckboxWidget. */
+/** Properties available for the `rjsfSlotProps` target of the CheckboxWidget. */
 export interface CheckboxWidgetMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the CheckboxWidget. */
+  rjsfSlotProps?: {
     /** Props applied to the individual `Checkbox` component. */
     checkbox?: CheckboxProps;
     /** Props applied to the `FormControlLabel` component wrapping the checkbox. */
@@ -67,8 +67,7 @@ export default function CheckboxWidget<
   const _onFocus: React.FocusEventHandler<HTMLButtonElement> = () => onFocus(id, value);
   const description = options.description ?? schema.description;
 
-  const muiProps = getMuiProps<T, S, F, CheckboxWidgetMuiProps>(options);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps, ...otherMuiProps } = getMuiProps<T, S, F, CheckboxWidgetMuiProps>(options);
 
   return (
     <>

--- a/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -7,11 +7,23 @@ import {
   labelValue,
   schemaRequiresTrueValue,
   FormContextType,
+  GenericObjectType,
   RJSFSchema,
   StrictRJSFSchema,
   WidgetProps,
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the CheckboxWidget. */
+export interface CheckboxWidgetMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the individual `Checkbox` component. */
+    checkbox?: CheckboxProps;
+    /** Props applied to the `FormControlLabel` component wrapping the checkbox. */
+    formControlLabel?: FormControlLabelProps;
+  };
+}
 
 /** The `CheckBoxWidget` is a widget for rendering boolean properties.
  *  It is typically used to represent a boolean.
@@ -55,7 +67,7 @@ export default function CheckboxWidget<
   const _onFocus: React.FocusEventHandler<HTMLButtonElement> = () => onFocus(id, value);
   const description = options.description ?? schema.description;
 
-  const muiProps = getMuiProps<T, S, F>(options);
+  const muiProps = getMuiProps<T, S, F, CheckboxWidgetMuiProps>(options);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
@@ -70,8 +82,8 @@ export default function CheckboxWidget<
         />
       )}
       <FormControlLabel
-        {...(otherMuiProps as FormControlLabelProps)}
-        {...(muiSlotProps?.formControlLabel as FormControlLabelProps)}
+        {...otherMuiProps}
+        {...muiSlotProps?.formControlLabel}
         control={
           <Checkbox
             id={id}
@@ -84,7 +96,7 @@ export default function CheckboxWidget<
             onBlur={_onBlur}
             onFocus={_onFocus}
             aria-describedby={ariaDescribedByIds(id)}
-            {...(muiSlotProps?.checkbox as CheckboxProps)}
+            {...muiSlotProps?.checkbox}
           />
         }
         label={labelValue(label, hideLabel, false)}

--- a/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -55,11 +55,8 @@ export default function CheckboxWidget<
   const _onFocus: React.FocusEventHandler<HTMLButtonElement> = () => onFocus(id, value);
   const description = options.description ?? schema.description;
 
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options,
-  });
+  const muiProps = getMuiProps<T, S, F>(options);
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
     <>
@@ -73,7 +70,8 @@ export default function CheckboxWidget<
         />
       )}
       <FormControlLabel
-        {...(muiProps as FormControlLabelProps)}
+        {...(otherMuiProps as FormControlLabelProps)}
+        {...(muiSlotProps?.formControlLabel as FormControlLabelProps)}
         control={
           <Checkbox
             id={id}
@@ -86,7 +84,7 @@ export default function CheckboxWidget<
             onBlur={_onBlur}
             onFocus={_onFocus}
             aria-describedby={ariaDescribedByIds(id)}
-            {...(muiProps as CheckboxProps)}
+            {...(muiSlotProps?.checkbox as CheckboxProps)}
           />
         }
         label={labelValue(label, hideLabel, false)}

--- a/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FocusEvent } from 'react';
-import Checkbox from '@mui/material/Checkbox';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import FormGroup from '@mui/material/FormGroup';
+import Checkbox, { CheckboxProps } from '@mui/material/Checkbox';
+import FormControlLabel, { FormControlLabelProps } from '@mui/material/FormControlLabel';
+import FormGroup, { FormGroupProps } from '@mui/material/FormGroup';
 import FormLabel from '@mui/material/FormLabel';
 import {
   ariaDescribedByIds,
@@ -16,6 +16,7 @@ import {
   RJSFSchema,
   StrictRJSFSchema,
 } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `CheckboxesWidget` is a widget for rendering checkbox groups.
  *  It is typically used to represent an array of enums.
@@ -26,21 +27,24 @@ export default function CheckboxesWidget<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
->({
-  label,
-  hideLabel,
-  id,
-  htmlName,
-  disabled,
-  options,
-  value,
-  autofocus,
-  readonly,
-  required,
-  onChange,
-  onBlur,
-  onFocus,
-}: WidgetProps<T, S, F>) {
+>(props: WidgetProps<T, S, F>) {
+  const {
+    label,
+    hideLabel,
+    id,
+    htmlName,
+    disabled,
+    options,
+    value,
+    autofocus,
+    readonly,
+    required,
+    onChange,
+    onBlur,
+    onFocus,
+    registry,
+    uiSchema,
+  } = props;
   const { enumOptions, enumDisabled, inline, emptyValue } = options;
   const checkboxesValues = Array.isArray(value) ? value : [value];
 
@@ -59,6 +63,13 @@ export default function CheckboxesWidget<
   const _onFocus = ({ target }: FocusEvent<HTMLButtonElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(target && target.value, enumOptions, emptyValue));
 
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   return (
     <>
       {labelValue(
@@ -67,13 +78,15 @@ export default function CheckboxesWidget<
         </FormLabel>,
         hideLabel,
       )}
-      <FormGroup id={id} row={!!inline}>
+      <FormGroup {...(otherMuiProps as FormGroupProps)} id={id} row={!!inline}>
         {Array.isArray(enumOptions) &&
           enumOptions.map((option, index: number) => {
             const checked = enumOptionsIsSelected<S>(option.value, checkboxesValues);
             const itemDisabled = Array.isArray(enumDisabled) && enumDisabled.indexOf(option.value) !== -1;
             const checkbox = (
               <Checkbox
+                {...(otherMuiProps as CheckboxProps)}
+                {...(muiSlotProps?.checkbox as CheckboxProps)}
                 id={optionId(id, index)}
                 name={htmlName || id}
                 checked={checked}
@@ -85,7 +98,14 @@ export default function CheckboxesWidget<
                 aria-describedby={ariaDescribedByIds(id)}
               />
             );
-            return <FormControlLabel control={checkbox} key={index} label={option.label} />;
+            return (
+              <FormControlLabel
+                {...(muiSlotProps?.formControlLabel as FormControlLabelProps)}
+                control={checkbox}
+                key={index}
+                label={option.label}
+              />
+            );
           })}
       </FormGroup>
     </>

--- a/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -19,10 +19,10 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the CheckboxesWidget. */
+/** Properties available for the `rjsfSlotProps` target of the CheckboxesWidget. */
 export interface CheckboxesWidgetMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the CheckboxesWidget. */
+  rjsfSlotProps?: {
     /** Props applied to the `FormGroup` container. */
     formGroup?: FormGroupProps;
     /** Props applied to the individual `Checkbox` components. */
@@ -75,8 +75,7 @@ export default function CheckboxesWidget<
   const _onFocus = ({ target }: FocusEvent<HTMLButtonElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(target && target.value, enumOptions, emptyValue));
 
-  const muiProps = getMuiProps<T, S, F, CheckboxesWidgetMuiProps>(options);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps, ...otherMuiProps } = getMuiProps<T, S, F, CheckboxesWidgetMuiProps>(options);
 
   return (
     <>

--- a/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -12,11 +12,25 @@ import {
   labelValue,
   optionId,
   FormContextType,
+  GenericObjectType,
   WidgetProps,
   RJSFSchema,
   StrictRJSFSchema,
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the CheckboxesWidget. */
+export interface CheckboxesWidgetMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the `FormGroup` container. */
+    formGroup?: FormGroupProps;
+    /** Props applied to the individual `Checkbox` components. */
+    checkbox?: CheckboxProps;
+    /** Props applied to the `FormControlLabel` components wrapping each checkbox. */
+    formControlLabel?: FormControlLabelProps;
+  };
+}
 
 /** The `CheckboxesWidget` is a widget for rendering checkbox groups.
  *  It is typically used to represent an array of enums.
@@ -61,7 +75,7 @@ export default function CheckboxesWidget<
   const _onFocus = ({ target }: FocusEvent<HTMLButtonElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(target && target.value, enumOptions, emptyValue));
 
-  const muiProps = getMuiProps<T, S, F>(options);
+  const muiProps = getMuiProps<T, S, F, CheckboxesWidgetMuiProps>(options);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
@@ -72,14 +86,14 @@ export default function CheckboxesWidget<
         </FormLabel>,
         hideLabel,
       )}
-      <FormGroup {...(otherMuiProps as FormGroupProps)} id={id} row={!!inline}>
+      <FormGroup {...otherMuiProps} {...muiSlotProps?.formGroup} id={id} row={!!inline}>
         {Array.isArray(enumOptions) &&
           enumOptions.map((option, index: number) => {
             const checked = enumOptionsIsSelected<S>(option.value, checkboxesValues);
             const itemDisabled = Array.isArray(enumDisabled) && enumDisabled.indexOf(option.value) !== -1;
             const checkbox = (
               <Checkbox
-                {...(muiSlotProps?.checkbox as CheckboxProps)}
+                {...muiSlotProps?.checkbox}
                 id={optionId(id, index)}
                 name={htmlName || id}
                 checked={checked}
@@ -93,7 +107,7 @@ export default function CheckboxesWidget<
             );
             return (
               <FormControlLabel
-                {...(muiSlotProps?.formControlLabel as FormControlLabelProps)}
+                {...muiSlotProps?.formControlLabel}
                 control={checkbox}
                 key={index}
                 label={option.label}

--- a/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -42,8 +42,6 @@ export default function CheckboxesWidget<
     onChange,
     onBlur,
     onFocus,
-    registry,
-    uiSchema,
   } = props;
   const { enumOptions, enumDisabled, inline, emptyValue } = options;
   const checkboxesValues = Array.isArray(value) ? value : [value];
@@ -63,11 +61,7 @@ export default function CheckboxesWidget<
   const _onFocus = ({ target }: FocusEvent<HTMLButtonElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(target && target.value, enumOptions, emptyValue));
 
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options,
-  });
+  const muiProps = getMuiProps<T, S, F>(options);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
@@ -85,7 +79,6 @@ export default function CheckboxesWidget<
             const itemDisabled = Array.isArray(enumDisabled) && enumDisabled.indexOf(option.value) !== -1;
             const checkbox = (
               <Checkbox
-                {...(otherMuiProps as CheckboxProps)}
                 {...(muiSlotProps?.checkbox as CheckboxProps)}
                 id={optionId(id, index)}
                 name={htmlName || id}

--- a/packages/mui/src/DescriptionField/DescriptionField.tsx
+++ b/packages/mui/src/DescriptionField/DescriptionField.tsx
@@ -1,6 +1,7 @@
-import Typography from '@mui/material/Typography';
-import { DescriptionFieldProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import Typography, { TypographyProps } from '@mui/material/Typography';
+import { DescriptionFieldProps, FormContextType, RJSFSchema, StrictRJSFSchema, getUiOptions } from '@rjsf/utils';
 import { RichDescription } from '@rjsf/core';
+import { getMuiProps } from '../util';
 
 /** The `DescriptionField` is the template to use to render the description of a field
  *
@@ -12,9 +13,24 @@ export default function DescriptionField<
   F extends FormContextType = any,
 >(props: DescriptionFieldProps<T, S, F>) {
   const { id, description, registry, uiSchema } = props;
+
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options: uiOptions,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   if (description) {
     return (
-      <Typography id={id} variant='subtitle2' style={{ marginTop: '5px' }}>
+      <Typography
+        id={id}
+        variant='subtitle2'
+        style={{ marginTop: '5px' }}
+        {...(otherMuiProps as TypographyProps)}
+        {...(muiSlotProps?.typography as TypographyProps)}
+      >
         <RichDescription description={description} registry={registry} uiSchema={uiSchema} />
       </Typography>
     );

--- a/packages/mui/src/DescriptionField/DescriptionField.tsx
+++ b/packages/mui/src/DescriptionField/DescriptionField.tsx
@@ -1,7 +1,23 @@
 import Typography, { TypographyProps } from '@mui/material/Typography';
-import { DescriptionFieldProps, FormContextType, RJSFSchema, StrictRJSFSchema, getUiOptions } from '@rjsf/utils';
+import {
+  DescriptionFieldProps,
+  FormContextType,
+  GenericObjectType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  getUiOptions,
+} from '@rjsf/utils';
 import { RichDescription } from '@rjsf/core';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the DescriptionField. */
+export interface DescriptionFieldMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the `Typography` element used for the description. */
+    typography?: TypographyProps;
+  };
+}
 
 /** The `DescriptionField` is the template to use to render the description of a field
  *
@@ -15,11 +31,12 @@ export default function DescriptionField<
   const { id, description, registry, uiSchema } = props;
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F, TypographyProps>(uiOptions);
+  const muiProps = getMuiProps<T, S, F, DescriptionFieldMuiProps>(uiOptions);
+  const { slotProps: muiSlotProps } = muiProps;
 
   if (description) {
     return (
-      <Typography id={id} variant='subtitle2' style={{ marginTop: '5px' }} {...muiProps}>
+      <Typography id={id} variant='subtitle2' style={{ marginTop: '5px' }} {...muiSlotProps?.typography}>
         <RichDescription description={description} registry={registry} uiSchema={uiSchema} />
       </Typography>
     );

--- a/packages/mui/src/DescriptionField/DescriptionField.tsx
+++ b/packages/mui/src/DescriptionField/DescriptionField.tsx
@@ -10,10 +10,10 @@ import {
 import { RichDescription } from '@rjsf/core';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the DescriptionField. */
+/** Properties available for the `rjsfSlotProps` target of the DescriptionField. */
 export interface DescriptionFieldMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the DescriptionField. */
+  rjsfSlotProps?: {
     /** Props applied to the `Typography` element used for the description. */
     typography?: TypographyProps;
   };
@@ -32,7 +32,7 @@ export default function DescriptionField<
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
   const muiProps = getMuiProps<T, S, F, DescriptionFieldMuiProps>(uiOptions);
-  const { slotProps: muiSlotProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps } = muiProps;
 
   if (description) {
     return (

--- a/packages/mui/src/DescriptionField/DescriptionField.tsx
+++ b/packages/mui/src/DescriptionField/DescriptionField.tsx
@@ -15,22 +15,11 @@ export default function DescriptionField<
   const { id, description, registry, uiSchema } = props;
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options: uiOptions,
-  });
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const muiProps = getMuiProps<T, S, F, TypographyProps>(uiOptions);
 
   if (description) {
     return (
-      <Typography
-        id={id}
-        variant='subtitle2'
-        style={{ marginTop: '5px' }}
-        {...(otherMuiProps as TypographyProps)}
-        {...(muiSlotProps?.typography as TypographyProps)}
-      >
+      <Typography id={id} variant='subtitle2' style={{ marginTop: '5px' }} {...muiProps}>
         <RichDescription description={description} registry={registry} uiSchema={uiSchema} />
       </Typography>
     );

--- a/packages/mui/src/DescriptionField/DescriptionField.tsx
+++ b/packages/mui/src/DescriptionField/DescriptionField.tsx
@@ -15,7 +15,7 @@ export interface DescriptionFieldMuiProps extends GenericObjectType {
   /** RJSF-specific slot props for targeting child elements of the DescriptionField. */
   rjsfSlotProps?: {
     /** Props applied to the `Typography` element used for the description. */
-    typography?: TypographyProps;
+    descTypography?: TypographyProps;
   };
 }
 
@@ -36,7 +36,7 @@ export default function DescriptionField<
 
   if (description) {
     return (
-      <Typography id={id} variant='subtitle2' style={{ marginTop: '5px' }} {...muiSlotProps?.typography}>
+      <Typography id={id} variant='subtitle2' style={{ marginTop: '5px' }} {...muiSlotProps?.descTypography}>
         <RichDescription description={description} registry={registry} uiSchema={uiSchema} />
       </Typography>
     );

--- a/packages/mui/src/ErrorList/ErrorList.tsx
+++ b/packages/mui/src/ErrorList/ErrorList.tsx
@@ -1,12 +1,20 @@
 import ErrorIcon from '@mui/icons-material/Error';
-import Box from '@mui/material/Box';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import Paper from '@mui/material/Paper';
-import Typography from '@mui/material/Typography';
-import { ErrorListProps, FormContextType, RJSFSchema, StrictRJSFSchema, TranslatableString } from '@rjsf/utils';
+import Box, { BoxProps } from '@mui/material/Box';
+import List, { ListProps } from '@mui/material/List';
+import ListItem, { ListItemProps } from '@mui/material/ListItem';
+import ListItemIcon, { ListItemIconProps } from '@mui/material/ListItemIcon';
+import ListItemText, { ListItemTextProps } from '@mui/material/ListItemText';
+import Paper, { PaperProps } from '@mui/material/Paper';
+import Typography, { TypographyProps } from '@mui/material/Typography';
+import {
+  ErrorListProps,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  TranslatableString,
+  getUiOptions,
+} from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `ErrorList` component is the template that renders the all the errors associated with the fields in the `Form`
  *
@@ -15,20 +23,32 @@ import { ErrorListProps, FormContextType, RJSFSchema, StrictRJSFSchema, Translat
 export default function ErrorList<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>({
   errors,
   registry,
+  uiSchema,
 }: ErrorListProps<T, S, F>) {
   const { translateString } = registry;
+
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options: uiOptions,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   return (
-    <Paper elevation={2}>
-      <Box mb={2} p={2}>
-        <Typography variant='h6'>{translateString(TranslatableString.ErrorsLabel)}</Typography>
-        <List dense={true}>
+    <Paper elevation={2} {...(otherMuiProps as PaperProps)} {...(muiSlotProps?.paper as PaperProps)}>
+      <Box mb={2} p={2} {...(muiSlotProps?.box as BoxProps)}>
+        <Typography variant='h6' {...(muiSlotProps?.typography as TypographyProps)}>
+          {translateString(TranslatableString.ErrorsLabel)}
+        </Typography>
+        <List dense={true} {...(muiSlotProps?.list as ListProps)}>
           {errors.map((error, i: number) => {
             return (
-              <ListItem key={i}>
-                <ListItemIcon>
+              <ListItem key={i} {...(muiSlotProps?.listItem as ListItemProps)}>
+                <ListItemIcon {...(muiSlotProps?.listItemIcon as ListItemIconProps)}>
                   <ErrorIcon color='error' />
                 </ListItemIcon>
-                <ListItemText primary={error.stack} />
+                <ListItemText primary={error.stack} {...(muiSlotProps?.listItemText as ListItemTextProps)} />
               </ListItem>
             );
           })}

--- a/packages/mui/src/ErrorList/ErrorList.tsx
+++ b/packages/mui/src/ErrorList/ErrorList.tsx
@@ -22,19 +22,19 @@ export interface ErrorListMuiProps extends GenericObjectType {
   /** RJSF-specific slot props for targeting child elements of the ErrorList. */
   rjsfSlotProps?: {
     /** Props applied to the outermost `Paper` component. */
-    paper?: PaperProps;
+    errorPaper?: PaperProps;
     /** Props applied to the `Box` container. */
-    box?: BoxProps;
+    errorBox?: BoxProps;
     /** Props applied to the `Typography` element for the title. */
-    typography?: TypographyProps;
+    errorTypography?: TypographyProps;
     /** Props applied to the `List` container holding the errors. */
-    list?: ListProps;
+    errorList?: ListProps;
     /** Props applied to each `ListItem` representing an error. */
-    listItem?: ListItemProps;
+    errorListItem?: ListItemProps;
     /** Props applied to each `ListItemIcon` representing the error icon. */
-    listItemIcon?: ListItemIconProps;
+    errorListItemIcon?: ListItemIconProps;
     /** Props applied to each `ListItemText` representing the error message. */
-    listItemText?: ListItemTextProps;
+    errorListItemText?: ListItemTextProps;
   };
 }
 
@@ -53,19 +53,19 @@ export default function ErrorList<T = any, S extends StrictRJSFSchema = RJSFSche
   const { rjsfSlotProps: muiSlotProps } = getMuiProps<T, S, F, ErrorListMuiProps>(uiOptions);
 
   return (
-    <Paper elevation={2} {...muiSlotProps?.paper}>
-      <Box mb={2} p={2} {...muiSlotProps?.box}>
-        <Typography variant='h6' {...muiSlotProps?.typography}>
+    <Paper elevation={2} {...muiSlotProps?.errorPaper}>
+      <Box mb={2} p={2} {...muiSlotProps?.errorBox}>
+        <Typography variant='h6' {...muiSlotProps?.errorTypography}>
           {translateString(TranslatableString.ErrorsLabel)}
         </Typography>
-        <List dense={true} {...muiSlotProps?.list}>
+        <List dense={true} {...muiSlotProps?.errorList}>
           {errors.map((error, i: number) => {
             return (
-              <ListItem key={i} {...muiSlotProps?.listItem}>
-                <ListItemIcon {...muiSlotProps?.listItemIcon}>
+              <ListItem key={i} {...muiSlotProps?.errorListItem}>
+                <ListItemIcon {...muiSlotProps?.errorListItemIcon}>
                   <ErrorIcon color='error' />
                 </ListItemIcon>
-                <ListItemText primary={error.stack} {...muiSlotProps?.listItemText} />
+                <ListItemText primary={error.stack} {...muiSlotProps?.errorListItemText} />
               </ListItem>
             );
           })}

--- a/packages/mui/src/ErrorList/ErrorList.tsx
+++ b/packages/mui/src/ErrorList/ErrorList.tsx
@@ -17,10 +17,10 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the ErrorList. */
+/** Properties available for the `rjsfSlotProps` target of the ErrorList. */
 export interface ErrorListMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the ErrorList. */
+  rjsfSlotProps?: {
     /** Props applied to the outermost `Paper` component. */
     paper?: PaperProps;
     /** Props applied to the `Box` container. */
@@ -50,11 +50,10 @@ export default function ErrorList<T = any, S extends StrictRJSFSchema = RJSFSche
   const { translateString } = registry;
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F, ErrorListMuiProps>(uiOptions);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps } = getMuiProps<T, S, F, ErrorListMuiProps>(uiOptions);
 
   return (
-    <Paper elevation={2} {...otherMuiProps} {...muiSlotProps?.paper}>
+    <Paper elevation={2} {...muiSlotProps?.paper}>
       <Box mb={2} p={2} {...muiSlotProps?.box}>
         <Typography variant='h6' {...muiSlotProps?.typography}>
           {translateString(TranslatableString.ErrorsLabel)}

--- a/packages/mui/src/ErrorList/ErrorList.tsx
+++ b/packages/mui/src/ErrorList/ErrorList.tsx
@@ -28,11 +28,7 @@ export default function ErrorList<T = any, S extends StrictRJSFSchema = RJSFSche
   const { translateString } = registry;
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options: uiOptions,
-  });
+  const muiProps = getMuiProps<T, S, F>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (

--- a/packages/mui/src/ErrorList/ErrorList.tsx
+++ b/packages/mui/src/ErrorList/ErrorList.tsx
@@ -9,12 +9,34 @@ import Typography, { TypographyProps } from '@mui/material/Typography';
 import {
   ErrorListProps,
   FormContextType,
+  GenericObjectType,
   RJSFSchema,
   StrictRJSFSchema,
   TranslatableString,
   getUiOptions,
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the ErrorList. */
+export interface ErrorListMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the outermost `Paper` component. */
+    paper?: PaperProps;
+    /** Props applied to the `Box` container. */
+    box?: BoxProps;
+    /** Props applied to the `Typography` element for the title. */
+    typography?: TypographyProps;
+    /** Props applied to the `List` container holding the errors. */
+    list?: ListProps;
+    /** Props applied to each `ListItem` representing an error. */
+    listItem?: ListItemProps;
+    /** Props applied to each `ListItemIcon` representing the error icon. */
+    listItemIcon?: ListItemIconProps;
+    /** Props applied to each `ListItemText` representing the error message. */
+    listItemText?: ListItemTextProps;
+  };
+}
 
 /** The `ErrorList` component is the template that renders the all the errors associated with the fields in the `Form`
  *
@@ -28,23 +50,23 @@ export default function ErrorList<T = any, S extends StrictRJSFSchema = RJSFSche
   const { translateString } = registry;
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>(uiOptions);
+  const muiProps = getMuiProps<T, S, F, ErrorListMuiProps>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
-    <Paper elevation={2} {...(otherMuiProps as PaperProps)} {...(muiSlotProps?.paper as PaperProps)}>
-      <Box mb={2} p={2} {...(muiSlotProps?.box as BoxProps)}>
-        <Typography variant='h6' {...(muiSlotProps?.typography as TypographyProps)}>
+    <Paper elevation={2} {...otherMuiProps} {...muiSlotProps?.paper}>
+      <Box mb={2} p={2} {...muiSlotProps?.box}>
+        <Typography variant='h6' {...muiSlotProps?.typography}>
           {translateString(TranslatableString.ErrorsLabel)}
         </Typography>
-        <List dense={true} {...(muiSlotProps?.list as ListProps)}>
+        <List dense={true} {...muiSlotProps?.list}>
           {errors.map((error, i: number) => {
             return (
-              <ListItem key={i} {...(muiSlotProps?.listItem as ListItemProps)}>
-                <ListItemIcon {...(muiSlotProps?.listItemIcon as ListItemIconProps)}>
+              <ListItem key={i} {...muiSlotProps?.listItem}>
+                <ListItemIcon {...muiSlotProps?.listItemIcon}>
                   <ErrorIcon color='error' />
                 </ListItemIcon>
-                <ListItemText primary={error.stack} {...(muiSlotProps?.listItemText as ListItemTextProps)} />
+                <ListItemText primary={error.stack} {...muiSlotProps?.listItemText} />
               </ListItem>
             );
           })}

--- a/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -1,7 +1,8 @@
-import ListItem from '@mui/material/ListItem';
-import FormHelperText from '@mui/material/FormHelperText';
-import List from '@mui/material/List';
-import { errorId, FieldErrorProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import ListItem, { ListItemProps } from '@mui/material/ListItem';
+import FormHelperText, { FormHelperTextProps } from '@mui/material/FormHelperText';
+import List, { ListProps } from '@mui/material/List';
+import { errorId, FieldErrorProps, FormContextType, RJSFSchema, StrictRJSFSchema, getUiOptions } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `FieldErrorTemplate` component renders the errors local to the particular field
  *
@@ -12,18 +13,36 @@ export default function FieldErrorTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: FieldErrorProps<T, S, F>) {
-  const { errors = [], fieldPathId } = props;
+  const { errors = [], fieldPathId, uiSchema, registry } = props;
   if (errors.length === 0) {
     return null;
   }
   const id = errorId(fieldPathId);
 
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options: uiOptions,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   return (
-    <List id={id} dense={true} disablePadding={true}>
+    <List
+      id={id}
+      dense={true}
+      disablePadding={true}
+      {...(otherMuiProps as ListProps)}
+      {...(muiSlotProps?.list as ListProps)}
+    >
       {errors.map((error, i: number) => {
         return (
-          <ListItem key={i} disableGutters={true}>
-            <FormHelperText component='div' id={`${id}-${i}`}>
+          <ListItem key={i} disableGutters={true} {...(muiSlotProps?.listItem as ListItemProps)}>
+            <FormHelperText
+              component='div'
+              id={`${id}-${i}`}
+              {...(muiSlotProps?.formHelperText as FormHelperTextProps)}
+            >
               {error}
             </FormHelperText>
           </ListItem>

--- a/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -1,8 +1,29 @@
 import ListItem, { ListItemProps } from '@mui/material/ListItem';
 import FormHelperText, { FormHelperTextProps } from '@mui/material/FormHelperText';
 import List, { ListProps } from '@mui/material/List';
-import { errorId, FieldErrorProps, FormContextType, RJSFSchema, StrictRJSFSchema, getUiOptions } from '@rjsf/utils';
+import {
+  errorId,
+  FieldErrorProps,
+  FormContextType,
+  GenericObjectType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  getUiOptions,
+} from '@rjsf/utils';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the FieldErrorTemplate. */
+export interface FieldErrorTemplateMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the `List` container holding the errors. */
+    list?: ListProps;
+    /** Props applied to each `ListItem` representing an error. */
+    listItem?: ListItemProps;
+    /** Props applied to the `FormHelperText` displaying the actual error message. */
+    formHelperText?: FormHelperTextProps;
+  };
+}
 
 /** The `FieldErrorTemplate` component renders the errors local to the particular field
  *
@@ -20,25 +41,15 @@ export default function FieldErrorTemplate<
   const id = errorId(fieldPathId);
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>(uiOptions);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const muiProps = getMuiProps<T, S, F, FieldErrorTemplateMuiProps>(uiOptions);
+  const { slotProps: muiSlotProps } = muiProps;
 
   return (
-    <List
-      id={id}
-      dense={true}
-      disablePadding={true}
-      {...(otherMuiProps as ListProps)}
-      {...(muiSlotProps?.list as ListProps)}
-    >
+    <List id={id} dense={true} disablePadding={true} {...muiSlotProps?.list}>
       {errors.map((error, i: number) => {
         return (
-          <ListItem key={i} disableGutters={true} {...(muiSlotProps?.listItem as ListItemProps)}>
-            <FormHelperText
-              component='div'
-              id={`${id}-${i}`}
-              {...(muiSlotProps?.formHelperText as FormHelperTextProps)}
-            >
+          <ListItem key={i} disableGutters={true} {...muiSlotProps?.listItem}>
+            <FormHelperText component='div' id={`${id}-${i}`} {...muiSlotProps?.formHelperText}>
               {error}
             </FormHelperText>
           </ListItem>

--- a/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -13,18 +13,14 @@ export default function FieldErrorTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: FieldErrorProps<T, S, F>) {
-  const { errors = [], fieldPathId, uiSchema, registry } = props;
+  const { errors = [], fieldPathId, uiSchema } = props;
   if (errors.length === 0) {
     return null;
   }
   const id = errorId(fieldPathId);
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options: uiOptions,
-  });
+  const muiProps = getMuiProps<T, S, F>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (

--- a/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -17,11 +17,11 @@ export interface FieldErrorTemplateMuiProps extends GenericObjectType {
   /** RJSF-specific slot props for targeting child elements of the FieldErrorTemplate. */
   rjsfSlotProps?: {
     /** Props applied to the `List` container holding the errors. */
-    list?: ListProps;
+    fieldErrorList?: ListProps;
     /** Props applied to each `ListItem` representing an error. */
-    listItem?: ListItemProps;
+    fieldErrorListItem?: ListItemProps;
     /** Props applied to the `FormHelperText` displaying the actual error message. */
-    formHelperText?: FormHelperTextProps;
+    fieldErrorFormHelperText?: FormHelperTextProps;
   };
 }
 
@@ -45,11 +45,11 @@ export default function FieldErrorTemplate<
   const { rjsfSlotProps: muiSlotProps } = muiProps;
 
   return (
-    <List id={id} dense={true} disablePadding={true} {...muiSlotProps?.list}>
+    <List id={id} dense={true} disablePadding={true} {...muiSlotProps?.fieldErrorList}>
       {errors.map((error, i: number) => {
         return (
-          <ListItem key={i} disableGutters={true} {...muiSlotProps?.listItem}>
-            <FormHelperText component='div' id={`${id}-${i}`} {...muiSlotProps?.formHelperText}>
+          <ListItem key={i} disableGutters={true} {...muiSlotProps?.fieldErrorListItem}>
+            <FormHelperText component='div' id={`${id}-${i}`} {...muiSlotProps?.fieldErrorFormHelperText}>
               {error}
             </FormHelperText>
           </ListItem>

--- a/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -12,10 +12,10 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the FieldErrorTemplate. */
+/** Properties available for the `rjsfSlotProps` target of the FieldErrorTemplate. */
 export interface FieldErrorTemplateMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the FieldErrorTemplate. */
+  rjsfSlotProps?: {
     /** Props applied to the `List` container holding the errors. */
     list?: ListProps;
     /** Props applied to each `ListItem` representing an error. */
@@ -42,7 +42,7 @@ export default function FieldErrorTemplate<
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
   const muiProps = getMuiProps<T, S, F, FieldErrorTemplateMuiProps>(uiOptions);
-  const { slotProps: muiSlotProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps } = muiProps;
 
   return (
     <List id={id} dense={true} disablePadding={true} {...muiSlotProps?.list}>

--- a/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,6 +1,7 @@
 import { RichHelp } from '@rjsf/core';
-import { helpId, FieldHelpProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
-import FormHelperText from '@mui/material/FormHelperText';
+import { helpId, FieldHelpProps, FormContextType, RJSFSchema, StrictRJSFSchema, getUiOptions } from '@rjsf/utils';
+import FormHelperText, { FormHelperTextProps } from '@mui/material/FormHelperText';
+import { getMuiProps } from '../util';
 
 /** The `FieldHelpTemplate` component renders any help desired for a field
  *
@@ -16,8 +17,22 @@ export default function FieldHelpTemplate<
     return null;
   }
 
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options: uiOptions,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   return (
-    <FormHelperText component='div' id={helpId(fieldPathId)} style={{ marginTop: '5px' }}>
+    <FormHelperText
+      component='div'
+      id={helpId(fieldPathId)}
+      style={{ marginTop: '5px' }}
+      {...(otherMuiProps as FormHelperTextProps)}
+      {...(muiSlotProps?.formHelperText as FormHelperTextProps)}
+    >
       <RichHelp help={help} registry={registry} uiSchema={uiSchema} />
     </FormHelperText>
   );

--- a/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -11,10 +11,10 @@ import {
 import FormHelperText, { FormHelperTextProps } from '@mui/material/FormHelperText';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the FieldHelpTemplate. */
+/** Properties available for the `rjsfSlotProps` target of the FieldHelpTemplate. */
 export interface FieldHelpTemplateMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the FieldHelpTemplate. */
+  rjsfSlotProps?: {
     /** Props applied to the `FormHelperText` used for help text. */
     formHelperText?: FormHelperTextProps;
   };
@@ -36,7 +36,7 @@ export default function FieldHelpTemplate<
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
   const muiProps = getMuiProps<T, S, F, FieldHelpTemplateMuiProps>(uiOptions);
-  const { slotProps: muiSlotProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps } = muiProps;
 
   return (
     <FormHelperText

--- a/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,7 +1,24 @@
 import { RichHelp } from '@rjsf/core';
-import { helpId, FieldHelpProps, FormContextType, RJSFSchema, StrictRJSFSchema, getUiOptions } from '@rjsf/utils';
+import {
+  helpId,
+  FieldHelpProps,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  getUiOptions,
+  GenericObjectType,
+} from '@rjsf/utils';
 import FormHelperText, { FormHelperTextProps } from '@mui/material/FormHelperText';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the FieldHelpTemplate. */
+export interface FieldHelpTemplateMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the `FormHelperText` used for help text. */
+    formHelperText?: FormHelperTextProps;
+  };
+}
 
 /** The `FieldHelpTemplate` component renders any help desired for a field
  *
@@ -18,10 +35,16 @@ export default function FieldHelpTemplate<
   }
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F, FormHelperTextProps>(uiOptions);
+  const muiProps = getMuiProps<T, S, F, FieldHelpTemplateMuiProps>(uiOptions);
+  const { slotProps: muiSlotProps } = muiProps;
 
   return (
-    <FormHelperText component='div' id={helpId(fieldPathId)} style={{ marginTop: '5px' }} {...muiProps}>
+    <FormHelperText
+      component='div'
+      id={helpId(fieldPathId)}
+      style={{ marginTop: '5px' }}
+      {...muiSlotProps?.formHelperText}
+    >
       <RichHelp help={help} registry={registry} uiSchema={uiSchema} />
     </FormHelperText>
   );

--- a/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -18,21 +18,10 @@ export default function FieldHelpTemplate<
   }
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options: uiOptions,
-  });
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const muiProps = getMuiProps<T, S, F, FormHelperTextProps>(uiOptions);
 
   return (
-    <FormHelperText
-      component='div'
-      id={helpId(fieldPathId)}
-      style={{ marginTop: '5px' }}
-      {...(otherMuiProps as FormHelperTextProps)}
-      {...(muiSlotProps?.formHelperText as FormHelperTextProps)}
-    >
+    <FormHelperText component='div' id={helpId(fieldPathId)} style={{ marginTop: '5px' }} {...muiProps}>
       <RichHelp help={help} registry={registry} uiSchema={uiSchema} />
     </FormHelperText>
   );

--- a/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -16,7 +16,7 @@ export interface FieldHelpTemplateMuiProps extends GenericObjectType {
   /** RJSF-specific slot props for targeting child elements of the FieldHelpTemplate. */
   rjsfSlotProps?: {
     /** Props applied to the `FormHelperText` used for help text. */
-    formHelperText?: FormHelperTextProps;
+    helpFormHelperText?: FormHelperTextProps;
   };
 }
 
@@ -43,7 +43,7 @@ export default function FieldHelpTemplate<
       component='div'
       id={helpId(fieldPathId)}
       style={{ marginTop: '5px' }}
-      {...muiSlotProps?.formHelperText}
+      {...muiSlotProps?.helpFormHelperText}
     >
       <RichHelp help={help} registry={registry} uiSchema={uiSchema} />
     </FormHelperText>

--- a/packages/mui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/mui/src/FieldTemplate/FieldTemplate.tsx
@@ -1,5 +1,5 @@
-import FormControl from '@mui/material/FormControl';
-import Typography from '@mui/material/Typography';
+import FormControl, { FormControlProps } from '@mui/material/FormControl';
+import Typography, { TypographyProps } from '@mui/material/Typography';
 import {
   FieldTemplateProps,
   FormContextType,
@@ -8,6 +8,7 @@ import {
   getTemplate,
   getUiOptions,
 } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `FieldTemplate` component is the template used by `SchemaField` to render any field. It renders the field
  * content, (label, description, children, errors and help) inside of a `WrapIfAdditional` component.
@@ -55,6 +56,13 @@ export default function FieldTemplate<
 
   const isCheckbox = uiOptions.widget === 'checkbox';
 
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options: uiOptions,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
@@ -73,10 +81,17 @@ export default function FieldTemplate<
       uiSchema={uiSchema}
       registry={registry}
     >
-      <FormControl fullWidth={true} error={rawErrors.length ? true : false} required={required}>
+      <FormControl
+        fullWidth={true}
+        error={rawErrors.length ? true : false}
+        required={required}
+        {...(muiSlotProps?.formControl as FormControlProps)}
+        sx={otherMuiProps.sx}
+        className={otherMuiProps.className}
+      >
         {children}
         {displayLabel && !isCheckbox && rawDescription ? (
-          <Typography variant='caption' color='textSecondary'>
+          <Typography variant='caption' color='textSecondary' {...(muiSlotProps?.typography as TypographyProps)}>
             {description}
           </Typography>
         ) : null}

--- a/packages/mui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/mui/src/FieldTemplate/FieldTemplate.tsx
@@ -3,12 +3,24 @@ import Typography, { TypographyProps } from '@mui/material/Typography';
 import {
   FieldTemplateProps,
   FormContextType,
+  GenericObjectType,
   RJSFSchema,
   StrictRJSFSchema,
   getTemplate,
   getUiOptions,
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the FieldTemplate. */
+export interface FieldTemplateMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the MUI `FormControl` wrapping the field. */
+    formControl?: FormControlProps;
+    /** Props applied to the MUI `Typography` element used for description. */
+    typography?: TypographyProps;
+  };
+}
 
 /** The `FieldTemplate` component is the template used by `SchemaField` to render any field. It renders the field
  * content, (label, description, children, errors and help) inside of a `WrapIfAdditional` component.
@@ -56,7 +68,7 @@ export default function FieldTemplate<
 
   const isCheckbox = uiOptions.widget === 'checkbox';
 
-  const muiProps = getMuiProps<T, S, F>(uiOptions);
+  const muiProps = getMuiProps<T, S, F, FieldTemplateMuiProps>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
@@ -81,13 +93,13 @@ export default function FieldTemplate<
         fullWidth={true}
         error={rawErrors.length ? true : false}
         required={required}
-        {...(muiSlotProps?.formControl as FormControlProps)}
+        {...muiSlotProps?.formControl}
         sx={otherMuiProps.sx}
         className={otherMuiProps.className}
       >
         {children}
         {displayLabel && !isCheckbox && rawDescription ? (
-          <Typography variant='caption' color='textSecondary' {...(muiSlotProps?.typography as TypographyProps)}>
+          <Typography variant='caption' color='textSecondary' {...muiSlotProps?.typography}>
             {description}
           </Typography>
         ) : null}

--- a/packages/mui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/mui/src/FieldTemplate/FieldTemplate.tsx
@@ -56,11 +56,7 @@ export default function FieldTemplate<
 
   const isCheckbox = uiOptions.widget === 'checkbox';
 
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options: uiOptions,
-  });
+  const muiProps = getMuiProps<T, S, F>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (

--- a/packages/mui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/mui/src/FieldTemplate/FieldTemplate.tsx
@@ -16,9 +16,9 @@ export interface FieldTemplateMuiProps extends GenericObjectType {
   /** RJSF-specific slot props for targeting child elements of the FieldTemplate. */
   rjsfSlotProps?: {
     /** Props applied to the MUI `FormControl` wrapping the field. */
-    formControl?: FormControlProps;
+    fieldFormControl?: FormControlProps;
     /** Props applied to the MUI `Typography` element used for description. */
-    typography?: TypographyProps;
+    fieldTypography?: TypographyProps;
   };
 }
 
@@ -92,13 +92,13 @@ export default function FieldTemplate<
         fullWidth={true}
         error={rawErrors.length ? true : false}
         required={required}
-        {...muiSlotProps?.formControl}
+        {...muiSlotProps?.fieldFormControl}
         sx={otherMuiProps.sx}
         className={otherMuiProps.className}
       >
         {children}
         {displayLabel && !isCheckbox && rawDescription ? (
-          <Typography variant='caption' color='textSecondary' {...muiSlotProps?.typography}>
+          <Typography variant='caption' color='textSecondary' {...muiSlotProps?.fieldTypography}>
             {description}
           </Typography>
         ) : null}

--- a/packages/mui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/mui/src/FieldTemplate/FieldTemplate.tsx
@@ -11,10 +11,10 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the FieldTemplate. */
+/** Properties available for the `rjsfSlotProps` target of the FieldTemplate. */
 export interface FieldTemplateMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the FieldTemplate. */
+  rjsfSlotProps?: {
     /** Props applied to the MUI `FormControl` wrapping the field. */
     formControl?: FormControlProps;
     /** Props applied to the MUI `Typography` element used for description. */
@@ -68,8 +68,7 @@ export default function FieldTemplate<
 
   const isCheckbox = uiOptions.widget === 'checkbox';
 
-  const muiProps = getMuiProps<T, S, F, FieldTemplateMuiProps>(uiOptions);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps, ...otherMuiProps } = getMuiProps<T, S, F, FieldTemplateMuiProps>(uiOptions);
 
   return (
     <WrapIfAdditionalTemplate

--- a/packages/mui/src/GridTemplate/GridTemplate.tsx
+++ b/packages/mui/src/GridTemplate/GridTemplate.tsx
@@ -1,15 +1,32 @@
-import Grid from '@mui/material/Grid';
-import { GridTemplateProps } from '@rjsf/utils';
+import Grid, { GridProps } from '@mui/material/Grid';
+import { FormContextType, GridTemplateProps, RJSFSchema, StrictRJSFSchema, getUiOptions } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** Renders a `GridTemplate` for mui, which is expecting the column sizing information coming in via the
  * extra props provided by the caller, which are spread directly on the `Grid`.
  *
  * @param props - The GridTemplateProps, including the extra props containing the mui grid positioning details
  */
-export default function GridTemplate(props: GridTemplateProps) {
-  const { children, column, ...rest } = props;
+export default function GridTemplate<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: GridTemplateProps,
+) {
+  const { children, column, uiSchema, registry, ...rest } = props;
+
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry?.formContext,
+    options: uiOptions,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   return (
-    <Grid container={!column} {...rest}>
+    <Grid
+      container={!column}
+      {...(rest as GridProps)}
+      {...(otherMuiProps as GridProps)}
+      {...(muiSlotProps?.grid as GridProps)}
+    >
       {children}
     </Grid>
   );

--- a/packages/mui/src/GridTemplate/GridTemplate.tsx
+++ b/packages/mui/src/GridTemplate/GridTemplate.tsx
@@ -1,32 +1,16 @@
 import Grid, { GridProps } from '@mui/material/Grid';
-import { FormContextType, GridTemplateProps, RJSFSchema, StrictRJSFSchema, getUiOptions } from '@rjsf/utils';
-import { getMuiProps } from '../util';
+import { GridTemplateProps } from '@rjsf/utils';
 
 /** Renders a `GridTemplate` for mui, which is expecting the column sizing information coming in via the
  * extra props provided by the caller, which are spread directly on the `Grid`.
  *
  * @param props - The GridTemplateProps, including the extra props containing the mui grid positioning details
  */
-export default function GridTemplate<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
-  props: GridTemplateProps,
-) {
-  const { children, column, uiSchema, registry, ...rest } = props;
-
-  const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry?.formContext,
-    options: uiOptions,
-  });
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+export default function GridTemplate(props: GridTemplateProps) {
+  const { children, column, ...rest } = props;
 
   return (
-    <Grid
-      container={!column}
-      {...(rest as GridProps)}
-      {...(otherMuiProps as GridProps)}
-      {...(muiSlotProps?.grid as GridProps)}
-    >
+    <Grid container={!column} {...(rest as GridProps)}>
       {children}
     </Grid>
   );

--- a/packages/mui/src/GridTemplate/GridTemplate.tsx
+++ b/packages/mui/src/GridTemplate/GridTemplate.tsx
@@ -1,4 +1,4 @@
-import Grid, { GridProps } from '@mui/material/Grid';
+import Grid from '@mui/material/Grid';
 import { GridTemplateProps } from '@rjsf/utils';
 
 /** Renders a `GridTemplate` for mui, which is expecting the column sizing information coming in via the
@@ -8,9 +8,8 @@ import { GridTemplateProps } from '@rjsf/utils';
  */
 export default function GridTemplate(props: GridTemplateProps) {
   const { children, column, ...rest } = props;
-
   return (
-    <Grid container={!column} {...(rest as GridProps)}>
+    <Grid container={!column} {...rest}>
       {children}
     </Grid>
   );

--- a/packages/mui/src/IconButton/IconButton.tsx
+++ b/packages/mui/src/IconButton/IconButton.tsx
@@ -5,6 +5,7 @@ import CopyIcon from '@mui/icons-material/ContentCopy';
 import RemoveIcon from '@mui/icons-material/Remove';
 import ClearIcon from '@mui/icons-material/Clear';
 import { FormContextType, IconButtonProps, RJSFSchema, StrictRJSFSchema, TranslatableString } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 export default function MuiIconButton<
   T = any,
@@ -12,8 +13,19 @@ export default function MuiIconButton<
   F extends FormContextType = any,
 >(props: IconButtonProps<T, S, F>) {
   const { icon, color, uiSchema, registry, ...otherProps } = props;
+
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+  });
+
   return (
-    <IconButton {...otherProps} size='small' color={color as MuiIconButtonProps['color']}>
+    <IconButton
+      {...(muiProps as MuiIconButtonProps)}
+      {...otherProps}
+      size='small'
+      color={color as MuiIconButtonProps['color']}
+    >
       {icon}
     </IconButton>
   );

--- a/packages/mui/src/IconButton/IconButton.tsx
+++ b/packages/mui/src/IconButton/IconButton.tsx
@@ -22,7 +22,14 @@ export default function MuiIconButton<
   const { icon, color, uiSchema, registry, ...otherProps } = props;
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F, MuiIconButtonProps>(uiOptions);
+  const muiProps = getMuiProps<T, S, F, MuiIconButtonProps>(uiOptions, [
+    'color',
+    'disableFocusRipple',
+    'disableRipple',
+    'edge',
+    'size',
+    'sx',
+  ]);
 
   return (
     <IconButton {...muiProps} {...otherProps} size='small' color={color as MuiIconButtonProps['color']}>

--- a/packages/mui/src/IconButton/IconButton.tsx
+++ b/packages/mui/src/IconButton/IconButton.tsx
@@ -4,7 +4,14 @@ import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import CopyIcon from '@mui/icons-material/ContentCopy';
 import RemoveIcon from '@mui/icons-material/Remove';
 import ClearIcon from '@mui/icons-material/Clear';
-import { FormContextType, IconButtonProps, RJSFSchema, StrictRJSFSchema, TranslatableString } from '@rjsf/utils';
+import {
+  FormContextType,
+  IconButtonProps,
+  RJSFSchema,
+  StrictRJSFSchema,
+  TranslatableString,
+  getUiOptions,
+} from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
 export default function MuiIconButton<
@@ -14,18 +21,11 @@ export default function MuiIconButton<
 >(props: IconButtonProps<T, S, F>) {
   const { icon, color, uiSchema, registry, ...otherProps } = props;
 
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-  });
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const muiProps = getMuiProps<T, S, F, MuiIconButtonProps>(uiOptions);
 
   return (
-    <IconButton
-      {...(muiProps as MuiIconButtonProps)}
-      {...otherProps}
-      size='small'
-      color={color as MuiIconButtonProps['color']}
-    >
+    <IconButton {...muiProps} {...otherProps} size='small' color={color as MuiIconButtonProps['color']}>
       {icon}
     </IconButton>
   );

--- a/packages/mui/src/MultiSchemaFieldTemplate/MultiSchemaFieldTemplate.tsx
+++ b/packages/mui/src/MultiSchemaFieldTemplate/MultiSchemaFieldTemplate.tsx
@@ -1,17 +1,32 @@
-import Box from '@mui/material/Box';
-import { FormContextType, MultiSchemaFieldTemplateProps, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
-import FormControl from '@mui/material/FormControl';
+import Box, { BoxProps } from '@mui/material/Box';
+import {
+  FormContextType,
+  MultiSchemaFieldTemplateProps,
+  RJSFSchema,
+  StrictRJSFSchema,
+  getUiOptions,
+} from '@rjsf/utils';
+import FormControl, { FormControlProps } from '@mui/material/FormControl';
+import { getMuiProps } from '../util';
 
 export default function MultiSchemaFieldTemplate<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: MultiSchemaFieldTemplateProps<T, S, F>) {
-  const { optionSchemaField, selector } = props;
+  const { optionSchemaField, selector, uiSchema, registry } = props;
+
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options: uiOptions,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
-    <Box sx={{ mb: 2 }}>
-      <FormControl fullWidth sx={{ mb: 2 }}>
+    <Box sx={{ mb: 2 }} {...(otherMuiProps as BoxProps)} {...(muiSlotProps?.box as BoxProps)}>
+      <FormControl fullWidth sx={{ mb: 2 }} {...(muiSlotProps?.formControl as FormControlProps)}>
         {selector}
       </FormControl>
       {optionSchemaField}

--- a/packages/mui/src/MultiSchemaFieldTemplate/MultiSchemaFieldTemplate.tsx
+++ b/packages/mui/src/MultiSchemaFieldTemplate/MultiSchemaFieldTemplate.tsx
@@ -10,10 +10,10 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the MultiSchemaFieldTemplate. */
+/** Properties available for the `rjsfSlotProps` target of the MultiSchemaFieldTemplate. */
 export interface MultiSchemaFieldTemplateMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the MultiSchemaFieldTemplate. */
+  rjsfSlotProps?: {
     /** Props applied to the wrapper `Box` container. */
     box?: BoxProps;
     /** Props applied to the MUI `FormControl` wrapping the selector. */
@@ -29,11 +29,10 @@ export default function MultiSchemaFieldTemplate<
   const { optionSchemaField, selector, uiSchema } = props;
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F, MultiSchemaFieldTemplateMuiProps>(uiOptions);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps } = getMuiProps<T, S, F, MultiSchemaFieldTemplateMuiProps>(uiOptions);
 
   return (
-    <Box sx={{ mb: 2 }} {...otherMuiProps} {...muiSlotProps?.box}>
+    <Box sx={{ mb: 2 }} {...muiSlotProps?.box}>
       <FormControl fullWidth sx={{ mb: 2 }} {...muiSlotProps?.formControl}>
         {selector}
       </FormControl>

--- a/packages/mui/src/MultiSchemaFieldTemplate/MultiSchemaFieldTemplate.tsx
+++ b/packages/mui/src/MultiSchemaFieldTemplate/MultiSchemaFieldTemplate.tsx
@@ -1,13 +1,25 @@
 import Box, { BoxProps } from '@mui/material/Box';
+import FormControl, { FormControlProps } from '@mui/material/FormControl';
 import {
   FormContextType,
+  GenericObjectType,
   MultiSchemaFieldTemplateProps,
   RJSFSchema,
   StrictRJSFSchema,
   getUiOptions,
 } from '@rjsf/utils';
-import FormControl, { FormControlProps } from '@mui/material/FormControl';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the MultiSchemaFieldTemplate. */
+export interface MultiSchemaFieldTemplateMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the wrapper `Box` container. */
+    box?: BoxProps;
+    /** Props applied to the MUI `FormControl` wrapping the selector. */
+    formControl?: FormControlProps;
+  };
+}
 
 export default function MultiSchemaFieldTemplate<
   T = any,
@@ -17,12 +29,12 @@ export default function MultiSchemaFieldTemplate<
   const { optionSchemaField, selector, uiSchema } = props;
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>(uiOptions);
+  const muiProps = getMuiProps<T, S, F, MultiSchemaFieldTemplateMuiProps>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
-    <Box sx={{ mb: 2 }} {...(otherMuiProps as BoxProps)} {...(muiSlotProps?.box as BoxProps)}>
-      <FormControl fullWidth sx={{ mb: 2 }} {...(muiSlotProps?.formControl as FormControlProps)}>
+    <Box sx={{ mb: 2 }} {...otherMuiProps} {...muiSlotProps?.box}>
+      <FormControl fullWidth sx={{ mb: 2 }} {...muiSlotProps?.formControl}>
         {selector}
       </FormControl>
       {optionSchemaField}

--- a/packages/mui/src/MultiSchemaFieldTemplate/MultiSchemaFieldTemplate.tsx
+++ b/packages/mui/src/MultiSchemaFieldTemplate/MultiSchemaFieldTemplate.tsx
@@ -15,9 +15,9 @@ export interface MultiSchemaFieldTemplateMuiProps extends GenericObjectType {
   /** RJSF-specific slot props for targeting child elements of the MultiSchemaFieldTemplate. */
   rjsfSlotProps?: {
     /** Props applied to the wrapper `Box` container. */
-    box?: BoxProps;
+    multiBox?: BoxProps;
     /** Props applied to the MUI `FormControl` wrapping the selector. */
-    formControl?: FormControlProps;
+    multiFormControl?: FormControlProps;
   };
 }
 
@@ -32,8 +32,8 @@ export default function MultiSchemaFieldTemplate<
   const { rjsfSlotProps: muiSlotProps } = getMuiProps<T, S, F, MultiSchemaFieldTemplateMuiProps>(uiOptions);
 
   return (
-    <Box sx={{ mb: 2 }} {...muiSlotProps?.box}>
-      <FormControl fullWidth sx={{ mb: 2 }} {...muiSlotProps?.formControl}>
+    <Box sx={{ mb: 2 }} {...muiSlotProps?.multiBox}>
+      <FormControl fullWidth sx={{ mb: 2 }} {...muiSlotProps?.multiFormControl}>
         {selector}
       </FormControl>
       {optionSchemaField}

--- a/packages/mui/src/MultiSchemaFieldTemplate/MultiSchemaFieldTemplate.tsx
+++ b/packages/mui/src/MultiSchemaFieldTemplate/MultiSchemaFieldTemplate.tsx
@@ -14,14 +14,10 @@ export default function MultiSchemaFieldTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: MultiSchemaFieldTemplateProps<T, S, F>) {
-  const { optionSchemaField, selector, uiSchema, registry } = props;
+  const { optionSchemaField, selector, uiSchema } = props;
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options: uiOptions,
-  });
+  const muiProps = getMuiProps<T, S, F>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (

--- a/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -1,4 +1,4 @@
-import Grid from '@mui/material/Grid';
+import Grid, { GridProps } from '@mui/material/Grid';
 import {
   FormContextType,
   ObjectFieldTemplateProps,
@@ -11,6 +11,7 @@ import {
   titleId,
   buttonId,
 } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `ObjectFieldTemplate` is the template to use to render all the inner properties of an object along with the
  * title and description if available. If the object is expandable, then an `AddButton` is also rendered after all
@@ -50,6 +51,14 @@ export default function ObjectFieldTemplate<
   const {
     ButtonTemplates: { AddButton },
   } = registry.templates;
+
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options: uiOptions,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   return (
     <>
       {title && (
@@ -72,7 +81,13 @@ export default function ObjectFieldTemplate<
           registry={registry}
         />
       )}
-      <Grid container spacing={2} style={{ marginTop: '10px' }}>
+      <Grid
+        container
+        spacing={2}
+        style={{ marginTop: '10px' }}
+        {...(otherMuiProps as GridProps)}
+        {...(muiSlotProps?.grid as GridProps)}
+      >
         {!showOptionalDataControlInTitle ? optionalDataControl : undefined}
         {properties.map((element, index) =>
           // Remove the <Grid> if the inner element is hidden as the <Grid>
@@ -80,15 +95,15 @@ export default function ObjectFieldTemplate<
           element.hidden ? (
             element.content
           ) : (
-            <Grid size={{ xs: 12 }} key={index} style={{ marginBottom: '10px' }}>
+            <Grid size={{ xs: 12 }} key={index} style={{ marginBottom: '10px' }} {...(muiSlotProps?.grid as GridProps)}>
               {element.content}
             </Grid>
           ),
         )}
       </Grid>
       {canExpand<T, S, F>(schema, uiSchema, formData) && (
-        <Grid container justifyContent='flex-end'>
-          <Grid>
+        <Grid container justifyContent='flex-end' {...(muiSlotProps?.grid as GridProps)}>
+          <Grid {...(muiSlotProps?.grid as GridProps)}>
             <AddButton
               id={buttonId(fieldPathId, 'add')}
               className='rjsf-object-property-expand'

--- a/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -19,13 +19,13 @@ export interface ObjectFieldTemplateMuiProps extends GenericObjectType {
   /** RJSF-specific slot props for targeting child elements of the ObjectFieldTemplate. */
   rjsfSlotProps?: {
     /** Props applied to the outermost `Grid` container wrapping all object properties. */
-    gridContainer?: GridProps;
+    objectGridContainer?: GridProps;
     /** Props applied to the `Grid` item wrapping each individual object property. */
-    gridItem?: GridProps;
+    objectGridItem?: GridProps;
     /** Props applied to the wrapper `Grid` container next to the Add Button (when expandable). */
-    addButtonGridContainer?: GridProps;
+    objectAddButtonGridContainer?: GridProps;
     /** Props applied to the `Grid` item containing the Add Button. */
-    addButtonGridItem?: GridProps;
+    objectAddButtonGridItem?: GridProps;
   };
 }
 
@@ -92,7 +92,7 @@ export default function ObjectFieldTemplate<
           registry={registry}
         />
       )}
-      <Grid container spacing={2} style={{ marginTop: '10px' }} {...muiSlotProps?.gridContainer}>
+      <Grid container spacing={2} style={{ marginTop: '10px' }} {...muiSlotProps?.objectGridContainer}>
         {!showOptionalDataControlInTitle ? optionalDataControl : undefined}
         {properties.map((element, index) =>
           // Remove the <Grid> if the inner element is hidden as the <Grid>
@@ -100,15 +100,15 @@ export default function ObjectFieldTemplate<
           element.hidden ? (
             element.content
           ) : (
-            <Grid size={{ xs: 12 }} key={index} style={{ marginBottom: '10px' }} {...muiSlotProps?.gridItem}>
+            <Grid size={{ xs: 12 }} key={index} style={{ marginBottom: '10px' }} {...muiSlotProps?.objectGridItem}>
               {element.content}
             </Grid>
           ),
         )}
       </Grid>
       {canExpand<T, S, F>(schema, uiSchema, formData) && (
-        <Grid container justifyContent='flex-end' {...muiSlotProps?.addButtonGridContainer}>
-          <Grid {...muiSlotProps?.addButtonGridItem}>
+        <Grid container justifyContent='flex-end' {...muiSlotProps?.objectAddButtonGridContainer}>
+          <Grid {...muiSlotProps?.objectAddButtonGridItem}>
             <AddButton
               id={buttonId(fieldPathId, 'add')}
               className='rjsf-object-property-expand'

--- a/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -1,6 +1,7 @@
 import Grid, { GridProps } from '@mui/material/Grid';
 import {
   FormContextType,
+  GenericObjectType,
   ObjectFieldTemplateProps,
   RJSFSchema,
   StrictRJSFSchema,
@@ -12,6 +13,21 @@ import {
   buttonId,
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the ObjectFieldTemplate. */
+export interface ObjectFieldTemplateMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the outermost `Grid` container wrapping all object properties. */
+    gridContainer?: GridProps;
+    /** Props applied to the `Grid` item wrapping each individual object property. */
+    gridItem?: GridProps;
+    /** Props applied to the wrapper `Grid` container next to the Add Button (when expandable). */
+    addButtonGridContainer?: GridProps;
+    /** Props applied to the `Grid` item containing the Add Button. */
+    addButtonGridItem?: GridProps;
+  };
+}
 
 /** The `ObjectFieldTemplate` is the template to use to render all the inner properties of an object along with the
  * title and description if available. If the object is expandable, then an `AddButton` is also rendered after all
@@ -52,7 +68,7 @@ export default function ObjectFieldTemplate<
     ButtonTemplates: { AddButton },
   } = registry.templates;
 
-  const muiProps = getMuiProps<T, S, F>(uiOptions);
+  const muiProps = getMuiProps<T, S, F, ObjectFieldTemplateMuiProps>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
@@ -77,13 +93,7 @@ export default function ObjectFieldTemplate<
           registry={registry}
         />
       )}
-      <Grid
-        container
-        spacing={2}
-        style={{ marginTop: '10px' }}
-        {...(otherMuiProps as GridProps)}
-        {...(muiSlotProps?.grid as GridProps)}
-      >
+      <Grid container spacing={2} style={{ marginTop: '10px' }} {...otherMuiProps} {...muiSlotProps?.gridContainer}>
         {!showOptionalDataControlInTitle ? optionalDataControl : undefined}
         {properties.map((element, index) =>
           // Remove the <Grid> if the inner element is hidden as the <Grid>
@@ -91,15 +101,15 @@ export default function ObjectFieldTemplate<
           element.hidden ? (
             element.content
           ) : (
-            <Grid size={{ xs: 12 }} key={index} style={{ marginBottom: '10px' }} {...(muiSlotProps?.grid as GridProps)}>
+            <Grid size={{ xs: 12 }} key={index} style={{ marginBottom: '10px' }} {...muiSlotProps?.gridItem}>
               {element.content}
             </Grid>
           ),
         )}
       </Grid>
       {canExpand<T, S, F>(schema, uiSchema, formData) && (
-        <Grid container justifyContent='flex-end' {...(muiSlotProps?.grid as GridProps)}>
-          <Grid {...(muiSlotProps?.grid as GridProps)}>
+        <Grid container justifyContent='flex-end' {...muiSlotProps?.addButtonGridContainer}>
+          <Grid {...muiSlotProps?.addButtonGridItem}>
             <AddButton
               id={buttonId(fieldPathId, 'add')}
               className='rjsf-object-property-expand'

--- a/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -14,10 +14,10 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the ObjectFieldTemplate. */
+/** Properties available for the `rjsfSlotProps` target of the ObjectFieldTemplate. */
 export interface ObjectFieldTemplateMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the ObjectFieldTemplate. */
+  rjsfSlotProps?: {
     /** Props applied to the outermost `Grid` container wrapping all object properties. */
     gridContainer?: GridProps;
     /** Props applied to the `Grid` item wrapping each individual object property. */
@@ -68,8 +68,7 @@ export default function ObjectFieldTemplate<
     ButtonTemplates: { AddButton },
   } = registry.templates;
 
-  const muiProps = getMuiProps<T, S, F, ObjectFieldTemplateMuiProps>(uiOptions);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps } = getMuiProps<T, S, F, ObjectFieldTemplateMuiProps>(uiOptions);
 
   return (
     <>
@@ -93,7 +92,7 @@ export default function ObjectFieldTemplate<
           registry={registry}
         />
       )}
-      <Grid container spacing={2} style={{ marginTop: '10px' }} {...otherMuiProps} {...muiSlotProps?.gridContainer}>
+      <Grid container spacing={2} style={{ marginTop: '10px' }} {...muiSlotProps?.gridContainer}>
         {!showOptionalDataControlInTitle ? optionalDataControl : undefined}
         {properties.map((element, index) =>
           // Remove the <Grid> if the inner element is hidden as the <Grid>

--- a/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -52,11 +52,7 @@ export default function ObjectFieldTemplate<
     ButtonTemplates: { AddButton },
   } = registry.templates;
 
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options: uiOptions,
-  });
+  const muiProps = getMuiProps<T, S, F>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (

--- a/packages/mui/src/OptionalDataControlsTemplate/OptionalDataControlsTemplate.tsx
+++ b/packages/mui/src/OptionalDataControlsTemplate/OptionalDataControlsTemplate.tsx
@@ -16,12 +16,13 @@ export default function OptionalDataControlsTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: OptionalDataControlsTemplateProps<T, S, F>) {
-  const { id, registry, label, onAddClick, onRemoveClick } = props;
+  const { id, registry, label, onAddClick, onRemoveClick, uiSchema } = props;
   if (onAddClick) {
     return (
       <IconButton
         id={id}
         registry={registry}
+        uiSchema={uiSchema}
         className='rjsf-add-optional-data'
         onClick={onAddClick}
         title={label}
@@ -33,6 +34,7 @@ export default function OptionalDataControlsTemplate<
       <RemoveButton
         id={id}
         registry={registry}
+        uiSchema={uiSchema}
         className='rjsf-remove-optional-data'
         onClick={onRemoveClick}
         title={label}

--- a/packages/mui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/mui/src/RadioWidget/RadioWidget.tsx
@@ -1,8 +1,8 @@
 import { FocusEvent } from 'react';
-import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControlLabel, { FormControlLabelProps } from '@mui/material/FormControlLabel';
 import FormLabel from '@mui/material/FormLabel';
-import Radio from '@mui/material/Radio';
-import RadioGroup from '@mui/material/RadioGroup';
+import Radio, { RadioProps } from '@mui/material/Radio';
+import RadioGroup, { RadioGroupProps } from '@mui/material/RadioGroup';
 import {
   ariaDescribedByIds,
   enumOptionsIndexForValue,
@@ -14,26 +14,32 @@ import {
   StrictRJSFSchema,
   WidgetProps,
 } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `RadioWidget` is a widget for rendering a radio group.
  *  It is typically used with a string property constrained with enum options.
  *
  * @param props - The `WidgetProps` for this component
  */
-export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>({
-  id,
-  htmlName,
-  options,
-  value,
-  required,
-  disabled,
-  readonly,
-  label,
-  hideLabel,
-  onChange,
-  onBlur,
-  onFocus,
-}: WidgetProps<T, S, F>) {
+export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: WidgetProps<T, S, F>,
+) {
+  const {
+    id,
+    htmlName,
+    options,
+    value,
+    required,
+    disabled,
+    readonly,
+    label,
+    hideLabel,
+    onChange,
+    onBlur,
+    onFocus,
+    registry,
+    uiSchema,
+  } = props;
   const { enumOptions, enumDisabled, emptyValue } = options;
 
   const _onChange = (_: any, value: any) => onChange(enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
@@ -45,6 +51,13 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
   const row = options ? options.inline : false;
   const selectedIndex = enumOptionsIndexForValue<S>(value, enumOptions) ?? null;
 
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   return (
     <>
       {labelValue(
@@ -54,6 +67,7 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
         hideLabel,
       )}
       <RadioGroup
+        {...(otherMuiProps as RadioGroupProps)}
         id={id}
         name={htmlName || id}
         value={selectedIndex}
@@ -68,7 +82,16 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
             const itemDisabled = Array.isArray(enumDisabled) && enumDisabled.indexOf(option.value) !== -1;
             const radio = (
               <FormControlLabel
-                control={<Radio name={htmlName || id} id={optionId(id, index)} color='primary' />}
+                {...(muiSlotProps?.formControlLabel as FormControlLabelProps)}
+                control={
+                  <Radio
+                    {...(otherMuiProps as RadioProps)}
+                    {...(muiSlotProps?.radio as RadioProps)}
+                    name={htmlName || id}
+                    id={optionId(id, index)}
+                    color='primary'
+                  />
+                }
                 label={option.label}
                 value={String(index)}
                 key={index}

--- a/packages/mui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/mui/src/RadioWidget/RadioWidget.tsx
@@ -24,22 +24,8 @@ import { getMuiProps } from '../util';
 export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: WidgetProps<T, S, F>,
 ) {
-  const {
-    id,
-    htmlName,
-    options,
-    value,
-    required,
-    disabled,
-    readonly,
-    label,
-    hideLabel,
-    onChange,
-    onBlur,
-    onFocus,
-    registry,
-    uiSchema,
-  } = props;
+  const { id, htmlName, options, value, required, disabled, readonly, label, hideLabel, onChange, onBlur, onFocus } =
+    props;
   const { enumOptions, enumDisabled, emptyValue } = options;
 
   const _onChange = (_: any, value: any) => onChange(enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
@@ -51,11 +37,7 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
   const row = options ? options.inline : false;
   const selectedIndex = enumOptionsIndexForValue<S>(value, enumOptions) ?? null;
 
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options,
-  });
+  const muiProps = getMuiProps<T, S, F>(options);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (

--- a/packages/mui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/mui/src/RadioWidget/RadioWidget.tsx
@@ -10,11 +10,25 @@ import {
   labelValue,
   optionId,
   FormContextType,
+  GenericObjectType,
   RJSFSchema,
   StrictRJSFSchema,
   WidgetProps,
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the RadioWidget. */
+export interface RadioWidgetMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the `RadioGroup` component. */
+    radioGroup?: RadioGroupProps;
+    /** Props applied to the individual `Radio` components. */
+    radio?: RadioProps;
+    /** Props applied to the `FormControlLabel` components wrapping each radio button. */
+    formControlLabel?: FormControlLabelProps;
+  };
+}
 
 /** The `RadioWidget` is a widget for rendering a radio group.
  *  It is typically used with a string property constrained with enum options.
@@ -37,7 +51,7 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
   const row = options ? options.inline : false;
   const selectedIndex = enumOptionsIndexForValue<S>(value, enumOptions) ?? null;
 
-  const muiProps = getMuiProps<T, S, F>(options);
+  const muiProps = getMuiProps<T, S, F, RadioWidgetMuiProps>(options);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
@@ -49,7 +63,8 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
         hideLabel,
       )}
       <RadioGroup
-        {...(otherMuiProps as RadioGroupProps)}
+        {...otherMuiProps}
+        {...muiSlotProps?.radioGroup}
         id={id}
         name={htmlName || id}
         value={selectedIndex}
@@ -64,15 +79,9 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
             const itemDisabled = Array.isArray(enumDisabled) && enumDisabled.indexOf(option.value) !== -1;
             const radio = (
               <FormControlLabel
-                {...(muiSlotProps?.formControlLabel as FormControlLabelProps)}
+                {...muiSlotProps?.formControlLabel}
                 control={
-                  <Radio
-                    {...(otherMuiProps as RadioProps)}
-                    {...(muiSlotProps?.radio as RadioProps)}
-                    name={htmlName || id}
-                    id={optionId(id, index)}
-                    color='primary'
-                  />
+                  <Radio {...muiSlotProps?.radio} name={htmlName || id} id={optionId(id, index)} color='primary' />
                 }
                 label={option.label}
                 value={String(index)}

--- a/packages/mui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/mui/src/RadioWidget/RadioWidget.tsx
@@ -17,10 +17,10 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the RadioWidget. */
+/** Properties available for the `rjsfSlotProps` target of the RadioWidget. */
 export interface RadioWidgetMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the RadioWidget. */
+  rjsfSlotProps?: {
     /** Props applied to the `RadioGroup` component. */
     radioGroup?: RadioGroupProps;
     /** Props applied to the individual `Radio` components. */
@@ -51,8 +51,7 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
   const row = options ? options.inline : false;
   const selectedIndex = enumOptionsIndexForValue<S>(value, enumOptions) ?? null;
 
-  const muiProps = getMuiProps<T, S, F, RadioWidgetMuiProps>(options);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps, ...otherMuiProps } = getMuiProps<T, S, F, RadioWidgetMuiProps>(options);
 
   return (
     <>

--- a/packages/mui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/mui/src/RangeWidget/RangeWidget.tsx
@@ -1,6 +1,6 @@
 import { FocusEvent } from 'react';
 import FormLabel from '@mui/material/FormLabel';
-import Slider from '@mui/material/Slider';
+import Slider, { SliderProps } from '@mui/material/Slider';
 import {
   ariaDescribedByIds,
   labelValue,
@@ -10,6 +10,7 @@ import {
   WidgetProps,
   rangeSpec,
 } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `RangeWidget` component uses the `BaseInputTemplate` changing the type to `range` and wrapping the result
  * in a div, with the value along side it.
@@ -19,8 +20,22 @@ import {
 export default function RangeWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: WidgetProps<T, S, F>,
 ) {
-  const { value, readonly, disabled, onBlur, onFocus, options, schema, onChange, required, label, hideLabel, id } =
-    props;
+  const {
+    value,
+    readonly,
+    disabled,
+    onBlur,
+    onFocus,
+    options,
+    schema,
+    onChange,
+    required,
+    label,
+    hideLabel,
+    id,
+    registry,
+    uiSchema,
+  } = props;
   const sliderProps = { value, label, id, name: id, ...rangeSpec<S>(schema) };
 
   const _onChange = (_: any, value?: number | number[]) => {
@@ -28,6 +43,13 @@ export default function RangeWidget<T = any, S extends StrictRJSFSchema = RJSFSc
   };
   const _onBlur = ({ target }: FocusEvent<HTMLInputElement>) => onBlur(id, target && target.value);
   const _onFocus = ({ target }: FocusEvent<HTMLInputElement>) => onFocus(id, target && target.value);
+
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
     <>
@@ -38,12 +60,16 @@ export default function RangeWidget<T = any, S extends StrictRJSFSchema = RJSFSc
         hideLabel,
       )}
       <Slider
+        {...(otherMuiProps as SliderProps)}
         disabled={disabled || readonly}
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
         valueLabelDisplay='auto'
         {...sliderProps}
+        slotProps={{
+          ...muiSlotProps,
+        }}
         aria-describedby={ariaDescribedByIds(id)}
       />
     </>

--- a/packages/mui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/mui/src/RangeWidget/RangeWidget.tsx
@@ -20,22 +20,8 @@ import { getMuiProps } from '../util';
 export default function RangeWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: WidgetProps<T, S, F>,
 ) {
-  const {
-    value,
-    readonly,
-    disabled,
-    onBlur,
-    onFocus,
-    options,
-    schema,
-    onChange,
-    required,
-    label,
-    hideLabel,
-    id,
-    registry,
-    uiSchema,
-  } = props;
+  const { value, readonly, disabled, onBlur, onFocus, options, schema, onChange, required, label, hideLabel, id } =
+    props;
   const sliderProps = { value, label, id, name: id, ...rangeSpec<S>(schema) };
 
   const _onChange = (_: any, value?: number | number[]) => {
@@ -44,12 +30,7 @@ export default function RangeWidget<T = any, S extends StrictRJSFSchema = RJSFSc
   const _onBlur = ({ target }: FocusEvent<HTMLInputElement>) => onBlur(id, target && target.value);
   const _onFocus = ({ target }: FocusEvent<HTMLInputElement>) => onFocus(id, target && target.value);
 
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options,
-  });
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const muiProps = getMuiProps<T, S, F, SliderProps>(options);
 
   return (
     <>
@@ -60,16 +41,13 @@ export default function RangeWidget<T = any, S extends StrictRJSFSchema = RJSFSc
         hideLabel,
       )}
       <Slider
-        {...(otherMuiProps as SliderProps)}
+        {...muiProps}
         disabled={disabled || readonly}
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
         valueLabelDisplay='auto'
         {...sliderProps}
-        slotProps={{
-          ...muiSlotProps,
-        }}
         aria-describedby={ariaDescribedByIds(id)}
       />
     </>

--- a/packages/mui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/mui/src/RangeWidget/RangeWidget.tsx
@@ -5,12 +5,22 @@ import {
   ariaDescribedByIds,
   labelValue,
   FormContextType,
+  GenericObjectType,
   RJSFSchema,
   StrictRJSFSchema,
   WidgetProps,
   rangeSpec,
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the RangeWidget. */
+export interface RangeWidgetMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the MUI `Slider` component. */
+    slider?: SliderProps;
+  };
+}
 
 /** The `RangeWidget` component uses the `BaseInputTemplate` changing the type to `range` and wrapping the result
  * in a div, with the value along side it.
@@ -30,7 +40,8 @@ export default function RangeWidget<T = any, S extends StrictRJSFSchema = RJSFSc
   const _onBlur = ({ target }: FocusEvent<HTMLInputElement>) => onBlur(id, target && target.value);
   const _onFocus = ({ target }: FocusEvent<HTMLInputElement>) => onFocus(id, target && target.value);
 
-  const muiProps = getMuiProps<T, S, F, SliderProps>(options);
+  const muiProps = getMuiProps<T, S, F, RangeWidgetMuiProps>(options);
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
     <>
@@ -41,12 +52,13 @@ export default function RangeWidget<T = any, S extends StrictRJSFSchema = RJSFSc
         hideLabel,
       )}
       <Slider
-        {...muiProps}
         disabled={disabled || readonly}
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
         valueLabelDisplay='auto'
+        {...otherMuiProps}
+        {...muiSlotProps?.slider}
         {...sliderProps}
         aria-describedby={ariaDescribedByIds(id)}
       />

--- a/packages/mui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/mui/src/RangeWidget/RangeWidget.tsx
@@ -13,10 +13,10 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the RangeWidget. */
+/** Properties available for the `rjsfSlotProps` target of the RangeWidget. */
 export interface RangeWidgetMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the RangeWidget. */
+  rjsfSlotProps?: {
     /** Props applied to the MUI `Slider` component. */
     slider?: SliderProps;
   };
@@ -40,8 +40,7 @@ export default function RangeWidget<T = any, S extends StrictRJSFSchema = RJSFSc
   const _onBlur = ({ target }: FocusEvent<HTMLInputElement>) => onBlur(id, target && target.value);
   const _onFocus = ({ target }: FocusEvent<HTMLInputElement>) => onFocus(id, target && target.value);
 
-  const muiProps = getMuiProps<T, S, F, RangeWidgetMuiProps>(options);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps, ...otherMuiProps } = getMuiProps<T, S, F, RangeWidgetMuiProps>(options);
 
   return (
     <>

--- a/packages/mui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/mui/src/SelectWidget/SelectWidget.tsx
@@ -11,47 +11,48 @@ import {
   StrictRJSFSchema,
   WidgetProps,
 } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `SelectWidget` is a widget for rendering dropdowns.
  *  It is typically used with string properties constrained with enum options.
  *
  * @param props - The `WidgetProps` for this component
  */
-export default function SelectWidget<
-  T = any,
-  S extends StrictRJSFSchema = RJSFSchema,
-  F extends FormContextType = any,
->({
-  schema,
-  id,
-  name, // remove this from textFieldProps
-  htmlName,
-  options,
-  label,
-  hideLabel,
-  required,
-  disabled,
-  placeholder,
-  readonly,
-  value,
-  multiple,
-  autofocus,
-  onChange,
-  onBlur,
-  onFocus,
-  errorSchema,
-  rawErrors = [],
-  registry,
-  uiSchema,
-  hideError,
-  ...textFieldProps
-}: WidgetProps<T, S, F>) {
+export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: WidgetProps<T, S, F>,
+) {
+  const {
+    schema,
+    id,
+    name, // remove this from textFieldProps
+    htmlName,
+    options,
+    label,
+    hideLabel,
+    required,
+    disabled,
+    placeholder,
+    readonly,
+    value,
+    multiple,
+    autofocus,
+    onChange,
+    onBlur,
+    onFocus,
+    errorSchema,
+    rawErrors = [],
+    registry,
+    uiSchema,
+    hideError,
+    ...textFieldProps
+  } = props;
   const { enumOptions, enumDisabled, emptyValue: optEmptyVal } = options;
 
-  multiple = typeof multiple === 'undefined' ? false : !!multiple;
+  const isMultiple = typeof multiple === 'undefined' ? false : !!multiple;
 
-  const emptyValue = multiple ? [] : '';
-  const isEmpty = typeof value === 'undefined' || (multiple && value.length < 1) || (!multiple && value === emptyValue);
+  const emptyValue = isMultiple ? [] : '';
+  const isEmpty =
+    typeof value === 'undefined' || (isMultiple && value.length < 1) || (!isMultiple && value === emptyValue);
 
   const _onChange = ({ target: { value } }: ChangeEvent<{ value: string }>) =>
     onChange(enumOptionsValueForIndex<S>(value, enumOptions, optEmptyVal));
@@ -59,9 +60,16 @@ export default function SelectWidget<
     onBlur(id, enumOptionsValueForIndex<S>(target && target.value, enumOptions, optEmptyVal));
   const _onFocus = ({ target }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(target && target.value, enumOptions, optEmptyVal));
-  const selectedIndexes = enumOptionsIndexForValue<S>(value, enumOptions, multiple);
+  const selectedIndexes = enumOptionsIndexForValue<S>(value, enumOptions, isMultiple);
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   const { InputLabelProps, SelectProps, autocomplete, ...textFieldRemainingProps } = textFieldProps;
-  const showPlaceholderOption = !multiple && schema.default === undefined;
+  const showPlaceholderOption = !isMultiple && schema.default === undefined;
 
   return (
     <TextField
@@ -78,13 +86,19 @@ export default function SelectWidget<
       onChange={_onChange}
       onBlur={_onBlur}
       onFocus={_onFocus}
+      {...otherMuiProps}
       {...(textFieldRemainingProps as TextFieldProps)}
       select // Apply this and the following props after the potential overrides defined in textFieldProps
+      slotProps={{
+        ...muiSlotProps,
+      }}
       InputLabelProps={{
+        ...muiSlotProps?.inputLabel,
         ...InputLabelProps,
         shrink: !isEmpty,
       }}
       SelectProps={{
+        ...muiSlotProps?.select,
         ...SelectProps,
         multiple,
       }}

--- a/packages/mui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/mui/src/SelectWidget/SelectWidget.tsx
@@ -61,11 +61,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
   const _onFocus = ({ target }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(target && target.value, enumOptions, optEmptyVal));
   const selectedIndexes = enumOptionsIndexForValue<S>(value, enumOptions, isMultiple);
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options,
-  });
+  const muiProps = getMuiProps<T, S, F, TextFieldProps>(options);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   const { InputLabelProps, SelectProps, autocomplete, ...textFieldRemainingProps } = textFieldProps;

--- a/packages/mui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/mui/src/SelectWidget/SelectWidget.tsx
@@ -1,17 +1,33 @@
 import { ChangeEvent, FocusEvent } from 'react';
 import MenuItem from '@mui/material/MenuItem';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
+import { InputLabelProps as MuiInputLabelProps } from '@mui/material/InputLabel';
+import { SelectProps as MuiSelectProps } from '@mui/material/Select';
 import {
   ariaDescribedByIds,
   enumOptionsIndexForValue,
   enumOptionsValueForIndex,
   labelValue,
   FormContextType,
+  GenericObjectType,
   RJSFSchema,
   StrictRJSFSchema,
   WidgetProps,
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the SelectWidget. */
+export interface SelectWidgetMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the `InputLabel` element. */
+    inputLabel?: MuiInputLabelProps;
+    /** Props applied to the `Select` element. */
+    select?: MuiSelectProps;
+    /** Any other slotProps targetable by `TextField` internally. */
+    [key: string]: any;
+  };
+}
 
 /** The `SelectWidget` is a widget for rendering dropdowns.
  *  It is typically used with string properties constrained with enum options.
@@ -61,7 +77,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
   const _onFocus = ({ target }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(target && target.value, enumOptions, optEmptyVal));
   const selectedIndexes = enumOptionsIndexForValue<S>(value, enumOptions, isMultiple);
-  const muiProps = getMuiProps<T, S, F, TextFieldProps>(options);
+  const muiProps = getMuiProps<T, S, F, SelectWidgetMuiProps>(options);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   const { InputLabelProps, SelectProps, autocomplete, ...textFieldRemainingProps } = textFieldProps;
@@ -82,21 +98,18 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
       onChange={_onChange}
       onBlur={_onBlur}
       onFocus={_onFocus}
-      {...otherMuiProps}
-      {...(textFieldRemainingProps as TextFieldProps)}
+      {...({ ...otherMuiProps, ...textFieldRemainingProps } as TextFieldProps)}
       select // Apply this and the following props after the potential overrides defined in textFieldProps
       slotProps={{
         ...muiSlotProps,
-      }}
-      InputLabelProps={{
-        ...muiSlotProps?.inputLabel,
-        ...InputLabelProps,
-        shrink: !isEmpty,
-      }}
-      SelectProps={{
-        ...muiSlotProps?.select,
-        ...SelectProps,
-        multiple,
+        inputLabel: {
+          ...muiSlotProps?.inputLabel,
+          shrink: !isEmpty,
+        },
+        select: {
+          ...muiSlotProps?.select,
+          multiple,
+        },
       }}
       aria-describedby={ariaDescribedByIds(id)}
     >

--- a/packages/mui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/mui/src/SelectWidget/SelectWidget.tsx
@@ -16,16 +16,14 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the SelectWidget. */
+/** Properties available for the `rjsfSlotProps` target of the SelectWidget. */
 export interface SelectWidgetMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the SelectWidget. */
+  rjsfSlotProps?: {
     /** Props applied to the `InputLabel` element. */
     inputLabel?: MuiInputLabelProps;
     /** Props applied to the `Select` element. */
     select?: MuiSelectProps;
-    /** Any other slotProps targetable by `TextField` internally. */
-    [key: string]: any;
   };
 }
 
@@ -77,8 +75,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
   const _onFocus = ({ target }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(target && target.value, enumOptions, optEmptyVal));
   const selectedIndexes = enumOptionsIndexForValue<S>(value, enumOptions, isMultiple);
-  const muiProps = getMuiProps<T, S, F, SelectWidgetMuiProps>(options);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps, ...otherMuiProps } = getMuiProps<T, S, F, SelectWidgetMuiProps>(options);
 
   const { InputLabelProps, SelectProps, autocomplete, ...textFieldRemainingProps } = textFieldProps;
   const showPlaceholderOption = !isMultiple && schema.default === undefined;

--- a/packages/mui/src/SubmitButton/SubmitButton.tsx
+++ b/packages/mui/src/SubmitButton/SubmitButton.tsx
@@ -1,6 +1,14 @@
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import { getSubmitButtonOptions, FormContextType, RJSFSchema, StrictRJSFSchema, SubmitButtonProps } from '@rjsf/utils';
+import Box, { BoxProps } from '@mui/material/Box';
+import Button, { ButtonProps } from '@mui/material/Button';
+import {
+  getSubmitButtonOptions,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  SubmitButtonProps,
+  getUiOptions,
+} from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `SubmitButton` renders a button that represent the `Submit` action on a form
  */
@@ -8,14 +16,30 @@ export default function SubmitButton<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
->({ uiSchema }: SubmitButtonProps<T, S, F>) {
+>({ uiSchema, registry }: SubmitButtonProps<T, S, F>) {
   const { submitText, norender, props: submitButtonProps = {} } = getSubmitButtonOptions<T, S, F>(uiSchema);
   if (norender) {
     return null;
   }
+
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options: uiOptions,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   return (
-    <Box marginTop={3}>
-      <Button type='submit' variant='contained' color='primary' {...submitButtonProps}>
+    <Box marginTop={3} {...(muiSlotProps?.box as BoxProps)}>
+      <Button
+        type='submit'
+        variant='contained'
+        color='primary'
+        {...submitButtonProps}
+        {...(otherMuiProps as ButtonProps)}
+        {...(muiSlotProps?.button as ButtonProps)}
+      >
         {submitText}
       </Button>
     </Box>

--- a/packages/mui/src/SubmitButton/SubmitButton.tsx
+++ b/packages/mui/src/SubmitButton/SubmitButton.tsx
@@ -2,6 +2,7 @@ import Box, { BoxProps } from '@mui/material/Box';
 import Button, { ButtonProps } from '@mui/material/Button';
 import {
   getSubmitButtonOptions,
+  GenericObjectType,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -9,6 +10,17 @@ import {
   getUiOptions,
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the SubmitButton. */
+export interface SubmitButtonMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the `Box` wrapper. */
+    box?: BoxProps;
+    /** Props applied to the `Button` element. */
+    button?: ButtonProps;
+  };
+}
 
 /** The `SubmitButton` renders a button that represent the `Submit` action on a form
  */
@@ -23,18 +35,18 @@ export default function SubmitButton<
   }
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>(uiOptions);
+  const muiProps = getMuiProps<T, S, F, SubmitButtonMuiProps>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (
-    <Box marginTop={3} {...(muiSlotProps?.box as BoxProps)}>
+    <Box marginTop={3} {...muiSlotProps?.box}>
       <Button
         type='submit'
         variant='contained'
         color='primary'
         {...submitButtonProps}
-        {...(otherMuiProps as ButtonProps)}
-        {...(muiSlotProps?.button as ButtonProps)}
+        {...otherMuiProps}
+        {...muiSlotProps?.button}
       >
         {submitText}
       </Button>

--- a/packages/mui/src/SubmitButton/SubmitButton.tsx
+++ b/packages/mui/src/SubmitButton/SubmitButton.tsx
@@ -16,9 +16,9 @@ export interface SubmitButtonMuiProps extends GenericObjectType {
   /** RJSF-specific slot props for targeting child elements of the SubmitButton. */
   rjsfSlotProps?: {
     /** Props applied to the `Box` wrapper. */
-    box?: BoxProps;
+    submitBox?: BoxProps;
     /** Props applied to the `Button` element. */
-    button?: ButtonProps;
+    submitButton?: ButtonProps;
   };
 }
 
@@ -38,14 +38,14 @@ export default function SubmitButton<
   const { rjsfSlotProps: muiSlotProps, ...otherMuiProps } = getMuiProps<T, S, F, SubmitButtonMuiProps>(uiOptions);
 
   return (
-    <Box marginTop={3} {...muiSlotProps?.box}>
+    <Box marginTop={3} {...muiSlotProps?.submitBox}>
       <Button
         type='submit'
         variant='contained'
         color='primary'
         {...submitButtonProps}
         {...otherMuiProps}
-        {...muiSlotProps?.button}
+        {...muiSlotProps?.submitButton}
       >
         {submitText}
       </Button>

--- a/packages/mui/src/SubmitButton/SubmitButton.tsx
+++ b/packages/mui/src/SubmitButton/SubmitButton.tsx
@@ -16,18 +16,14 @@ export default function SubmitButton<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
->({ uiSchema, registry }: SubmitButtonProps<T, S, F>) {
+>({ uiSchema }: SubmitButtonProps<T, S, F>) {
   const { submitText, norender, props: submitButtonProps = {} } = getSubmitButtonOptions<T, S, F>(uiSchema);
   if (norender) {
     return null;
   }
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options: uiOptions,
-  });
+  const muiProps = getMuiProps<T, S, F>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   return (

--- a/packages/mui/src/SubmitButton/SubmitButton.tsx
+++ b/packages/mui/src/SubmitButton/SubmitButton.tsx
@@ -11,10 +11,10 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the SubmitButton. */
+/** Properties available for the `rjsfSlotProps` target of the SubmitButton. */
 export interface SubmitButtonMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the SubmitButton. */
+  rjsfSlotProps?: {
     /** Props applied to the `Box` wrapper. */
     box?: BoxProps;
     /** Props applied to the `Button` element. */
@@ -35,8 +35,7 @@ export default function SubmitButton<
   }
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F, SubmitButtonMuiProps>(uiOptions);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps, ...otherMuiProps } = getMuiProps<T, S, F, SubmitButtonMuiProps>(uiOptions);
 
   return (
     <Box marginTop={3} {...muiSlotProps?.box}>

--- a/packages/mui/src/TitleField/TitleField.tsx
+++ b/packages/mui/src/TitleField/TitleField.tsx
@@ -1,31 +1,48 @@
-import Box from '@mui/material/Box';
-import Divider from '@mui/material/Divider';
-import Grid from '@mui/material/Grid';
-import Typography from '@mui/material/Typography';
-import { FormContextType, TitleFieldProps, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import Box, { BoxProps } from '@mui/material/Box';
+import Divider, { DividerProps } from '@mui/material/Divider';
+import Grid, { GridProps } from '@mui/material/Grid';
+import Typography, { TypographyProps } from '@mui/material/Typography';
+import { FormContextType, TitleFieldProps, RJSFSchema, StrictRJSFSchema, getUiOptions } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `TitleField` is the template to use to render the title of a field
  *
  * @param props - The `TitleFieldProps` for this component
  */
-export default function TitleField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>({
-  id,
-  title,
-  optionalDataControl,
-}: TitleFieldProps<T, S, F>) {
-  let heading = <Typography variant='h5'>{title}</Typography>;
+export default function TitleField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: TitleFieldProps<T, S, F>,
+) {
+  const { id, title, optionalDataControl, uiSchema, registry } = props;
+
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options: uiOptions,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
+  let heading = (
+    <Typography variant='h5' {...(otherMuiProps as TypographyProps)} {...(muiSlotProps?.typography as TypographyProps)}>
+      {title}
+    </Typography>
+  );
   if (optionalDataControl) {
     heading = (
-      <Grid container={true} spacing={0}>
-        <Grid size='grow'>{heading}</Grid>
-        <Grid justifyContent='flex-end'>{optionalDataControl}</Grid>
+      <Grid container={true} spacing={0} {...(muiSlotProps?.grid as GridProps)}>
+        <Grid size='grow' {...(muiSlotProps?.grid as GridProps)}>
+          {heading}
+        </Grid>
+        <Grid justifyContent='flex-end' {...(muiSlotProps?.grid as GridProps)}>
+          {optionalDataControl}
+        </Grid>
       </Grid>
     );
   }
   return (
-    <Box id={id} mb={1} mt={1}>
+    <Box id={id} mb={1} mt={1} {...(muiSlotProps?.box as BoxProps)}>
       {heading}
-      <Divider />
+      <Divider {...(muiSlotProps?.divider as DividerProps)} />
     </Box>
   );
 }

--- a/packages/mui/src/TitleField/TitleField.tsx
+++ b/packages/mui/src/TitleField/TitleField.tsx
@@ -2,8 +2,34 @@ import Box, { BoxProps } from '@mui/material/Box';
 import Divider, { DividerProps } from '@mui/material/Divider';
 import Grid, { GridProps } from '@mui/material/Grid';
 import Typography, { TypographyProps } from '@mui/material/Typography';
-import { FormContextType, TitleFieldProps, RJSFSchema, StrictRJSFSchema, getUiOptions } from '@rjsf/utils';
+import {
+  FormContextType,
+  GenericObjectType,
+  TitleFieldProps,
+  RJSFSchema,
+  StrictRJSFSchema,
+  getUiOptions,
+} from '@rjsf/utils';
 import { getMuiProps } from '../util';
+
+/** Properties available for the `slotProps` target of the TitleField. */
+export interface TitleFieldMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the `Box` wrapper. */
+    box?: BoxProps;
+    /** Props applied to the `Divider` element. */
+    divider?: DividerProps;
+    /** Props applied to the `Typography` element used for the title. */
+    typography?: TypographyProps;
+    /** Props applied to the `Grid` container used when `optionalDataControl` is present. */
+    gridContainer?: GridProps;
+    /** Props applied to the `Grid` item containing the title. */
+    gridItem?: GridProps;
+    /** Props applied to the `Grid` item containing the `optionalDataControl`. */
+    optionalDataGridItem?: GridProps;
+  };
+}
 
 /** The `TitleField` is the template to use to render the title of a field
  *
@@ -15,30 +41,30 @@ export default function TitleField<T = any, S extends StrictRJSFSchema = RJSFSch
   const { id, title, optionalDataControl, uiSchema } = props;
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>(uiOptions);
+  const muiProps = getMuiProps<T, S, F, TitleFieldMuiProps>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   let heading = (
-    <Typography variant='h5' {...(muiSlotProps?.typography as TypographyProps)}>
+    <Typography variant='h5' {...muiSlotProps?.typography}>
       {title}
     </Typography>
   );
   if (optionalDataControl) {
     heading = (
-      <Grid container={true} spacing={0} {...(muiSlotProps?.grid as GridProps)}>
-        <Grid size='grow' {...(muiSlotProps?.grid as GridProps)}>
+      <Grid container={true} spacing={0} {...muiSlotProps?.gridContainer}>
+        <Grid size='grow' {...muiSlotProps?.gridItem}>
           {heading}
         </Grid>
-        <Grid justifyContent='flex-end' {...(muiSlotProps?.grid as GridProps)}>
+        <Grid justifyContent='flex-end' {...muiSlotProps?.optionalDataGridItem}>
           {optionalDataControl}
         </Grid>
       </Grid>
     );
   }
   return (
-    <Box id={id} mb={1} mt={1} {...(otherMuiProps as BoxProps)} {...(muiSlotProps?.box as BoxProps)}>
+    <Box id={id} mb={1} mt={1} {...otherMuiProps} {...muiSlotProps?.box}>
       {heading}
-      <Divider {...(muiSlotProps?.divider as DividerProps)} />
+      <Divider {...muiSlotProps?.divider} />
     </Box>
   );
 }

--- a/packages/mui/src/TitleField/TitleField.tsx
+++ b/packages/mui/src/TitleField/TitleField.tsx
@@ -17,17 +17,17 @@ export interface TitleFieldMuiProps extends GenericObjectType {
   /** RJSF-specific slot props for targeting child elements of the TitleField. */
   rjsfSlotProps?: {
     /** Props applied to the `Box` wrapper. */
-    box?: BoxProps;
+    titleBox?: BoxProps;
     /** Props applied to the `Divider` element. */
-    divider?: DividerProps;
+    titleDivider?: DividerProps;
     /** Props applied to the `Typography` element used for the title. */
-    typography?: TypographyProps;
+    titleTypography?: TypographyProps;
     /** Props applied to the `Grid` container used when `optionalDataControl` is present. */
-    gridContainer?: GridProps;
+    titleGridContainer?: GridProps;
     /** Props applied to the `Grid` item containing the title. */
-    gridItem?: GridProps;
+    titleGridItem?: GridProps;
     /** Props applied to the `Grid` item containing the `optionalDataControl`. */
-    optionalDataGridItem?: GridProps;
+    titleOptionalDataGridItem?: GridProps;
   };
 }
 
@@ -44,26 +44,26 @@ export default function TitleField<T = any, S extends StrictRJSFSchema = RJSFSch
   const { rjsfSlotProps: muiSlotProps } = getMuiProps<T, S, F, TitleFieldMuiProps>(uiOptions);
 
   let heading = (
-    <Typography variant='h5' {...muiSlotProps?.typography}>
+    <Typography variant='h5' {...muiSlotProps?.titleTypography}>
       {title}
     </Typography>
   );
   if (optionalDataControl) {
     heading = (
-      <Grid container={true} spacing={0} {...muiSlotProps?.gridContainer}>
-        <Grid size='grow' {...muiSlotProps?.gridItem}>
+      <Grid container={true} spacing={0} {...muiSlotProps?.titleGridContainer}>
+        <Grid size='grow' {...muiSlotProps?.titleGridItem}>
           {heading}
         </Grid>
-        <Grid justifyContent='flex-end' {...muiSlotProps?.optionalDataGridItem}>
+        <Grid justifyContent='flex-end' {...muiSlotProps?.titleOptionalDataGridItem}>
           {optionalDataControl}
         </Grid>
       </Grid>
     );
   }
   return (
-    <Box id={id} mb={1} mt={1} {...muiSlotProps?.box}>
+    <Box id={id} mb={1} mt={1} {...muiSlotProps?.titleBox}>
       {heading}
-      <Divider {...muiSlotProps?.divider} />
+      <Divider {...muiSlotProps?.titleDivider} />
     </Box>
   );
 }

--- a/packages/mui/src/TitleField/TitleField.tsx
+++ b/packages/mui/src/TitleField/TitleField.tsx
@@ -19,7 +19,7 @@ export default function TitleField<T = any, S extends StrictRJSFSchema = RJSFSch
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   let heading = (
-    <Typography variant='h5' {...(otherMuiProps as TypographyProps)} {...(muiSlotProps?.typography as TypographyProps)}>
+    <Typography variant='h5' {...(muiSlotProps?.typography as TypographyProps)}>
       {title}
     </Typography>
   );
@@ -36,7 +36,7 @@ export default function TitleField<T = any, S extends StrictRJSFSchema = RJSFSch
     );
   }
   return (
-    <Box id={id} mb={1} mt={1} {...(muiSlotProps?.box as BoxProps)}>
+    <Box id={id} mb={1} mt={1} {...(otherMuiProps as BoxProps)} {...(muiSlotProps?.box as BoxProps)}>
       {heading}
       <Divider {...(muiSlotProps?.divider as DividerProps)} />
     </Box>

--- a/packages/mui/src/TitleField/TitleField.tsx
+++ b/packages/mui/src/TitleField/TitleField.tsx
@@ -12,10 +12,10 @@ import {
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
 
-/** Properties available for the `slotProps` target of the TitleField. */
+/** Properties available for the `rjsfSlotProps` target of the TitleField. */
 export interface TitleFieldMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the TitleField. */
+  rjsfSlotProps?: {
     /** Props applied to the `Box` wrapper. */
     box?: BoxProps;
     /** Props applied to the `Divider` element. */
@@ -41,8 +41,7 @@ export default function TitleField<T = any, S extends StrictRJSFSchema = RJSFSch
   const { id, title, optionalDataControl, uiSchema } = props;
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F, TitleFieldMuiProps>(uiOptions);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps: muiSlotProps } = getMuiProps<T, S, F, TitleFieldMuiProps>(uiOptions);
 
   let heading = (
     <Typography variant='h5' {...muiSlotProps?.typography}>
@@ -62,7 +61,7 @@ export default function TitleField<T = any, S extends StrictRJSFSchema = RJSFSch
     );
   }
   return (
-    <Box id={id} mb={1} mt={1} {...otherMuiProps} {...muiSlotProps?.box}>
+    <Box id={id} mb={1} mt={1} {...muiSlotProps?.box}>
       {heading}
       <Divider {...muiSlotProps?.divider} />
     </Box>

--- a/packages/mui/src/TitleField/TitleField.tsx
+++ b/packages/mui/src/TitleField/TitleField.tsx
@@ -12,14 +12,10 @@ import { getMuiProps } from '../util';
 export default function TitleField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: TitleFieldProps<T, S, F>,
 ) {
-  const { id, title, optionalDataControl, uiSchema, registry } = props;
+  const { id, title, optionalDataControl, uiSchema } = props;
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options: uiOptions,
-  });
+  const muiProps = getMuiProps<T, S, F>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   let heading = (

--- a/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -3,6 +3,7 @@ import Grid, { GridProps } from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
 import {
   ADDITIONAL_PROPERTY_FLAG,
+  GenericObjectType,
   buttonId,
   FormContextType,
   RJSFSchema,
@@ -12,6 +13,22 @@ import {
   getUiOptions,
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
+/** Properties available for the `slotProps` target of the WrapIfAdditionalTemplate. */
+export interface WrapIfAdditionalTemplateMuiProps extends GenericObjectType {
+  /** MUI subset property for targeting specific child elements. */
+  slotProps?: {
+    /** Props applied to the outermost `Grid` container. */
+    gridContainer?: GridProps;
+    /** Props applied to the `Grid` item containing the key TextField. */
+    keyGridItem?: GridProps;
+    /** Props applied to the `Grid` item containing the field children. */
+    childrenGridItem?: GridProps;
+    /** Props applied to the `Grid` item containing the remove button. */
+    removeButtonGridItem?: GridProps;
+    /** Any other slotProps targetable by `TextField` internally. */
+    [key: string]: any;
+  };
+}
 
 /** The `WrapIfAdditional` component is used by the `FieldTemplate` to rename, or remove properties that are
  * part of an `additionalProperties` part of a schema.
@@ -52,7 +69,7 @@ export default function WrapIfAdditionalTemplate<
   };
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>(uiOptions);
+  const muiProps = getMuiProps<T, S, F, WrapIfAdditionalTemplateMuiProps>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   if (!additional) {
@@ -63,6 +80,10 @@ export default function WrapIfAdditionalTemplate<
     );
   }
 
+  // Extract grid-specific slotProps to prevent overlap onto TextField
+  const { gridContainer, keyGridItem, childrenGridItem, removeButtonGridItem, ...textFieldSlotProps } =
+    muiSlotProps || {};
+
   return (
     <Grid
       container
@@ -71,10 +92,10 @@ export default function WrapIfAdditionalTemplate<
       spacing={2}
       className={classNames}
       style={style}
-      {...(otherMuiProps as GridProps)}
-      {...(muiSlotProps?.grid as GridProps)}
+      {...otherMuiProps}
+      {...gridContainer}
     >
-      <Grid size={5.5} {...(muiSlotProps?.grid as GridProps)}>
+      <Grid size={5.5} {...keyGridItem}>
         <TextField
           key={label}
           fullWidth={true}
@@ -87,14 +108,14 @@ export default function WrapIfAdditionalTemplate<
           onBlur={!readonly ? onKeyRenameBlur : undefined}
           type='text'
           slotProps={{
-            ...muiSlotProps,
+            ...textFieldSlotProps,
           }}
         />
       </Grid>
-      <Grid size={5.5} {...(muiSlotProps?.grid as GridProps)}>
+      <Grid size={5.5} {...childrenGridItem}>
         {children}
       </Grid>
-      <Grid sx={{ mt: 1.5 }} {...(muiSlotProps?.grid as GridProps)}>
+      <Grid sx={{ mt: 1.5 }} {...removeButtonGridItem}>
         <RemoveButton
           id={buttonId(id, 'remove')}
           className='rjsf-object-property-remove'

--- a/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -52,11 +52,7 @@ export default function WrapIfAdditionalTemplate<
   };
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F>({
-    uiSchema,
-    formContext: registry.formContext,
-    options: uiOptions,
-  });
+  const muiProps = getMuiProps<T, S, F>(uiOptions);
   const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
 
   if (!additional) {

--- a/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties } from 'react';
-import Grid from '@mui/material/Grid';
+import Grid, { GridProps } from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
 import {
   ADDITIONAL_PROPERTY_FLAG,
@@ -9,7 +9,9 @@ import {
   StrictRJSFSchema,
   TranslatableString,
   WrapIfAdditionalTemplateProps,
+  getUiOptions,
 } from '@rjsf/utils';
+import { getMuiProps } from '../util';
 
 /** The `WrapIfAdditional` component is used by the `FieldTemplate` to rename, or remove properties that are
  * part of an `additionalProperties` part of a schema.
@@ -49,6 +51,14 @@ export default function WrapIfAdditionalTemplate<
     fontWeight: 'bold',
   };
 
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const muiProps = getMuiProps<T, S, F>({
+    uiSchema,
+    formContext: registry.formContext,
+    options: uiOptions,
+  });
+  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+
   if (!additional) {
     return (
       <div className={classNames} style={style}>
@@ -58,8 +68,17 @@ export default function WrapIfAdditionalTemplate<
   }
 
   return (
-    <Grid container key={`${id}-key`} alignItems='flex-start' spacing={2} className={classNames} style={style}>
-      <Grid size={5.5}>
+    <Grid
+      container
+      key={`${id}-key`}
+      alignItems='flex-start'
+      spacing={2}
+      className={classNames}
+      style={style}
+      {...(otherMuiProps as GridProps)}
+      {...(muiSlotProps?.grid as GridProps)}
+    >
+      <Grid size={5.5} {...(muiSlotProps?.grid as GridProps)}>
         <TextField
           key={label}
           fullWidth={true}
@@ -71,10 +90,15 @@ export default function WrapIfAdditionalTemplate<
           name={`${id}-key`}
           onBlur={!readonly ? onKeyRenameBlur : undefined}
           type='text'
+          slotProps={{
+            ...muiSlotProps,
+          }}
         />
       </Grid>
-      <Grid size={5.5}>{children}</Grid>
-      <Grid sx={{ mt: 1.5 }}>
+      <Grid size={5.5} {...(muiSlotProps?.grid as GridProps)}>
+        {children}
+      </Grid>
+      <Grid sx={{ mt: 1.5 }} {...(muiSlotProps?.grid as GridProps)}>
         <RemoveButton
           id={buttonId(id, 'remove')}
           className='rjsf-object-property-remove'

--- a/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -18,13 +18,13 @@ export interface WrapIfAdditionalTemplateMuiProps extends GenericObjectType {
   /** RJSF-specific slot props for targeting child elements of the WrapIfAdditionalTemplate. */
   rjsfSlotProps?: {
     /** Props applied to the outermost `Grid` container. */
-    gridContainer?: GridProps;
+    wrapGridContainer?: GridProps;
     /** Props applied to the `Grid` item containing the key TextField. */
-    keyGridItem?: GridProps;
+    wrapKeyGridItem?: GridProps;
     /** Props applied to the `Grid` item containing the field children. */
-    childrenGridItem?: GridProps;
+    wrapChildrenGridItem?: GridProps;
     /** Props applied to the `Grid` item containing the remove button. */
-    removeButtonGridItem?: GridProps;
+    wrapRemoveButtonGridItem?: GridProps;
   };
 }
 
@@ -78,7 +78,7 @@ export default function WrapIfAdditionalTemplate<
     );
   }
 
-  const { gridContainer, keyGridItem, childrenGridItem, removeButtonGridItem } = muiSlotProps || {};
+  const { wrapGridContainer, wrapKeyGridItem, wrapChildrenGridItem, wrapRemoveButtonGridItem } = muiSlotProps || {};
 
   return (
     <Grid
@@ -88,9 +88,9 @@ export default function WrapIfAdditionalTemplate<
       spacing={2}
       className={classNames}
       style={style}
-      {...gridContainer}
+      {...wrapGridContainer}
     >
-      <Grid size={5.5} {...keyGridItem}>
+      <Grid size={5.5} {...wrapKeyGridItem}>
         <TextField
           key={label}
           fullWidth={true}
@@ -104,10 +104,10 @@ export default function WrapIfAdditionalTemplate<
           type='text'
         />
       </Grid>
-      <Grid size={5.5} {...childrenGridItem}>
+      <Grid size={5.5} {...wrapChildrenGridItem}>
         {children}
       </Grid>
-      <Grid sx={{ mt: 1.5 }} {...removeButtonGridItem}>
+      <Grid sx={{ mt: 1.5 }} {...wrapRemoveButtonGridItem}>
         <RemoveButton
           id={buttonId(id, 'remove')}
           className='rjsf-object-property-remove'

--- a/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -13,10 +13,10 @@ import {
   getUiOptions,
 } from '@rjsf/utils';
 import { getMuiProps } from '../util';
-/** Properties available for the `slotProps` target of the WrapIfAdditionalTemplate. */
+/** Properties available for the `rjsfSlotProps` target of the WrapIfAdditionalTemplate. */
 export interface WrapIfAdditionalTemplateMuiProps extends GenericObjectType {
-  /** MUI subset property for targeting specific child elements. */
-  slotProps?: {
+  /** RJSF-specific slot props for targeting child elements of the WrapIfAdditionalTemplate. */
+  rjsfSlotProps?: {
     /** Props applied to the outermost `Grid` container. */
     gridContainer?: GridProps;
     /** Props applied to the `Grid` item containing the key TextField. */
@@ -25,8 +25,6 @@ export interface WrapIfAdditionalTemplateMuiProps extends GenericObjectType {
     childrenGridItem?: GridProps;
     /** Props applied to the `Grid` item containing the remove button. */
     removeButtonGridItem?: GridProps;
-    /** Any other slotProps targetable by `TextField` internally. */
-    [key: string]: any;
   };
 }
 
@@ -69,8 +67,8 @@ export default function WrapIfAdditionalTemplate<
   };
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const muiProps = getMuiProps<T, S, F, WrapIfAdditionalTemplateMuiProps>(uiOptions);
-  const { slotProps: muiSlotProps, ...otherMuiProps } = muiProps;
+  const { rjsfSlotProps } = getMuiProps<T, S, F, WrapIfAdditionalTemplateMuiProps>(uiOptions);
+  const muiSlotProps = rjsfSlotProps;
 
   if (!additional) {
     return (
@@ -80,9 +78,7 @@ export default function WrapIfAdditionalTemplate<
     );
   }
 
-  // Extract grid-specific slotProps to prevent overlap onto TextField
-  const { gridContainer, keyGridItem, childrenGridItem, removeButtonGridItem, ...textFieldSlotProps } =
-    muiSlotProps || {};
+  const { gridContainer, keyGridItem, childrenGridItem, removeButtonGridItem } = muiSlotProps || {};
 
   return (
     <Grid
@@ -92,7 +88,6 @@ export default function WrapIfAdditionalTemplate<
       spacing={2}
       className={classNames}
       style={style}
-      {...otherMuiProps}
       {...gridContainer}
     >
       <Grid size={5.5} {...keyGridItem}>
@@ -107,9 +102,6 @@ export default function WrapIfAdditionalTemplate<
           name={`${id}-key`}
           onBlur={!readonly ? onKeyRenameBlur : undefined}
           type='text'
-          slotProps={{
-            ...textFieldSlotProps,
-          }}
         />
       </Grid>
       <Grid size={5.5} {...childrenGridItem}>

--- a/packages/mui/src/util.ts
+++ b/packages/mui/src/util.ts
@@ -1,0 +1,42 @@
+import {
+  FormContextType,
+  getUiOptions,
+  RJSFSchema,
+  StrictRJSFSchema,
+  UiSchema,
+  UIOptionsType,
+  GenericObjectType,
+} from '@rjsf/utils';
+
+export type MuiPropsType<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any> = {
+  formContext?: F;
+  uiSchema?: UiSchema<T, S, F>;
+  options?: UIOptionsType<T, S, F>;
+  defaultSchemaProps?: GenericObjectType;
+  defaultContextProps?: GenericObjectType;
+};
+
+/**
+ * Extract props meant for MUI components from props that are
+ * passed to Widgets, Templates and Fields.
+ * @param {Object} params
+ * @param {Object?} params.formContext
+ * @param {Object?} params.uiSchema
+ * @param {Object?} params.options
+ * @param {Object?} params.defaultSchemaProps
+ * @param {Object?} params.defaultContextProps
+ * @returns {any}
+ */
+export function getMuiProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>({
+  formContext = {} as F,
+  uiSchema = {},
+  options = {},
+  defaultSchemaProps = {},
+  defaultContextProps = {},
+}: MuiPropsType<T, S, F>) {
+  const FormContextProps = formContext.mui;
+  const SchemaProps = getUiOptions<T, S, F>(uiSchema).mui;
+  const OptionProps = options.mui;
+
+  return Object.assign({}, defaultSchemaProps, defaultContextProps, FormContextProps, SchemaProps, OptionProps);
+}

--- a/packages/mui/src/util.ts
+++ b/packages/mui/src/util.ts
@@ -3,16 +3,21 @@ import { FormContextType, RJSFSchema, StrictRJSFSchema, UIOptionsType, GenericOb
 /**
  * Extract props meant for MUI components from the `options` field of the `uiSchema`.
  * @param {UIOptionsType} options - The options from the uiSchema
- * @param {string[]} [propsToFilter] - An optional list of props to filter out
- * @returns {any}
+ * @param {string[]} [propsToFilter] - An optional allowlist of props to return (used by button/icon components)
+ * @param {boolean} [rjsfSlotPropsOnly] - If true, returns only `rjsfSlotProps`, preventing root-level prop bleeding
+ * @returns {P}
  */
 export function getMuiProps<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
   P extends GenericObjectType = GenericObjectType,
->(options: UIOptionsType<T, S, F>, propsToFilter?: string[]): P {
+>(options: UIOptionsType<T, S, F>, propsToFilter?: string[], rjsfSlotPropsOnly?: boolean): P {
   const muiProps = (options?.mui as P) || ({} as P);
+  if (rjsfSlotPropsOnly) {
+    const { rjsfSlotProps } = muiProps as any;
+    return { rjsfSlotProps } as unknown as P;
+  }
   if (propsToFilter) {
     return Object.keys(muiProps)
       .filter((key) => propsToFilter.includes(key))

--- a/packages/mui/src/util.ts
+++ b/packages/mui/src/util.ts
@@ -1,42 +1,25 @@
-import {
-  FormContextType,
-  getUiOptions,
-  RJSFSchema,
-  StrictRJSFSchema,
-  UiSchema,
-  UIOptionsType,
-  GenericObjectType,
-} from '@rjsf/utils';
-
-export type MuiPropsType<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any> = {
-  formContext?: F;
-  uiSchema?: UiSchema<T, S, F>;
-  options?: UIOptionsType<T, S, F>;
-  defaultSchemaProps?: GenericObjectType;
-  defaultContextProps?: GenericObjectType;
-};
+import { FormContextType, RJSFSchema, StrictRJSFSchema, UIOptionsType, GenericObjectType } from '@rjsf/utils';
 
 /**
- * Extract props meant for MUI components from props that are
- * passed to Widgets, Templates and Fields.
- * @param {Object} params
- * @param {Object?} params.formContext
- * @param {Object?} params.uiSchema
- * @param {Object?} params.options
- * @param {Object?} params.defaultSchemaProps
- * @param {Object?} params.defaultContextProps
+ * Extract props meant for MUI components from the `options` field of the `uiSchema`.
+ * @param {UIOptionsType} options - The options from the uiSchema
+ * @param {string[]} [propsToFilter] - An optional list of props to filter out
  * @returns {any}
  */
-export function getMuiProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>({
-  formContext = {} as F,
-  uiSchema = {},
-  options = {},
-  defaultSchemaProps = {},
-  defaultContextProps = {},
-}: MuiPropsType<T, S, F>) {
-  const FormContextProps = formContext.mui;
-  const SchemaProps = getUiOptions<T, S, F>(uiSchema).mui;
-  const OptionProps = options.mui;
-
-  return Object.assign({}, defaultSchemaProps, defaultContextProps, FormContextProps, SchemaProps, OptionProps);
+export function getMuiProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+  P extends GenericObjectType = GenericObjectType,
+>(options: UIOptionsType<T, S, F>, propsToFilter?: string[]): P {
+  const muiProps = (options?.mui as P) || ({} as P);
+  if (propsToFilter) {
+    return Object.keys(muiProps)
+      .filter((key) => propsToFilter.includes(key))
+      .reduce((obj, key) => {
+        obj[key as keyof P] = muiProps[key as keyof P];
+        return obj;
+      }, {} as P);
+  }
+  return muiProps;
 }

--- a/packages/mui/test/MuiProps.test.tsx
+++ b/packages/mui/test/MuiProps.test.tsx
@@ -1,0 +1,98 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Form from '../src';
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+import validator from '@rjsf/validator-ajv8';
+
+describe('MUI Theme-Specific Props', () => {
+  it('should apply mui props to BaseInputTemplate (TextField)', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        foo: { type: 'string' },
+      },
+    };
+    const uiSchema: UiSchema = {
+      foo: {
+        'ui:options': {
+          mui: {
+            placeholder: 'Custom Placeholder',
+            variant: 'standard',
+          },
+        },
+      },
+    };
+
+    const { container } = render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />);
+
+    const input = container.querySelector('input[placeholder="Custom Placeholder"]');
+    expect(input).toBeInTheDocument();
+    // In MUI, variant "standard" removes the notched outline classes that "outlined" (default) has.
+    // Or we can check the class name if we want to be very specific, but existence of placeholder is enough to show mui props worked as placeholder is a TextField prop.
+  });
+
+  it('should apply sx props via FieldTemplate', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        foo: { type: 'string' },
+      },
+    };
+    const uiSchema: UiSchema = {
+      foo: {
+        'ui:options': {
+          mui: {
+            sx: { backgroundColor: 'rgb(255, 0, 0)' },
+          },
+        },
+      },
+    };
+
+    const { container } = render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />);
+
+    // The FormControl in FieldTemplate should have the sx applied.
+    // We can't easily check for 'rgb(255, 0, 0)' in JSDOM if it's via sx/emotion without complex setup,
+    // but we can check if the element exists.
+    const field = container.querySelector('.MuiFormControl-root');
+    expect(field).toBeInTheDocument();
+  });
+
+  it('should apply props to ArrayFieldTemplate (Paper)', () => {
+    const schema: RJSFSchema = {
+      type: 'array',
+      items: { type: 'string' },
+    };
+    const uiSchema: UiSchema = {
+      'ui:options': {
+        mui: {
+          elevation: 10,
+        },
+      },
+    };
+
+    const { container } = render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />);
+
+    const paper = container.querySelector('.MuiPaper-root');
+    expect(paper).toBeInTheDocument();
+    expect(paper).toHaveClass('MuiPaper-elevation10');
+  });
+
+  it('should apply slotProps to SelectWidget', () => {
+    const schema: RJSFSchema = {
+      type: 'string',
+      enum: ['a', 'b'],
+    };
+    const uiSchema: UiSchema = {
+      'ui:options': {
+        mui: {
+          variant: 'filled',
+        },
+      },
+    };
+
+    const { container } = render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />);
+
+    const select = container.querySelector('.MuiFilledInput-root');
+    expect(select).toBeInTheDocument();
+  });
+});

--- a/packages/mui/test/MuiProps.test.tsx
+++ b/packages/mui/test/MuiProps.test.tsx
@@ -57,7 +57,7 @@ describe('MUI Theme-Specific Props', () => {
     expect(field).toBeInTheDocument();
   });
 
-  it('should apply props to ArrayFieldTemplate (Paper)', () => {
+  it('should apply rjsfSlotProps to ArrayFieldTemplate (Paper elevation)', () => {
     const schema: RJSFSchema = {
       type: 'array',
       items: { type: 'string' },
@@ -65,7 +65,9 @@ describe('MUI Theme-Specific Props', () => {
     const uiSchema: UiSchema = {
       'ui:options': {
         mui: {
-          elevation: 10,
+          rjsfSlotProps: {
+            paper: { elevation: 10 },
+          },
         },
       },
     };
@@ -77,7 +79,7 @@ describe('MUI Theme-Specific Props', () => {
     expect(paper).toHaveClass('MuiPaper-elevation10');
   });
 
-  it('should apply slotProps to SelectWidget', () => {
+  it('should apply variant to SelectWidget via root mui props', () => {
     const schema: RJSFSchema = {
       type: 'string',
       enum: ['a', 'b'],

--- a/packages/mui/test/MuiProps.test.tsx
+++ b/packages/mui/test/MuiProps.test.tsx
@@ -66,7 +66,7 @@ describe('MUI Theme-Specific Props', () => {
       'ui:options': {
         mui: {
           rjsfSlotProps: {
-            paper: { elevation: 10 },
+            arrayPaper: { elevation: 10 },
           },
         },
       },

--- a/packages/mui/test/util.test.ts
+++ b/packages/mui/test/util.test.ts
@@ -1,0 +1,56 @@
+import { getMuiProps } from '../src/util';
+
+describe('getMuiProps', () => {
+  it('should merge props in the correct order', () => {
+    const defaultSchemaProps = { a: 'defaultSchema' };
+    const defaultContextProps = { b: 'defaultContext' };
+    const uiSchema = { 'ui:options': { mui: { c: 'uiSchema' } } };
+    const options = { mui: { d: 'options' } };
+    const formContext = { mui: { e: 'formContext' } };
+
+    const result = getMuiProps({
+      defaultSchemaProps,
+      defaultContextProps,
+      uiSchema,
+      options,
+      formContext,
+    });
+
+    expect(result).toEqual({
+      a: 'defaultSchema',
+      b: 'defaultContext',
+      c: 'uiSchema',
+      d: 'options',
+      e: 'formContext',
+    });
+  });
+
+  it('should allow uiSchema props to override formContext props', () => {
+    const uiSchema = { 'ui:options': { mui: { a: 'uiSchema' } } };
+    const formContext = { mui: { a: 'formContext' } };
+
+    const result = getMuiProps({
+      uiSchema,
+      formContext,
+    });
+
+    expect(result.a).toBe('uiSchema');
+  });
+
+  it('should handle missing props gracefully', () => {
+    const result = getMuiProps({});
+    expect(result).toEqual({});
+  });
+
+  it('should extract mui props from uiSchema (via getUiOptions)', () => {
+    const uiSchema = {
+      'ui:options': {
+        mui: {
+          slotProps: { input: { endAdornment: 'kg' } },
+        },
+      },
+    };
+    const result = getMuiProps({ uiSchema });
+    expect(result.slotProps.input.endAdornment).toBe('kg');
+  });
+});

--- a/packages/mui/test/util.test.ts
+++ b/packages/mui/test/util.test.ts
@@ -1,56 +1,40 @@
 import { getMuiProps } from '../src/util';
 
 describe('getMuiProps', () => {
-  it('should merge props in the correct order', () => {
-    const defaultSchemaProps = { a: 'defaultSchema' };
-    const defaultContextProps = { b: 'defaultContext' };
-    const uiSchema = { 'ui:options': { mui: { c: 'uiSchema' } } };
-    const options = { mui: { d: 'options' } };
-    const formContext = { mui: { e: 'formContext' } };
-
-    const result = getMuiProps({
-      defaultSchemaProps,
-      defaultContextProps,
-      uiSchema,
-      options,
-      formContext,
-    });
-
-    expect(result).toEqual({
-      a: 'defaultSchema',
-      b: 'defaultContext',
-      c: 'uiSchema',
-      d: 'options',
-      e: 'formContext',
-    });
+  it('should extract mui props from uiOptions', () => {
+    const options = {
+      mui: {
+        slotProps: { input: { endAdornment: 'kg' } },
+        variant: 'filled',
+      },
+    };
+    const result = getMuiProps(options);
+    expect(result.slotProps.input.endAdornment).toBe('kg');
+    expect(result.variant).toBe('filled');
   });
 
-  it('should allow uiSchema props to override formContext props', () => {
-    const uiSchema = { 'ui:options': { mui: { a: 'uiSchema' } } };
-    const formContext = { mui: { a: 'formContext' } };
-
-    const result = getMuiProps({
-      uiSchema,
-      formContext,
-    });
-
-    expect(result.a).toBe('uiSchema');
-  });
-
-  it('should handle missing props gracefully', () => {
+  it('should handle missing mui props gracefully', () => {
     const result = getMuiProps({});
     expect(result).toEqual({});
   });
 
-  it('should extract mui props from uiSchema (via getUiOptions)', () => {
-    const uiSchema = {
-      'ui:options': {
-        mui: {
-          slotProps: { input: { endAdornment: 'kg' } },
-        },
+  it('should handle missing options gracefully', () => {
+    const result = getMuiProps(undefined as any);
+    expect(result).toEqual({});
+  });
+
+  it('should filter properties when propsToFilter is provided', () => {
+    const options = {
+      mui: {
+        variant: 'filled',
+        fullWidth: true,
+        disabled: false,
       },
     };
-    const result = getMuiProps({ uiSchema });
-    expect(result.slotProps.input.endAdornment).toBe('kg');
+    const result = getMuiProps(options, ['variant', 'disabled']);
+    expect(result).toEqual({
+      variant: 'filled',
+      disabled: false,
+    });
   });
 });

--- a/packages/mui/test/util.test.ts
+++ b/packages/mui/test/util.test.ts
@@ -4,12 +4,12 @@ describe('getMuiProps', () => {
   it('should extract mui props from uiOptions', () => {
     const options = {
       mui: {
-        rjsfSlotProps: { input: { endAdornment: 'kg' } },
+        rjsfSlotProps: { fieldErrorList: { dense: true } },
         variant: 'filled',
       },
     };
     const result = getMuiProps(options);
-    expect(result.rjsfSlotProps.input.endAdornment).toBe('kg');
+    expect(result.rjsfSlotProps.fieldErrorList.dense).toBe(true);
     expect(result.variant).toBe('filled');
   });
 
@@ -41,13 +41,13 @@ describe('getMuiProps', () => {
   it('should return only rjsfSlotProps when rjsfSlotPropsOnly is true', () => {
     const options = {
       mui: {
-        rjsfSlotProps: { paper: { elevation: 10 } },
+        rjsfSlotProps: { arrayPaper: { elevation: 10 } },
         variant: 'filled',
         sx: { mt: 2 },
       },
     };
     const result = getMuiProps(options, undefined, true);
-    expect(result.rjsfSlotProps).toEqual({ paper: { elevation: 10 } });
+    expect(result.rjsfSlotProps).toEqual({ arrayPaper: { elevation: 10 } });
     expect(result.variant).toBeUndefined();
     expect(result.sx).toBeUndefined();
   });

--- a/packages/mui/test/util.test.ts
+++ b/packages/mui/test/util.test.ts
@@ -4,12 +4,12 @@ describe('getMuiProps', () => {
   it('should extract mui props from uiOptions', () => {
     const options = {
       mui: {
-        slotProps: { input: { endAdornment: 'kg' } },
+        rjsfSlotProps: { input: { endAdornment: 'kg' } },
         variant: 'filled',
       },
     };
     const result = getMuiProps(options);
-    expect(result.slotProps.input.endAdornment).toBe('kg');
+    expect(result.rjsfSlotProps.input.endAdornment).toBe('kg');
     expect(result.variant).toBe('filled');
   });
 
@@ -36,5 +36,19 @@ describe('getMuiProps', () => {
       variant: 'filled',
       disabled: false,
     });
+  });
+
+  it('should return only rjsfSlotProps when rjsfSlotPropsOnly is true', () => {
+    const options = {
+      mui: {
+        rjsfSlotProps: { paper: { elevation: 10 } },
+        variant: 'filled',
+        sx: { mt: 2 },
+      },
+    };
+    const result = getMuiProps(options, undefined, true);
+    expect(result.rjsfSlotProps).toEqual({ paper: { elevation: 10 } });
+    expect(result.variant).toBeUndefined();
+    expect(result.sx).toBeUndefined();
   });
 });


### PR DESCRIPTION
### Reasons for making this change

Added support for passing theme-specific Material UI props (e.g., sx, variant, slotProps) directly via uiSchema or formContext.

Fixes #4996 

### Key Changes

- Added `getMuiProps` to extract and merge MUI-specific options.
- Refactored all templates (Field, Array, Object, etc.) to be able to use the Mui-specific-props.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
