### PR TITLE
fix(core): use ref to prevent stale formData in rapid additional property renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Added a new `removeEmptyOptionalObjects` boolean prop to gracefully prune optional empty objects preventing form submission lockouts, fixing [#4954](https://github.com/rjsf-team/react-jsonschema-form/issues/4954)
 - Included `button` elements in `focusOnError` querySelector so that radio and checkbox groups receive focus on validation error, fixing [#4870](https://github.com/rjsf-team/react-jsonschema-form/issues/4870)
+- Used `useRef` to track latest `formData` in `handleKeyRename`, preventing stale closure data when multiple additional property keys are renamed in quick succession, fixing [#5021](https://github.com/rjsf-team/react-jsonschema-form/issues/5021)
 
 ## @rjsf/utils
 

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -1,4 +1,4 @@
-import { FocusEvent, useCallback, useState } from 'react';
+import { FocusEvent, useCallback, useRef, useState } from 'react';
 import {
   ADDITIONAL_PROPERTY_FLAG,
   ANY_OF_KEY,
@@ -220,6 +220,8 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
   } = props;
   const { fields, schemaUtils, translateString, globalUiOptions } = registry;
   const { OptionalDataControlsField } = fields;
+  const formDataRef = useRef(formData);
+  formDataRef.current = formData;
   const schema: S = schemaUtils.retrieveSchema(rawSchema, formData, true);
   const uiOptions = getUiOptions<T, S, F>(uiSchema, globalUiOptions);
   const { properties: schemaProperties = {} } = schema;
@@ -305,9 +307,10 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
   const handleKeyRename = useCallback(
     (oldKey: string, newKey: string) => {
       if (oldKey !== newKey) {
-        const actualNewKey = getAvailableKey(newKey, formData);
+        const currentFormData = formDataRef.current;
+        const actualNewKey = getAvailableKey(newKey, currentFormData);
         const newFormData: GenericObjectType = {
-          ...(formData as GenericObjectType),
+          ...(currentFormData as GenericObjectType),
         };
         const newKeys: GenericObjectType = { [oldKey]: actualNewKey };
         const keyValues = Object.keys(newFormData).map((key) => {
@@ -316,10 +319,11 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
         });
         const renamedObj = Object.assign({}, ...keyValues);
 
+        formDataRef.current = renamedObj as T;
         onChange(renamedObj, childFieldPathId.path);
       }
     },
-    [formData, onChange, childFieldPathId, getAvailableKey],
+    [onChange, childFieldPathId, getAvailableKey],
   );
 
   /** Handles the remove click which calls the `onChange` callback with the special ADDITIONAL_PROPERTY_FIELD_REMOVE

--- a/packages/core/test/ObjectField.test.tsx
+++ b/packages/core/test/ObjectField.test.tsx
@@ -1098,6 +1098,38 @@ describe('ObjectField', () => {
       );
     });
 
+    it('should preserve all properties when two keys are renamed in quick succession', () => {
+      const formData = {
+        first: 1,
+        second: 2,
+        third: 3,
+      };
+      const { node, onChange } = createFormComponent({
+        schema,
+        formData,
+      });
+
+      const firstKeyNode = node.querySelector('#root_first-key');
+      const secondKeyNode = node.querySelector('#root_second-key');
+
+      act(() => {
+        fireEvent.blur(firstKeyNode!, {
+          target: { value: 'renamedFirst' },
+        });
+        fireEvent.blur(secondKeyNode!, {
+          target: { value: 'renamedSecond' },
+        });
+      });
+
+      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          formData: { renamedFirst: 1, renamedSecond: 2, third: 3 },
+        }),
+        'root',
+      );
+    });
+
     it('should have an expand button', () => {
       const { node } = createFormComponent({ schema });
 


### PR DESCRIPTION
### Reasons for making this change

Fixes #5021

When two additional property keys are renamed in quick succession (before React flushes the batched state update from the first rename), the second rename reads stale `formData` from the `useCallback` closure. This causes the first rename's result to be silently dropped.

The fix introduces a `useRef` to track the latest formData. After computing the renamed object, the ref is updated immediately before calling `onChange`, so any subsequent rename within the same React batch reads the up-to-date data. The ref is synced with the authoritative `formData` prop on every render.

Changes:
- `packages/core/src/components/fields/ObjectField.tsx`: read `formDataRef.current` instead of the closure-captured `formData` in `handleKeyRename`, and update the ref immediately after computing the new form data
- `packages/core/test/ObjectField.test.tsx`: add test for rapid successive key renames within a single `act()` boundary

Reproduction steps (on the playground's Additional Properties sample):
1. Click "Add Item" to create a `newKey` property
2. Rename `newKey` to `second`, press Tab
3. Immediately click the `assKickCount` key input, rename it to `renamed`, press Tab
4. Before fix: `second` disappears. After fix: both `second` and `renamed` are present.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature