### PR TITLE
perf(utils, validator-ajv8): improve deepEquals performance and skip redundant Ajv schema re-registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Switched `deepEquals` from `lodash.isEqualWith` to `fast-equals.createCustomEqual` with cycle detection enabled, and replaced direct `lodash.isEqual` usage in `useDeepCompareMemo`, `isRootSchema`, and `findSelectedOptionInXxxOf` with `deepEquals`, addressing [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291).
 
+## @rjsf/validator-ajv8
+
+- Cached the most recent `rootSchema` reference in `handleSchemaUpdate` so repeated `isValid` calls with the same root schema skip the deep-equality check and Ajv re-registration, addressing [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291).
+
 ## Dev / docs / playground
 
 - Cleaned up testing to make registry mocks simpler using `getTestRegistry()` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 6.5.2
 
+## @rjsf/utils
+
+- Switched `deepEquals` from `lodash.isEqualWith` to `fast-equals.createCustomEqual` with cycle detection enabled, and replaced direct `lodash.isEqual` usage in `useDeepCompareMemo`, `isRootSchema`, and `findSelectedOptionInXxxOf` with `deepEquals`, addressing [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291).
+
 ## Dev / docs / playground
 
 - Cleaned up testing to make registry mocks simpler using `getTestRegistry()` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,11 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
-- Switched `deepEquals` from `lodash.isEqualWith` to `fast-equals.createCustomEqual` with cycle detection enabled, and replaced direct `lodash.isEqual` usage in `useDeepCompareMemo`, `isRootSchema`, and `findSelectedOptionInXxxOf` with `deepEquals`, addressing [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291).
+- Switched `deepEquals` from `lodash.isEqualWith` to `fast-equals.createCustomEqual` with cycle detection enabled, and replaced direct `lodash.isEqual` usage in `useDeepCompareMemo`, `isRootSchema`, and `findSelectedOptionInXxxOf` with `deepEquals`, fixing [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291).
 
 ## @rjsf/validator-ajv8
 
