### PR TITLE
Fix 5025 by adding tsc-alias to mantine build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## Dev / docs / playground
 
 - Updated References playground sample to demonstrate `oneOf` with `ui:title` at recursive depth, related to [#4986](https://github.com/rjsf-team/react-jsonschema-form/issues/4986)
+- Updated the building of the `mantine` theme to properly support ESM, fixing [#5025](https://github.com/rjsf-team/react-jsonschema-form/issues/5025)
 
 # 6.4.2
 

--- a/packages/mantine/tsconfig.build.json
+++ b/packages/mantine/tsconfig.build.json
@@ -8,5 +8,9 @@
     {
       "path": "./src"
     }
-  ]
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": true
+  }
 }


### PR DESCRIPTION
### Reasons for making this change

Fixed #5025 by adding `tsc-alias` to the `mantine` build to add ESM support

- Updated `tsconfig.build.json` for the `mantine` theme to add `tsc-alias`
- Updated `CHANGELOG.md` accordingly


### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
