### PR TITLE
feat: support deprecated keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Switched `deepEquals` from `lodash.isEqualWith` to `fast-equals.createCustomEqual` with cycle detection enabled, and replaced direct `lodash.isEqual` usage in `useDeepCompareMemo`, `isRootSchema`, and `findSelectedOptionInXxxOf` with `deepEquals`, fixing [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291)
 - Fixed `getObjectDefaults` re-injecting stale schema-level `default` keys into an `additionalProperties` object when `formData` already contains its own keys (e.g. after a key rename), preventing ghost entries from reappearing, fixing [#4948](https://github.com/rjsf-team/react-jsonschema-form/issues/4948)
 - Added `deprecatedHandling` to `GlobalUISchemaOptions` and updated `StrictRJSFSchema` to be recursive, ensuring the `deprecated` keyword (and future extensions) are supported in all nested schema structures without requiring type casts. Fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
+- Added `DeprecatedLabel` to `TranslatableString` to support internationalization of the deprecated field suffix. Fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
 
 
 ## @rjsf/validator-ajv8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 6.5.3
+
+## @rjsf/core
+
+- Updated `ArrayField`'s change handling to only `null` out data for paths that are directly an array indexed value and not object properties within them, fixing [#4952](https://github.com/rjsf-team/react-jsonschema-form/issues/4952)
+- Added support for the JSON Schema `deprecated` keyword in `SchemaField`, providing options to hide, disable, or label deprecated fields via a new `deprecatedHandling` global UI option, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
+
+## @rjsf/utils
+
+- Added `deprecatedHandling` to `GlobalUISchemaOptions` and updated `StrictRJSFSchema` to be recursive, ensuring the `deprecated` keyword (and future extensions) are supported in all nested schema structures without requiring type casts, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
+  - Also added `DeprecatedLabel` to `TranslatableString` to support internationalization of the deprecated field suffix
+- Added support for the JSON Schema `deprecated` keyword in `SchemaField`, providing options to hide, disable, or label deprecated fields via a new `deprecatedHandling` global UI option, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
+
 # 6.5.2
 
 ## @rjsf/core
@@ -23,8 +36,6 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `processPendingChange` leaving optional object keys as `undefined` after clearing text inputs (invalid for AJV `type: "string"`), by unsetting keys for resolved non-oneOf/anyOf leaves while preserving explicit `undefined` for oneOf/anyOf branches, fixing [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518)
 - Fixed `processPendingChange()` using `originalErrorSchema` (which already contains merged `extraErrors`) as the base for `mergeErrors()`, causing sibling-field `extraErrors` to accumulate duplicate entries on every array mutation, fixing [#5041](https://github.com/rjsf-team/react-jsonschema-form/issues/5041)
 - Added `ObjectField` test for renaming a nested `additionalProperties` key using `userEvent` and `reset()` via a form ref, verifying fix for [#4948](https://github.com/rjsf-team/react-jsonschema-form/issues/4948)
-- Updated `ArrayField`'s change handling to only `null` out data for paths that are directly an array indexed value and not object properties within them, fixing [#4952](https://github.com/rjsf-team/react-jsonschema-form/issues/4952)
-- Added support for the JSON Schema `deprecated` keyword in `SchemaField`, providing options to hide, disable, or label deprecated fields via a new `deprecatedHandling` global UI option, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
 
 ## @rjsf/mui
 
@@ -37,10 +48,6 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Switched `deepEquals` from `lodash.isEqualWith` to `fast-equals.createCustomEqual` with cycle detection enabled, and replaced direct `lodash.isEqual` usage in `useDeepCompareMemo`, `isRootSchema`, and `findSelectedOptionInXxxOf` with `deepEquals`, fixing [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291)
 - Fixed `getObjectDefaults` re-injecting stale schema-level `default` keys into an `additionalProperties` object when `formData` already contains its own keys (e.g. after a key rename), preventing ghost entries from reappearing, fixing [#4948](https://github.com/rjsf-team/react-jsonschema-form/issues/4948)
-- Added support for the JSON Schema `deprecated` keyword in `SchemaField`, providing options to hide, disable, or label deprecated fields via a new `deprecatedHandling` global UI option, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
-- Added `deprecatedHandling` to `GlobalUISchemaOptions` and updated `StrictRJSFSchema` to be recursive, ensuring the `deprecated` keyword (and future extensions) are supported in all nested schema structures without requiring type casts, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
-  - Also added `DeprecatedLabel` to `TranslatableString` to support internationalization of the deprecated field suffix
-
 
 ## @rjsf/validator-ajv8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `processPendingChange()` using `originalErrorSchema` (which already contains merged `extraErrors`) as the base for `mergeErrors()`, causing sibling-field `extraErrors` to accumulate duplicate entries on every array mutation, fixing [#5041](https://github.com/rjsf-team/react-jsonschema-form/issues/5041)
 - Added `ObjectField` test for renaming a nested `additionalProperties` key using `userEvent` and `reset()` via a form ref, verifying fix for [#4948](https://github.com/rjsf-team/react-jsonschema-form/issues/4948)
 - Updated `ArrayField`'s change handling to only `null` out data for paths that are directly an array indexed value and not object properties within them, fixing [#4952](https://github.com/rjsf-team/react-jsonschema-form/issues/4952)
+- Added support for the JSON Schema `deprecated` keyword in `SchemaField`, providing options to hide, disable, or label deprecated fields via a new `deprecatedHandling` global UI option. Fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
 
 ## @rjsf/mui
 
@@ -36,6 +37,8 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Switched `deepEquals` from `lodash.isEqualWith` to `fast-equals.createCustomEqual` with cycle detection enabled, and replaced direct `lodash.isEqual` usage in `useDeepCompareMemo`, `isRootSchema`, and `findSelectedOptionInXxxOf` with `deepEquals`, fixing [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291)
 - Fixed `getObjectDefaults` re-injecting stale schema-level `default` keys into an `additionalProperties` object when `formData` already contains its own keys (e.g. after a key rename), preventing ghost entries from reappearing, fixing [#4948](https://github.com/rjsf-team/react-jsonschema-form/issues/4948)
+- Added `deprecatedHandling` to `GlobalUISchemaOptions` and updated `StrictRJSFSchema` to be recursive, ensuring the `deprecated` keyword (and future extensions) are supported in all nested schema structures without requiring type casts. Fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
+
 
 ## @rjsf/validator-ajv8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `processPendingChange()` using `originalErrorSchema` (which already contains merged `extraErrors`) as the base for `mergeErrors()`, causing sibling-field `extraErrors` to accumulate duplicate entries on every array mutation, fixing [#5041](https://github.com/rjsf-team/react-jsonschema-form/issues/5041)
 - Added `ObjectField` test for renaming a nested `additionalProperties` key using `userEvent` and `reset()` via a form ref, verifying fix for [#4948](https://github.com/rjsf-team/react-jsonschema-form/issues/4948)
 - Updated `ArrayField`'s change handling to only `null` out data for paths that are directly an array indexed value and not object properties within them, fixing [#4952](https://github.com/rjsf-team/react-jsonschema-form/issues/4952)
-- Added support for the JSON Schema `deprecated` keyword in `SchemaField`, providing options to hide, disable, or label deprecated fields via a new `deprecatedHandling` global UI option. Fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
+- Added support for the JSON Schema `deprecated` keyword in `SchemaField`, providing options to hide, disable, or label deprecated fields via a new `deprecatedHandling` global UI option, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
 
 ## @rjsf/mui
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,9 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Switched `deepEquals` from `lodash.isEqualWith` to `fast-equals.createCustomEqual` with cycle detection enabled, and replaced direct `lodash.isEqual` usage in `useDeepCompareMemo`, `isRootSchema`, and `findSelectedOptionInXxxOf` with `deepEquals`, fixing [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291)
 - Fixed `getObjectDefaults` re-injecting stale schema-level `default` keys into an `additionalProperties` object when `formData` already contains its own keys (e.g. after a key rename), preventing ghost entries from reappearing, fixing [#4948](https://github.com/rjsf-team/react-jsonschema-form/issues/4948)
-- Added `deprecatedHandling` to `GlobalUISchemaOptions` and updated `StrictRJSFSchema` to be recursive, ensuring the `deprecated` keyword (and future extensions) are supported in all nested schema structures without requiring type casts. Fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
-- Added `DeprecatedLabel` to `TranslatableString` to support internationalization of the deprecated field suffix. Fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
+- Added support for the JSON Schema `deprecated` keyword in `SchemaField`, providing options to hide, disable, or label deprecated fields via a new `deprecatedHandling` global UI option, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
+- Added `deprecatedHandling` to `GlobalUISchemaOptions` and updated `StrictRJSFSchema` to be recursive, ensuring the `deprecated` keyword (and future extensions) are supported in all nested schema structures without requiring type casts, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
+  - Also added `DeprecatedLabel` to `TranslatableString` to support internationalization of the deprecated field suffix
 
 
 ## @rjsf/validator-ajv8

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -133,7 +133,11 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   );
 
   const FieldComponent = getFieldComponent<T, S, F>(schema, uiOptions, registry);
-  const disabled = Boolean(uiOptions.disabled ?? props.disabled);
+
+  const isDeprecated = Boolean(schema.deprecated);
+  const deprecatedHandling = isDeprecated ? (uiOptions.deprecatedHandling ?? 'label') : undefined;
+
+  const disabled = Boolean(uiOptions.disabled ?? props.disabled) || deprecatedHandling === 'disable';
   const readonly = Boolean(uiOptions.readonly ?? (props.readonly || props.schema.readOnly || schema.readOnly));
   const uiSchemaHideError = uiOptions.hideError;
   // Set hideError to the value provided in the uiSchema, otherwise stick with the prop to propagate to children
@@ -214,9 +218,13 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
         : uiOptions.title || props.schema.title || schema.title || props.title || name;
   }
 
+  if (deprecatedHandling === 'label') {
+    label = `${label} (deprecated)`;
+  }
+
   const description = uiOptions.description || props.schema.description || schema.description || '';
   const help = uiOptions.help;
-  const hidden = uiOptions.widget === 'hidden';
+  const hidden = uiOptions.widget === 'hidden' || deprecatedHandling === 'hide';
 
   const classNames = ['rjsf-field', `rjsf-field-${getSchemaType(schema)}`];
   if (!hideError && __errors && __errors.length > 0) {

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -23,6 +23,7 @@ import {
   shouldRenderOptionalField,
   StrictRJSFSchema,
   toFieldPathId,
+  TranslatableString,
   UI_OPTIONS_KEY,
   UIOptionsType,
 } from '@rjsf/utils';
@@ -219,7 +220,7 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   }
 
   if (deprecatedHandling === 'label') {
-    label = `${label} (deprecated)`;
+    label = registry.translateString(TranslatableString.DeprecatedLabel, [label]);
   }
 
   const description = uiOptions.description || props.schema.description || schema.description || '';

--- a/packages/core/test/SchemaField.test.tsx
+++ b/packages/core/test/SchemaField.test.tsx
@@ -380,6 +380,51 @@ describe('SchemaField', () => {
     });
   });
 
+  describe('deprecatedHandling', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        foo: { type: 'string', deprecated: true },
+        bar: { type: 'string' },
+      },
+    };
+
+    it('should append (deprecated) to label by default', () => {
+      const { node } = createFormComponent({ schema });
+      const labels = node.querySelectorAll('label');
+      expect(labels[0]).toHaveTextContent('foo (deprecated)');
+      expect(labels[1]).toHaveTextContent('bar');
+    });
+
+    it('should not append (deprecated) if deprecatedHandling is not label', () => {
+      const uiSchema: UiSchema = {
+        'ui:globalOptions': { deprecatedHandling: 'disable' },
+      };
+      const { node } = createFormComponent({ schema, uiSchema });
+      const labels = node.querySelectorAll('label');
+      expect(labels[0]).toHaveTextContent('foo');
+    });
+
+    it('should disable field if deprecatedHandling is disable', () => {
+      const uiSchema: UiSchema = {
+        'ui:globalOptions': { deprecatedHandling: 'disable' },
+      };
+      const { node } = createFormComponent({ schema, uiSchema });
+      const inputs = node.querySelectorAll('input');
+      expect(inputs[0]).toBeDisabled();
+      expect(inputs[1]).not.toBeDisabled();
+    });
+
+    it('should hide field if deprecatedHandling is hide', () => {
+      const uiSchema: UiSchema = {
+        'ui:globalOptions': { deprecatedHandling: 'hide' },
+      };
+      const { node } = createFormComponent({ schema, uiSchema });
+      const hiddenFields = node.querySelectorAll('.hidden');
+      expect(hiddenFields.length).toBe(1);
+    });
+  });
+
   describe('description support', () => {
     const schema: RJSFSchema = {
       type: 'object',

--- a/packages/utils/src/enums.ts
+++ b/packages/utils/src/enums.ts
@@ -68,6 +68,8 @@ export enum TranslatableString {
   TitleOptionPrefix = '%1 option %2',
   /** Key label, where %1 will be replaced by the label as provided by WrapIfAdditionalTemplate */
   KeyLabel = '%1 Key',
+  /** Deprecated label, where %1 will be replaced by the label as provided by SchemaField */
+  DeprecatedLabel = '%1 (deprecated)',
   // Strings with replaceable parameters AND/OR that support markdown and html
   /** Invalid object field configuration as provided by the ObjectField.
    * NOTE: Use markdown notation rather than html tags.

--- a/packages/utils/src/jsonSchemaAugmentation.ts
+++ b/packages/utils/src/jsonSchemaAugmentation.ts
@@ -1,3 +1,5 @@
+import type { JSONSchema7 } from 'json-schema';
+
 /**
  * This file is used to augment the `json-schema` module with the `deprecated` keyword.
  *
@@ -7,8 +9,6 @@
  * ensures the augmentation is correctly applied by the TypeScript compiler without
  * confusing runtime module resolvers.
  */
-import type { JSONSchema7 } from 'json-schema';
-
 declare module 'json-schema' {
   export interface JSONSchema7 {
     /** The deprecated keyword is a boolean that indicates that the instance value the keyword applies to should not be

--- a/packages/utils/src/jsonSchemaAugmentation.ts
+++ b/packages/utils/src/jsonSchemaAugmentation.ts
@@ -1,0 +1,12 @@
+import type { JSONSchema7 } from 'json-schema';
+
+declare module 'json-schema' {
+  export interface JSONSchema7 {
+    /** The deprecated keyword is a boolean that indicates that the instance value the keyword applies to should not be
+     * used and may be removed in the future.
+     */
+    deprecated?: boolean;
+  }
+}
+
+export type { JSONSchema7 };

--- a/packages/utils/src/jsonSchemaAugmentation.ts
+++ b/packages/utils/src/jsonSchemaAugmentation.ts
@@ -1,3 +1,12 @@
+/**
+ * This file is used to augment the `json-schema` module with the `deprecated` keyword.
+ *
+ * It is a dedicated file because `json-schema` is a type-only package. Standard augmentation
+ * using `import 'json-schema'` in a file with other imports can cause module resolution
+ * errors in certain environments (like Jest). Using `import type` in this dedicated file
+ * ensures the augmentation is correctly applied by the TypeScript compiler without
+ * confusing runtime module resolvers.
+ */
 import type { JSONSchema7 } from 'json-schema';
 
 declare module 'json-schema' {

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -489,7 +489,7 @@ export type GlobalUISchemaOptions = GenericObjectType & {
   /** Controls how a deprecated property is rendered.
    * - `hide`: The field is completely hidden (via the `hidden` prop passed to FieldTemplate).
    * - `disable`: The field is rendered but disabled.
-   * - `label`: The field is rendered with "(deprecated)" appended to its label.
+   * - `label` (default): The field is rendered with "(deprecated)" appended to its label.
    */
   deprecatedHandling?: 'hide' | 'disable' | 'label';
 };

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -22,7 +22,46 @@ export type GenericObjectType = {
 /** Map the JSONSchema7 to our own type so that we can easily bump to a more recent version at some future date and only
  * have to update this one type.
  */
-export type StrictRJSFSchema = JSONSchema7;
+export type StrictRJSFSchema = JSONSchema7 & {
+  /** The deprecated keyword is a boolean that indicates that the instance value the keyword applies to should not be
+   * used and may be removed in the future.
+   */
+  deprecated?: boolean;
+  /** Recursive support for StrictRJSFSchema in properties */
+  properties?: {
+    [key: string]: StrictRJSFSchema | boolean;
+  };
+  /** Recursive support for StrictRJSFSchema in items */
+  items?: StrictRJSFSchema | StrictRJSFSchema[] | boolean;
+  /** Recursive support for StrictRJSFSchema in additionalProperties */
+  additionalProperties?: StrictRJSFSchema | boolean;
+  /** Recursive support for StrictRJSFSchema in patternProperties */
+  patternProperties?: {
+    [key: string]: StrictRJSFSchema | boolean;
+  };
+  /** Recursive support for StrictRJSFSchema in definitions */
+  definitions?: {
+    [key: string]: StrictRJSFSchema | boolean;
+  };
+  /** Recursive support for StrictRJSFSchema in dependencies */
+  dependencies?: {
+    [key: string]: StrictRJSFSchema | boolean | string[];
+  };
+  /** Recursive support for StrictRJSFSchema in allOf */
+  allOf?: StrictRJSFSchema[];
+  /** Recursive support for StrictRJSFSchema in anyOf */
+  anyOf?: StrictRJSFSchema[];
+  /** Recursive support for StrictRJSFSchema in oneOf */
+  oneOf?: StrictRJSFSchema[];
+  /** Recursive support for StrictRJSFSchema in not */
+  not?: StrictRJSFSchema | boolean;
+  /** Recursive support for StrictRJSFSchema in if */
+  if?: StrictRJSFSchema | boolean;
+  /** Recursive support for StrictRJSFSchema in then */
+  then?: StrictRJSFSchema | boolean;
+  /** Recursive support for StrictRJSFSchema in else */
+  else?: StrictRJSFSchema | boolean;
+};
 
 /** Allow for more flexible schemas (i.e. draft-2019) than the strict JSONSchema7
  */
@@ -447,6 +486,12 @@ export type GlobalUISchemaOptions = GenericObjectType & {
    *  only affects the DOM-level encoding.
    */
   optionValueFormat?: OptionValueFormat;
+  /** Controls how a deprecated property is rendered.
+   * - `hide`: The field is completely hidden (via the `hidden` prop passed to FieldTemplate).
+   * - `disable`: The field is rendered but disabled.
+   * - `label`: The field is rendered with "(deprecated)" appended to its label.
+   */
+  deprecatedHandling?: 'hide' | 'disable' | 'label';
 };
 
 /** The set of options from the `Form` that will be available on the `Registry` for use in everywhere the `registry` is

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -9,6 +9,7 @@ import type {
   StyleHTMLAttributes,
 } from 'react';
 import { JSONSchema7 } from 'json-schema';
+
 import { TranslatableString } from './enums';
 import './jsonSchemaAugmentation';
 

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -9,8 +9,8 @@ import type {
   StyleHTMLAttributes,
 } from 'react';
 import { JSONSchema7 } from 'json-schema';
-
 import { TranslatableString } from './enums';
+import './jsonSchemaAugmentation';
 
 /** The representation of any generic object type, usually used as an intersection on other types to make them more
  * flexible in the properties they support (i.e. anything else)
@@ -22,46 +22,7 @@ export type GenericObjectType = {
 /** Map the JSONSchema7 to our own type so that we can easily bump to a more recent version at some future date and only
  * have to update this one type.
  */
-export type StrictRJSFSchema = JSONSchema7 & {
-  /** The deprecated keyword is a boolean that indicates that the instance value the keyword applies to should not be
-   * used and may be removed in the future.
-   */
-  deprecated?: boolean;
-  /** Recursive support for StrictRJSFSchema in properties */
-  properties?: {
-    [key: string]: StrictRJSFSchema | boolean;
-  };
-  /** Recursive support for StrictRJSFSchema in items */
-  items?: StrictRJSFSchema | StrictRJSFSchema[] | boolean;
-  /** Recursive support for StrictRJSFSchema in additionalProperties */
-  additionalProperties?: StrictRJSFSchema | boolean;
-  /** Recursive support for StrictRJSFSchema in patternProperties */
-  patternProperties?: {
-    [key: string]: StrictRJSFSchema | boolean;
-  };
-  /** Recursive support for StrictRJSFSchema in definitions */
-  definitions?: {
-    [key: string]: StrictRJSFSchema | boolean;
-  };
-  /** Recursive support for StrictRJSFSchema in dependencies */
-  dependencies?: {
-    [key: string]: StrictRJSFSchema | boolean | string[];
-  };
-  /** Recursive support for StrictRJSFSchema in allOf */
-  allOf?: StrictRJSFSchema[];
-  /** Recursive support for StrictRJSFSchema in anyOf */
-  anyOf?: StrictRJSFSchema[];
-  /** Recursive support for StrictRJSFSchema in oneOf */
-  oneOf?: StrictRJSFSchema[];
-  /** Recursive support for StrictRJSFSchema in not */
-  not?: StrictRJSFSchema | boolean;
-  /** Recursive support for StrictRJSFSchema in if */
-  if?: StrictRJSFSchema | boolean;
-  /** Recursive support for StrictRJSFSchema in then */
-  then?: StrictRJSFSchema | boolean;
-  /** Recursive support for StrictRJSFSchema in else */
-  else?: StrictRJSFSchema | boolean;
-};
+export type StrictRJSFSchema = JSONSchema7;
 
 /** Allow for more flexible schemas (i.e. draft-2019) than the strict JSONSchema7
  */


### PR DESCRIPTION
### Reasons for making this change
Fixes : #5024 

### Summary:
*   **`@rjsf/utils`**: Added `deprecatedHandling` to `GlobalUISchemaOptions` and made `StrictRJSFSchema` recursive for deep keyword support.
*   **`@rjsf/core`**: Implemented the rendering logic in `SchemaField` to hide, disable, or label deprecated fields.
*   **Tests**: Added comprehensive unit tests for all handling modes.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