-- Cached the most recent `rootSchema` reference in `handleSchemaUpdate` so repeated `isValid` calls with the same root schema skip the deep-equality check and Ajv re-registration, addressing [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291).
+- Cached the most recent `rootSchema` reference in `handleSchemaUpdate` so repeated `isValid` calls with the same root schema skip the deep-equality check and Ajv re-registration, fixing [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291).
 
 ## Dev / docs / playground
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22958,6 +22958,15 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/fast-equals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.0.tgz",
+      "integrity": "sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -42187,6 +42196,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@x0k/json-schema-merge": "^1.0.3",
+        "fast-equals": "^6.0.0",
         "fast-uri": "^3.1.0",
         "jsonpointer": "^5.0.1",
         "lodash": "^4.18.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -66,6 +66,7 @@
   },
   "dependencies": {
     "@x0k/json-schema-merge": "^1.0.3",
+    "fast-equals": "^6.0.0",
     "fast-uri": "^3.1.0",
     "jsonpointer": "^5.0.1",
     "lodash": "^4.18.1",

--- a/packages/utils/src/deepEquals.ts
+++ b/packages/utils/src/deepEquals.ts
@@ -1,19 +1,20 @@
-import isEqualWith from 'lodash/isEqualWith';
+import { createCustomEqual } from 'fast-equals';
 
-/** Implements a deep equals using the `lodash.isEqualWith` function, that provides a customized comparator that
- * assumes all functions are equivalent.
+/** Implements a deep equals using `fast-equals.createCustomEqual`. Functions
+ * are always considered equal, and circular references are tracked to avoid
+ * infinite recursion on self-referential inputs.
  *
  * @param a - The first element to compare
  * @param b - The second element to compare
  * @returns - True if the `a` and `b` are deeply equal, false otherwise
  */
-export default function deepEquals(a: any, b: any): boolean {
-  return isEqualWith(a, b, (obj: any, other: any) => {
-    if (typeof obj === 'function' && typeof other === 'function') {
-      // Assume all functions are equivalent
-      // see https://github.com/rjsf-team/react-jsonschema-form/issues/255
-      return true;
-    }
-    return undefined; // fallback to default isEquals behavior
-  });
-}
+const deepEquals = createCustomEqual({
+  circular: true,
+  createCustomConfig: () => ({
+    areFunctionsEqual(_a, b) {
+      return typeof b === 'function';
+    },
+  }),
+});
+
+export default deepEquals;

--- a/packages/utils/src/isRootSchema.ts
+++ b/packages/utils/src/isRootSchema.ts
@@ -1,6 +1,6 @@
-import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 
+import deepEquals from './deepEquals';
 import { FormContextType, Registry, RJSFSchema, StrictRJSFSchema } from './types';
 import { REF_KEY, RJSF_REF_KEY } from './constants';
 
@@ -20,12 +20,12 @@ export default function isRootSchema<T = any, S extends StrictRJSFSchema = RJSFS
   schemaToCompare: S,
 ): boolean {
   const { rootSchema, schemaUtils } = registry;
-  if (isEqual(schemaToCompare, rootSchema)) {
+  if (deepEquals(schemaToCompare, rootSchema)) {
     return true;
   }
   if (REF_KEY in rootSchema) {
     const resolvedSchema = schemaUtils.retrieveSchema(rootSchema);
-    return isEqual(schemaToCompare, omit(resolvedSchema, RJSF_REF_KEY));
+    return deepEquals(schemaToCompare, omit(resolvedSchema, RJSF_REF_KEY));
   }
   return false;
 }

--- a/packages/utils/src/schema/findSelectedOptionInXxxOf.ts
+++ b/packages/utils/src/schema/findSelectedOptionInXxxOf.ts
@@ -1,7 +1,7 @@
 import get from 'lodash/get';
-import isEqual from 'lodash/isEqual';
 
 import { CONST_KEY, DEFAULT_KEY, PROPERTIES_KEY } from '../constants';
+import deepEquals from '../deepEquals';
 import { Experimental_CustomMergeAllOf, FormContextType, RJSFSchema, StrictRJSFSchema, ValidatorType } from '../types';
 import retrieveSchema from './retrieveSchema';
 import getDiscriminatorFieldFromSchema from '../getDiscriminatorFieldFromSchema';
@@ -42,7 +42,7 @@ export default function findSelectedOptionInXxxOf<
     const data = get(formData, selectorField);
     if (data !== undefined) {
       return xxxOfs.find((xxx) => {
-        return isEqual(
+        return deepEquals(
           get(xxx, [PROPERTIES_KEY, selectorField, DEFAULT_KEY], get(xxx, [PROPERTIES_KEY, selectorField, CONST_KEY])),
           data,
         );

--- a/packages/utils/src/useDeepCompareMemo.ts
+++ b/packages/utils/src/useDeepCompareMemo.ts
@@ -1,7 +1,8 @@
 'use client';
 
 import { useRef } from 'react';
-import isEqual from 'lodash/isEqual';
+
+import deepEquals from './deepEquals';
 
 /** Hook that stores and returns a `T` value. If `newValue` is the same as the stored one, then the stored one is
  * returned to avoid having a component rerender due it being a different object. Otherwise, the `newValue` is stored
@@ -12,7 +13,7 @@ import isEqual from 'lodash/isEqual';
  */
 export default function useDeepCompareMemo<T = unknown>(newValue: T): T {
   const valueRef = useRef<T>(newValue);
-  if (!isEqual(newValue, valueRef.current)) {
+  if (!deepEquals(newValue, valueRef.current)) {
     valueRef.current = newValue;
   }
   return valueRef.current;

--- a/packages/utils/test/deepEquals.test.ts
+++ b/packages/utils/test/deepEquals.test.ts
@@ -1,7 +1,6 @@
 import { deepEquals } from '../src';
 
 describe('deepEquals()', () => {
-  // Note: deepEquals implementation uses isEqualWith, so we focus on the behavioral differences we introduced.
   it('should assume functions are always equivalent', () => {
     expect(
       deepEquals(
@@ -11,5 +10,46 @@ describe('deepEquals()', () => {
     ).toBe(true);
     expect(deepEquals({ foo() {} }, { foo() {} })).toBe(true);
     expect(deepEquals({ foo: { bar() {} } }, { foo: { bar() {} } })).toBe(true);
+  });
+
+  it('does not stack-overflow on self-referential objects', () => {
+    const a: any = { foo: 1 };
+    a.self = a;
+    const b: any = { foo: 1 };
+    b.self = b;
+    expect(() => deepEquals(a, b)).not.toThrow();
+    expect(deepEquals(a, b)).toBe(true);
+  });
+
+  it('detects differences in self-referential objects', () => {
+    const a: any = { foo: 1 };
+    a.self = a;
+    const b: any = { foo: 2 };
+    b.self = b;
+    expect(deepEquals(a, b)).toBe(false);
+  });
+
+  it('does not stack-overflow on mutually-referential objects', () => {
+    const a1: any = { name: 'a' };
+    const a2: any = { name: 'b' };
+    a1.partner = a2;
+    a2.partner = a1;
+
+    const b1: any = { name: 'a' };
+    const b2: any = { name: 'b' };
+    b1.partner = b2;
+    b2.partner = b1;
+
+    expect(() => deepEquals(a1, b1)).not.toThrow();
+    expect(deepEquals(a1, b1)).toBe(true);
+  });
+
+  it('does not stack-overflow on cyclic arrays', () => {
+    const a: any[] = [1];
+    a.push(a);
+    const b: any[] = [1];
+    b.push(b);
+    expect(() => deepEquals(a, b)).not.toThrow();
+    expect(deepEquals(a, b)).toBe(true);
   });
 });

--- a/packages/validator-ajv8/src/validator.ts
+++ b/packages/validator-ajv8/src/validator.ts
@@ -44,6 +44,18 @@ export default class AJV8Validator<
    */
   readonly suppressDuplicateFiltering?: SuppressDuplicateFilteringType;
 
+  /** Most recent `rootSchema` reference processed by `handleSchemaUpdate`.
+   *
+   * @private
+   */
+  private lastSeenRootSchema?: S;
+
+  /** True once a `rootSchema` has been registered with Ajv in this lifecycle.
+   *
+   * @private
+   */
+  private hasRegisteredRootSchema = false;
+
   /** Constructs an `AJV8Validator` instance using the `options`
    *
    * @param options - The `CustomValidatorOptionsType` options that are used to create the AJV instance
@@ -75,6 +87,8 @@ export default class AJV8Validator<
    */
   reset() {
     this.ajv.removeSchema();
+    this.lastSeenRootSchema = undefined;
+    this.hasRegisteredRootSchema = false;
   }
 
   /** Runs the pure validation of the `schema` and `formData` without any of the RJSF functionality. Provided for use
@@ -181,9 +195,14 @@ export default class AJV8Validator<
 
   /**
    * This function checks if a schema needs to be added and if the root schemas don't match it removes the old root schema from the ajv instance and adds the new one.
+   * When called repeatedly with the same `rootSchema` reference the deep-equality check is skipped.
+   *
    * @param rootSchema - The root schema used to provide $ref resolutions
    */
   handleSchemaUpdate(rootSchema: S): void {
+    if (this.lastSeenRootSchema === rootSchema && this.hasRegisteredRootSchema) {
+      return;
+    }
     const rootSchemaId = rootSchema[ID_KEY] ?? ROOT_SCHEMA_PREFIX;
     // add the rootSchema ROOT_SCHEMA_PREFIX as id.
     // if schema validator instance doesn't exist, add it.
@@ -194,6 +213,8 @@ export default class AJV8Validator<
       this.ajv.removeSchema(rootSchemaId);
       this.ajv.addSchema(rootSchema, rootSchemaId);
     }
+    this.lastSeenRootSchema = rootSchema;
+    this.hasRegisteredRootSchema = true;
   }
 
   /** Validates data against a schema, returning true if the data is valid, or

--- a/packages/validator-ajv8/test/validator.test.ts
+++ b/packages/validator-ajv8/test/validator.test.ts
@@ -144,6 +144,54 @@ describe('AJV8Validator', () => {
         getSchemaSpy.mockRestore();
         expect(compileSpy).toHaveBeenCalledTimes(1);
       });
+      it('skips Ajv re-registration when handleSchemaUpdate is called repeatedly with the same rootSchema reference', () => {
+        const localValidator = new AJV8Validator({});
+        const rootSchema: RJSFSchema = {
+          type: 'object',
+          properties: { foo: { type: 'string' } },
+        };
+
+        const addSchemaSpy = jest.spyOn(localValidator.ajv, 'addSchema');
+        const removeSchemaSpy = jest.spyOn(localValidator.ajv, 'removeSchema');
+
+        localValidator.handleSchemaUpdate(rootSchema);
+        localValidator.handleSchemaUpdate(rootSchema);
+        localValidator.handleSchemaUpdate(rootSchema);
+        localValidator.handleSchemaUpdate(rootSchema);
+
+        expect(addSchemaSpy).toHaveBeenCalledTimes(1);
+        expect(removeSchemaSpy).not.toHaveBeenCalled();
+
+        addSchemaSpy.mockRestore();
+        removeSchemaSpy.mockRestore();
+      });
+      it('falls back to deep-equality when handleSchemaUpdate receives a different rootSchema reference', () => {
+        const localValidator = new AJV8Validator({});
+        const rootSchemaA: RJSFSchema = {
+          type: 'object',
+          properties: { foo: { type: 'string' } },
+        };
+        const rootSchemaAClone: RJSFSchema = JSON.parse(JSON.stringify(rootSchemaA));
+        const rootSchemaB: RJSFSchema = {
+          type: 'object',
+          properties: { foo: { type: 'number' } },
+        };
+
+        const addSchemaSpy = jest.spyOn(localValidator.ajv, 'addSchema');
+        const removeSchemaSpy = jest.spyOn(localValidator.ajv, 'removeSchema');
+
+        localValidator.handleSchemaUpdate(rootSchemaA);
+        localValidator.handleSchemaUpdate(rootSchemaAClone);
+        expect(addSchemaSpy).toHaveBeenCalledTimes(1);
+        expect(removeSchemaSpy).not.toHaveBeenCalled();
+
+        localValidator.handleSchemaUpdate(rootSchemaB);
+        expect(removeSchemaSpy).toHaveBeenCalledTimes(1);
+        expect(addSchemaSpy).toHaveBeenCalledTimes(2);
+
+        addSchemaSpy.mockRestore();
+        removeSchemaSpy.mockRestore();
+      });
     });
     describe('validator.validateFormData()', () => {
       describe('No custom validate function, single value', () => {


### PR DESCRIPTION
### Reasons for making this change

Fixes [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291).

On large schemas with deep `dependencies` / `oneOf` / `anyOf` branches and richly populated form data, profiling shows the per-click cost in `<Form>` is dominated by `lodash.isEqualWith` walks routed through `deepEquals`. After applying both changes in this PR `baseIsEqualDeep` drops from the top of the bottom-up panel to a small fraction of click time.

There is a history here that this PR explicitly tries not to repeat:

- [#4292](https://github.com/rjsf-team/react-jsonschema-form/pull/4292) replaced `lodash.isEqualWith` with `fast-equals.createCustomEqual`. It was reverted by [#4300](https://github.com/rjsf-team/react-jsonschema-form/pull/4300) because cyclic `formData` (e.g. an `onChange` handler storing the whole `IChangeEvent`) hit `Maximum call stack size exceeded`.
- [#4446](https://github.com/rjsf-team/react-jsonschema-form/pull/4446) re-attempted the migration after `fast-equals` shipped function comparison support. It was reverted by [#4478](https://github.com/rjsf-team/react-jsonschema-form/pull/4478) because [#4475](https://github.com/rjsf-team/react-jsonschema-form/issues/4475) reported the same `Maximum call stack size exceeded` symptom under `liveOmit` + `omitExtraData` with custom validation.

The common theme in both reverts: `fast-equals.createCustomEqual` was used **without** opting into cycle detection, and `lodash.isEqualWith`'s built-in `Stack` cache had been silently protecting consumers with cyclic inputs.

### What this PR does

Two independent perf changes, one per package, in two commits.

#### 1. `perf(utils): switch deepEquals to fast-equals with cycle detection`

- `deepEquals` now uses `createCustomEqual({ circular: true, ... })`. Cycle detection is the difference from #4292 / #4446 and is what makes this safe.
- The `lodash.isEqual` callers inside `@rjsf/utils` (`useDeepCompareMemo`, `isRootSchema`, `findSelectedOptionInXxxOf`) are migrated to `deepEquals` so the perf benefit is shared across the package — same intent as the second half of #4446.
- New regression tests in `packages/utils/test/deepEquals.test.ts` exercise self-referential, mutually-referential, and cyclic-array inputs. These tests pass on the current `lodash.isEqualWith`-based implementation (lodash also tracks cycles), they pass on this PR, and they fail (`Maximum call stack size exceeded`) on a `fast-equals` configuration that omits `circular: true` — which is the failure mode that drove both prior reverts. So the tests serve as a forward guard against re-introducing the same regression.

#### 2. `perf(validator-ajv8): cache rootSchema reference in handleSchemaUpdate`

Independent of the `deepEquals` change. `retrieveSchema` invokes `isValid` (and therefore `handleSchemaUpdate`) once per `if`/`then`/`else` and per `dependencies.<key>.oneOf` branch evaluated during a render. On a form with a large `rootSchema` containing many branches the deep-equality check inside `handleSchemaUpdate` dominates click cost, even with the faster `deepEquals` from commit 1.

This commit caches the last-seen `rootSchema` reference and short-circuits when it is referentially equal on subsequent calls. Most consumers pass a stable `rootSchema` across calls within a render, so all but the first call become O(1). The structural `deepEquals` fallback still runs when the reference changes, preserving correctness for callers that legitimately rebuild the schema. New regression tests in `packages/validator-ajv8/test/validator.test.ts` cover both the cache hit and the structural fallback.

### Trade-offs / risks

- `fast-equals` is added as a new direct dependency of `@rjsf/utils` (not a peer). Same dep that was added in #4292 / #4446.
- Behavioural difference vs `lodash.isEqualWith`: the function-equality customizer (#255) is preserved, and cycle handling is preserved via `circular: true`. The remaining surface — primitives, plain objects, arrays, RegExp, Map, Set, typed arrays — is supported by `fast-equals` and matches `lodash.isEqualWith` for the inputs RJSF compares (form data, schemas, error schemas, `FieldPathId`).
- `handleSchemaUpdate` semantics change: when called repeatedly with the same `rootSchema` reference within a render, no Ajv re-registration happens. This was already a no-op in practice (`deepEquals` returned `true` for the same content), so observable behaviour is identical; only the cost differs.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature