### PR TITLE
fix(@rjsf/core): prevent extraErrors duplication on array field mutation (#5041)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 6.5.2
 
+## @rjsf/core
+
+- Fixed `processPendingChange()` using `originalErrorSchema` (which already contains merged `extraErrors`) as the base for `mergeErrors()`, causing sibling-field `extraErrors` to accumulate duplicate entries on every array mutation, fixing [#5041](https://github.com/rjsf-team/react-jsonschema-form/issues/5041)
+
 ## Dev / docs / playground
 
 - Cleaned up testing to make registry mocks simpler using `getTestRegistry()` function

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -896,7 +896,11 @@ export default class Form<
     const { extraErrors, omitExtraData, liveOmit, noValidate, liveValidate, onChange, removeEmptyOptionalObjects } =
       this.props;
     const { formData: oldFormData, schemaUtils, schema, fieldPathId, schemaValidationErrorSchema, errors } = this.state;
-    let { customErrors, errorSchema: originalErrorSchema } = this.state;
+    let { customErrors } = this.state;
+    // Use the un-merged AJV-only schema as the base for re-merging extraErrors. Mirrors the
+    // pattern in getStateFromProps/getDerivedStateFromProps and avoids the duplication that
+    // happened when state.errorSchema (already containing merged extraErrors) was passed in.
+    let mergeBaseErrorSchema: ErrorSchema<T> = schemaValidationErrorSchema as ErrorSchema<T>;
     const rootPathId = fieldPathId.path[0] || '';
 
     const isRootPath = !path || path.length === 0 || (path.length === 1 && path[0] === rootPathId);
@@ -958,11 +962,13 @@ export default class Form<
       const oldValidationError = !isRootPath ? _get(schemaValidationErrorSchema, path) : schemaValidationErrorSchema;
       // If there is an old validation error for this path, assume we are updating it directly
       if (!_isEmpty(oldValidationError)) {
-        // Update the originalErrorSchema "in place" or replace it if it is the root
+        // Apply the user-supplied newErrorSchema onto a clone of the AJV-only base, so that
+        // mergeErrors below sees the user's error at this path without mutating shared state.
         if (!isRootPath) {
-          _set(originalErrorSchema, path, newErrorSchema);
+          mergeBaseErrorSchema = _cloneDeep(schemaValidationErrorSchema) as ErrorSchema<T>;
+          _set(mergeBaseErrorSchema, path, newErrorSchema);
         } else {
-          originalErrorSchema = newErrorSchema;
+          mergeBaseErrorSchema = newErrorSchema as ErrorSchema<T>;
         }
       } else {
         if (!customErrors) {
@@ -987,7 +993,7 @@ export default class Form<
       const liveValidation = this.liveValidate(
         schema,
         schemaUtils,
-        originalErrorSchema,
+        mergeBaseErrorSchema,
         newFormData,
         extraErrors,
         customErrors,
@@ -996,11 +1002,7 @@ export default class Form<
       state = { formData: newFormData, ...liveValidation, customErrors };
     } else if (!noValidate && newErrorSchema) {
       // Merging 'newErrorSchema' into 'errorSchema' to display the custom raised errors.
-      const mergedErrors = this.mergeErrors(
-        { errorSchema: schemaValidationErrorSchema as ErrorSchema<T>, errors },
-        extraErrors,
-        customErrors,
-      );
+      const mergedErrors = this.mergeErrors({ errorSchema: mergeBaseErrorSchema, errors }, extraErrors, customErrors);
       state = {
         formData: newFormData,
         ...mergedErrors,

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -996,7 +996,11 @@ export default class Form<
       state = { formData: newFormData, ...liveValidation, customErrors };
     } else if (!noValidate && newErrorSchema) {
       // Merging 'newErrorSchema' into 'errorSchema' to display the custom raised errors.
-      const mergedErrors = this.mergeErrors({ errorSchema: originalErrorSchema, errors }, extraErrors, customErrors);
+      const mergedErrors = this.mergeErrors(
+        { errorSchema: schemaValidationErrorSchema as ErrorSchema<T>, errors },
+        extraErrors,
+        customErrors,
+      );
       state = {
         formData: newFormData,
         ...mergedErrors,

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -6002,3 +6002,47 @@ describe('extraErrors set after submit (#4965)', () => {
     expect(errorItems.length).toBeGreaterThan(0);
   });
 });
+
+describe('extraErrors not duplicated when sibling array field mutated (#5041)', () => {
+  it('should not accumulate duplicate extraErrors after array item is added', async () => {
+    // Reproduces https://github.com/rjsf-team/react-jsonschema-form/issues/5041
+    // processPendingChange() used originalErrorSchema (which already contains merged
+    // extraErrors) as the base for re-merging extraErrors, causing __errors to be
+    // appended again on every array mutation.
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        items: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+    };
+
+    const extraErrors: ErrorSchema = {
+      name: { __errors: ['Name is required'] },
+    } as unknown as ErrorSchema;
+
+    const formRef = createRef<Form>();
+
+    function Wrapper() {
+      return <Form ref={formRef} schema={schema} validator={validator} extraErrors={extraErrors} />;
+    }
+
+    const { container } = render(<Wrapper />);
+    const form = container.firstElementChild!;
+
+    // Add an item to the sibling array field
+    const addBtn = form.querySelector('.btn-add');
+    await act(async () => {
+      fireEvent.click(addBtn!);
+    });
+
+    // The name field's extraErrors should still contain exactly one error
+    const state = formRef.current!.state;
+    const nameErrors = (state.errorSchema as any)?.name?.__errors ?? [];
+    expect(nameErrors).toHaveLength(1);
+    expect(nameErrors[0]).toBe('Name is required');
+  });
+});


### PR DESCRIPTION
### Reasons for making this change

`processPendingChange()` used `this.state.errorSchema` (which already contains merged `extraErrors`) as the base when re-merging `extraErrors` in the non-live-validate branch. Because `validationDataMerge` concatenates `__errors` arrays, each array mutation triggered an extra merge cycle that appended duplicate copies of any sibling field's `extraErrors`.

The fix uses `schemaValidationErrorSchema` (the un-merged AJV-only base) instead, which is consistent with how `getDerivedStateFromProps` and `getStateFromProps` handle the same merge pattern.

Fixes #5041

### Changes

- In `Form.processPendingChange()`, replaced `originalErrorSchema` with `schemaValidationErrorSchema` as the base passed to `mergeErrors()` in the `else if (!noValidate && newErrorSchema)` branch
- Added regression test: sibling field `extraErrors` must not accumulate after array item is added

### Checklist

- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR