### PR TITLE
Chore: Added adjustable panels for the Editors panels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34496,6 +34496,16 @@
         }
       }
     },
+    "node_modules/react-resizable-panels": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.10.0.tgz",
+      "integrity": "sha512-frjewRQt7TCv/vCH1pJfjZ7RxAhr5pKuqVQtVgzFq/vherxBFOWyC3xMbryx5Ti2wylViGUFc93Etg4rB3E0UA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-router": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
@@ -41680,6 +41690,7 @@
         "react-dom": "^18.3.1",
         "react-frame-component": "^5.3.2",
         "react-is": "^18.3.1",
+        "react-resizable-panels": "^4.10.0",
         "semantic-ui-react": "^2.1.5"
       },
       "devDependencies": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -69,6 +69,7 @@
     "react-dom": "^18.3.1",
     "react-frame-component": "^5.3.2",
     "react-is": "^18.3.1",
+    "react-resizable-panels": "^4.10.0",
     "semantic-ui-react": "^2.1.5"
   },
   "devDependencies": {

--- a/packages/playground/src/components/Editors.tsx
+++ b/packages/playground/src/components/Editors.tsx
@@ -3,7 +3,6 @@ import { styled } from '@mui/material/styles';
 import Accordion from '@mui/material/Accordion';
 import MuiAccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
-import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -189,29 +188,27 @@ export default function Editors({
         </Grid>
       </AccordionSummary>
       <AccordionDetails sx={{ p: 0 }}>
-        <Box sx={{ width: '100%' }}>
-          <Group orientation='horizontal'>
-            <Panel defaultSize={extraErrors ? '34%' : '25%'} minSize='10%'>
-              <Editor title='JSONSchema' code={toJson(schema)} onChange={onSchemaEdited} />
-            </Panel>
-            <Separator style={{ width: '4px', cursor: 'col-resize' }} />
-            <Panel defaultSize={extraErrors ? '33%' : '25%'} minSize='10%'>
-              <Editor title={uiSchemaTitle} code={toJson(uiSchema)} onChange={onUISchemaEdited} />
-            </Panel>
-            <Separator style={{ width: '4px', cursor: 'col-resize' }} />
-            <Panel defaultSize={extraErrors ? '33%' : '25%'} minSize='10%'>
-              <Editor title='formData' code={toJson(formData)} onChange={onFormDataEdited} />
-            </Panel>
-            {extraErrors && (
-              <>
-                <Separator style={{ width: '4px', cursor: 'col-resize' }} />
-                <Panel defaultSize='25%' minSize='10%'>
-                  <Editor title='extraErrors' code={toJson(extraErrors)} onChange={onExtraErrorsEdited} />
-                </Panel>
-              </>
-            )}
-          </Group>
-        </Box>
+        <Group orientation='horizontal'>
+          <Panel defaultSize={extraErrors ? '34%' : '25%'} minSize='10%'>
+            <Editor title='JSONSchema' code={toJson(schema)} onChange={onSchemaEdited} />
+          </Panel>
+          <Separator style={{ width: '4px', cursor: 'col-resize' }} />
+          <Panel defaultSize={extraErrors ? '33%' : '25%'} minSize='10%'>
+            <Editor title={uiSchemaTitle} code={toJson(uiSchema)} onChange={onUISchemaEdited} />
+          </Panel>
+          <Separator style={{ width: '4px', cursor: 'col-resize' }} />
+          <Panel defaultSize={extraErrors ? '33%' : '25%'} minSize='10%'>
+            <Editor title='formData' code={toJson(formData)} onChange={onFormDataEdited} />
+          </Panel>
+          {extraErrors && (
+            <>
+              <Separator style={{ width: '4px', cursor: 'col-resize' }} />
+              <Panel defaultSize='25%' minSize='10%'>
+                <Editor title='extraErrors' code={toJson(extraErrors)} onChange={onExtraErrorsEdited} />
+              </Panel>
+            </>
+          )}
+        </Group>
       </AccordionDetails>
     </Accordion>
   );

--- a/packages/playground/src/components/Editors.tsx
+++ b/packages/playground/src/components/Editors.tsx
@@ -3,12 +3,14 @@ import { styled } from '@mui/material/styles';
 import Accordion from '@mui/material/Accordion';
 import MuiAccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
+import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import MonacoEditor from '@monaco-editor/react';
 import { ErrorSchema, RJSFSchema, UiSchema } from '@rjsf/utils';
 import isEqualWith from 'lodash/isEqualWith';
+import { Panel, Group, Separator } from 'react-resizable-panels';
 
 import ThemeSelector, { ThemesType } from './ThemeSelector';
 import SubthemeSelector, { SubthemeType } from './SubthemeSelector';
@@ -60,7 +62,7 @@ function Editor({ title, code, onChange }: EditorProps) {
   const cls = valid ? 'valid' : 'invalid';
 
   return (
-    <div className='panel panel-default'>
+    <div className='panel panel-default' style={{ marginBottom: 0 }}>
       <div className='panel-heading'>
         <span className={`${cls} glyphicon glyphicon-${icon}`} />
         {' ' + title}
@@ -187,22 +189,29 @@ export default function Editors({
         </Grid>
       </AccordionSummary>
       <AccordionDetails sx={{ p: 0 }}>
-        <Grid container spacing={0.5}>
-          <Grid size={extraErrors ? 3 : 4}>
-            <Editor title='JSONSchema' code={toJson(schema)} onChange={onSchemaEdited} />
-          </Grid>
-          <Grid size={extraErrors ? 3 : 4}>
-            <Editor title={uiSchemaTitle} code={toJson(uiSchema)} onChange={onUISchemaEdited} />
-          </Grid>
-          <Grid size={extraErrors ? 3 : 4}>
-            <Editor title='formData' code={toJson(formData)} onChange={onFormDataEdited} />
-          </Grid>
-          {extraErrors && (
-            <Grid size={3}>
-              <Editor title='extraErrors' code={toJson(extraErrors || {})} onChange={onExtraErrorsEdited} />
-            </Grid>
-          )}
-        </Grid>
+        <Box sx={{ width: '100%' }}>
+          <Group orientation='horizontal'>
+            <Panel defaultSize={extraErrors ? '34%' : '25%'} minSize='10%'>
+              <Editor title='JSONSchema' code={toJson(schema)} onChange={onSchemaEdited} />
+            </Panel>
+            <Separator style={{ width: '4px', cursor: 'col-resize' }} />
+            <Panel defaultSize={extraErrors ? '33%' : '25%'} minSize='10%'>
+              <Editor title={uiSchemaTitle} code={toJson(uiSchema)} onChange={onUISchemaEdited} />
+            </Panel>
+            <Separator style={{ width: '4px', cursor: 'col-resize' }} />
+            <Panel defaultSize={extraErrors ? '33%' : '25%'} minSize='10%'>
+              <Editor title='formData' code={toJson(formData)} onChange={onFormDataEdited} />
+            </Panel>
+            {extraErrors && (
+              <>
+                <Separator style={{ width: '4px', cursor: 'col-resize' }} />
+                <Panel defaultSize='25%' minSize='10%'>
+                  <Editor title='extraErrors' code={toJson(extraErrors)} onChange={onExtraErrorsEdited} />
+                </Panel>
+              </>
+            )}
+          </Group>
+        </Box>
       </AccordionDetails>
     </Accordion>
   );


### PR DESCRIPTION
### Reasons for making this change

- Updated the playground's `Editors` component to add adjustable panels so that users can widen or shrink the width of an editor
- Installed `react-resizable-panels` to the playground

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature


https://github.com/user-attachments/assets/e27aeef6-d0d2-41c4-9ed3-ff3eb00d991a

