### PR TITLE
Fix 4952 by updating ArrayField onChange handling for objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Fixed `processPendingChange()` using `originalErrorSchema` (which already contains merged `extraErrors`) as the base for `mergeErrors()`, causing sibling-field `extraErrors` to accumulate duplicate entries on every array mutation, fixing [#5041](https://github.com/rjsf-team/react-jsonschema-form/issues/5041)
+- Updated `ArrayField`'s change handling to only `null` out data for paths that are directly an array indexed value and not object properties within them, fixing [#4952](https://github.com/rjsf-team/react-jsonschema-form/issues/4952)
 
 ## @rjsf/utils
 

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -1028,10 +1028,12 @@ export default function ArrayField<T = any, S extends StrictRJSFSchema = RJSFSch
    */
   const handleChange = useCallback(
     (value: any, path: FieldPathList, newErrorSchema?: ErrorSchema<T>, id?: string) => {
+      const lastPathIsItemIndex = typeof path.at(-1) === 'number';
       onChange(
         // We need to treat undefined items as nulls to have validation.
         // See https://github.com/tdegrunt/jsonschema/issues/206
-        value === undefined ? null : value,
+        // Only set to null for array items, and not for object properties within array items
+        lastPathIsItemIndex && value === undefined ? null : value,
         path,
         newErrorSchema as ErrorSchema<T[]>,
         id,

--- a/packages/core/test/ArrayField.test.tsx
+++ b/packages/core/test/ArrayField.test.tsx
@@ -3769,4 +3769,36 @@ describe('ArrayField', () => {
       expect(tagInputs.length).toBeGreaterThanOrEqual(3); // 2 tags in first item + 1 tag in second item
     });
   });
+
+  describe('Array of object items with optional number field', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        arrayList: {
+          type: 'array',
+          title: 'A list with a minimal number of items',
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string', default: 'Default name' },
+              age: { type: 'number' },
+            },
+          },
+        },
+      },
+    };
+
+    it('should not save null when clearing an optional number field and submitting', () => {
+      const { node, onSubmit } = createFormComponent({
+        schema,
+        formData: { arrayList: [{ name: 'John', age: 25 }] },
+      });
+
+      const ageInput = node.querySelector('#root_arrayList_0_age') as HTMLInputElement;
+      fireEvent.change(ageInput, { target: { value: '' } });
+      submitForm(node);
+
+      expectToHaveBeenCalledWithFormData(onSubmit, { arrayList: [{ name: 'John' }] }, true);
+    });
+  });
 });


### PR DESCRIPTION
### Reasons for making this change

Fixed #4952 by updating `ArrayField`'s change handling for contained object field properties to not set nulls
- Updated `ArrayField` to detect if the change is for the item index itself or the nested object property, and only set nulls for index changes
  - Updated the tests to verify the fix
- Updated `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
