### PR TITLE
fix(core): omit undefined object leaves so string validation works with patternProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
-- Fixed `processPendingChange` leaving optional object keys as `undefined` after clearing text inputs (invalid for AJV `type: "string"`), by unsetting keys for resolved non-oneOf/anyOf leaves while preserving explicit `undefined` for oneOf/anyOf branches, fixing [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) ([#5056](https://github.com/rjsf-team/react-jsonschema-form/pull/5056))
+- Fixed `processPendingChange` leaving optional object keys as `undefined` after clearing text inputs (invalid for AJV `type: "string"`), by unsetting keys for resolved non-oneOf/anyOf leaves while preserving explicit `undefined` for oneOf/anyOf branches, fixing [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518)
 - Fixed `processPendingChange()` using `originalErrorSchema` (which already contains merged `extraErrors`) as the base for `mergeErrors()`, causing sibling-field `extraErrors` to accumulate duplicate entries on every array mutation, fixing [#5041](https://github.com/rjsf-team/react-jsonschema-form/issues/5041)
 - Added `ObjectField` test for renaming a nested `additionalProperties` key using `userEvent` and `reset()` via a form ref, verifying fix for [#4948](https://github.com/rjsf-team/react-jsonschema-form/issues/4948)
 - Updated `ArrayField`'s change handling to only `null` out data for paths that are directly an array indexed value and not object properties within them, fixing [#4952](https://github.com/rjsf-team/react-jsonschema-form/issues/4952)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
+- Fixed `processPendingChange` leaving optional object keys as `undefined` after clearing text inputs (invalid for AJV `type: "string"`), by unsetting keys for resolved non-oneOf/anyOf leaves while preserving explicit `undefined` for oneOf/anyOf branches, fixing [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) ([#5056](https://github.com/rjsf-team/react-jsonschema-form/pull/5056))
 - Fixed `processPendingChange()` using `originalErrorSchema` (which already contains merged `extraErrors`) as the base for `mergeErrors()`, causing sibling-field `extraErrors` to accumulate duplicate entries on every array mutation, fixing [#5041](https://github.com/rjsf-team/react-jsonschema-form/issues/5041)
 - Added `ObjectField` test for renaming a nested `additionalProperties` key using `userEvent` and `reset()` via a form ref, verifying fix for [#4948](https://github.com/rjsf-team/react-jsonschema-form/issues/4948)
 - Updated `ArrayField`'s change handling to only `null` out data for paths that are directly an array indexed value and not object properties within them, fixing [#4952](https://github.com/rjsf-team/react-jsonschema-form/issues/4952)

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -926,11 +926,14 @@ export default class Form<
         _unset(formData, path);
       } else if (!isRootPath) {
         // If the newValue is not on the root path, then set it into the form data
+        let unsetPath = false;
+        let valueForPath: T | null | undefined = newValue;
+
         if (newValue === undefined) {
           const lastSegment = path[path.length - 1];
           if (typeof lastSegment === 'number') {
-            // Array items: match ArrayField `handleChange` — AJV needs `null`, not a hole/undefined.
-            _set(formData, path, null);
+            // Array items: match ArrayField `handleChange` — AJV needs `null`, not undefined.
+            valueForPath = null as unknown as T;
           } else {
             const { field } = schemaUtils.findFieldInSchema(schema, path, oldFormData);
             const leaf = field as RJSFSchema | undefined;
@@ -938,17 +941,21 @@ export default class Form<
             if (isOneOfOrAnyOfLeaf) {
               // Keep explicit `undefined` so mergeDefaults does not immediately re-apply a branch default (e.g. cleared
               // oneOf / anyOf widget).
-              _set(formData, path, newValue);
+              valueForPath = newValue;
             } else if (leaf !== undefined) {
               // Plain leaves: omit the key instead of `{ key: undefined }`, which breaks `type: "string"` validation in
               // AJV after clearing a text input (https://github.com/rjsf-team/react-jsonschema-form/issues/4518).
-              _unset(formData, path);
+              unsetPath = true;
             } else {
-              _set(formData, path, newValue);
+              valueForPath = newValue;
             }
           }
+        }
+
+        if (unsetPath) {
+          _unset(formData, path);
         } else {
-          _set(formData, path, newValue);
+          _set(formData, path, valueForPath);
         }
       }
       // Pass true to skip live validation in `getStateFromProps()` since we will do it a bit later

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -935,7 +935,12 @@ export default class Form<
             // Array items: match ArrayField `handleChange` — AJV needs `null`, not undefined.
             valueForPath = null as unknown as T;
           } else {
-            const { field } = schemaUtils.findFieldInSchema(schema, path, oldFormData);
+            const { field } = schemaUtils.findFieldInSchema(
+              schema,
+              // `findFieldInSchema` typings use `string[]`; paths may include numeric segments (same as lodash `get`).
+              path as string[],
+              oldFormData,
+            );
             const leaf = field as RJSFSchema | undefined;
             const isOneOfOrAnyOfLeaf = leaf && (ONE_OF_KEY in leaf || ANY_OF_KEY in leaf);
             // Plain leaves: omit the key instead of `{ key: undefined }`, which breaks `type: "string"` validation in

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -45,6 +45,8 @@ import {
   NameGeneratorFunction,
   getUsedFormData,
   getFieldNames,
+  ANY_OF_KEY,
+  ONE_OF_KEY,
 } from '@rjsf/utils';
 import _cloneDeep from 'lodash/cloneDeep';
 import _get from 'lodash/get';
@@ -924,7 +926,30 @@ export default class Form<
         _unset(formData, path);
       } else if (!isRootPath) {
         // If the newValue is not on the root path, then set it into the form data
-        _set(formData, path, newValue);
+        if (newValue === undefined) {
+          const lastSegment = path[path.length - 1];
+          if (typeof lastSegment === 'number') {
+            // Array items: match ArrayField `handleChange` — AJV needs `null`, not a hole/undefined.
+            _set(formData, path, null);
+          } else {
+            const { field } = schemaUtils.findFieldInSchema(schema, path, oldFormData);
+            const leaf = field as RJSFSchema | undefined;
+            const isOneOfOrAnyOfLeaf = leaf && (ONE_OF_KEY in leaf || ANY_OF_KEY in leaf);
+            if (isOneOfOrAnyOfLeaf) {
+              // Keep explicit `undefined` so mergeDefaults does not immediately re-apply a branch default (e.g. cleared
+              // oneOf / anyOf widget).
+              _set(formData, path, newValue);
+            } else if (leaf !== undefined) {
+              // Plain leaves: omit the key instead of `{ key: undefined }`, which breaks `type: "string"` validation in
+              // AJV after clearing a text input (https://github.com/rjsf-team/react-jsonschema-form/issues/4518).
+              _unset(formData, path);
+            } else {
+              _set(formData, path, newValue);
+            }
+          }
+        } else {
+          _set(formData, path, newValue);
+        }
       }
       // Pass true to skip live validation in `getStateFromProps()` since we will do it a bit later
       const newState = this.getStateFromProps(this.props, inputForDefaults, undefined, undefined, undefined, true);

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -938,16 +938,12 @@ export default class Form<
             const { field } = schemaUtils.findFieldInSchema(schema, path, oldFormData);
             const leaf = field as RJSFSchema | undefined;
             const isOneOfOrAnyOfLeaf = leaf && (ONE_OF_KEY in leaf || ANY_OF_KEY in leaf);
-            if (isOneOfOrAnyOfLeaf) {
-              // Keep explicit `undefined` so mergeDefaults does not immediately re-apply a branch default (e.g. cleared
-              // oneOf / anyOf widget).
-              valueForPath = newValue;
-            } else if (leaf !== undefined) {
-              // Plain leaves: omit the key instead of `{ key: undefined }`, which breaks `type: "string"` validation in
-              // AJV after clearing a text input (https://github.com/rjsf-team/react-jsonschema-form/issues/4518).
+            // Plain leaves: omit the key instead of `{ key: undefined }`, which breaks `type: "string"` validation in
+            // AJV after clearing a text input (https://github.com/rjsf-team/react-jsonschema-form/issues/4518).
+            // oneOf/anyOf leaves and unresolved leaves: keep `valueForPath === newValue` (already `undefined`) so
+            // mergeDefaults does not immediately re-apply a branch default when clearing those widgets.
+            if (!isOneOfOrAnyOfLeaf && leaf !== undefined) {
               unsetPath = true;
-            } else {
-              valueForPath = newValue;
             }
           }
         }

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -937,8 +937,8 @@ export default class Form<
           } else {
             const { field } = schemaUtils.findFieldInSchema(
               schema,
-              // `findFieldInSchema` typings use `string[]`; paths may include numeric segments (same as lodash `get`).
-              path as string[],
+              // `FieldPathList` allows numeric segments; normalize so `findFieldInSchema` receives `string[]`.
+              path.map((segment) => String(segment)),
               oldFormData,
             );
             const leaf = field as RJSFSchema | undefined;

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -6046,3 +6046,57 @@ describe('extraErrors not duplicated when sibling array field mutated (#5041)', 
     expect(nameErrors[0]).toBe('Name is required');
   });
 });
+
+describe('patternProperties with fixed properties (#4518)', () => {
+  it('should submit valid formData after a nested string field is cleared (no undefined leaf values)', async () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        annotations: {
+          type: 'object',
+          additionalProperties: {
+            type: 'string',
+          },
+          patternProperties: {
+            '^.+$': {
+              type: 'string',
+            },
+          },
+          description: 'A set of key-value annotations.',
+          properties: {
+            testEmptyAnnotation1: {
+              type: 'string',
+              title: 'annotation1',
+            },
+            testEmptyAnnotation2: {
+              type: 'string',
+              title: 'annotation2',
+            },
+          },
+        },
+      },
+    };
+
+    const { container, node, onSubmit, onError } = createFormComponent({
+      schema,
+      formData: { annotations: {} },
+    });
+
+    submitForm(node);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalled();
+    onSubmit.mockClear();
+    onError.mockClear();
+
+    const input = container.querySelector<HTMLInputElement>('#root_annotations_testEmptyAnnotation1');
+    expect(input).toBeInTheDocument();
+    await user.type(input!, 'hello');
+    await user.clear(input!);
+
+    submitForm(node);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalled();
+    const { formData } = onSubmit.mock.calls[onSubmit.mock.calls.length - 1][0];
+    expect(formData).toEqual({ annotations: {} });
+  });
+});

--- a/packages/utils/test/schema/findFieldInSchemaTest.ts
+++ b/packages/utils/test/schema/findFieldInSchemaTest.ts
@@ -87,6 +87,26 @@ export default function findFieldInSchemaTest(testValidator: TestValidatorType) 
         isRequired: false,
       });
     });
+    it('resolves fields when path segments are numeric (coerced to string keys, as from FieldPathList)', () => {
+      const schemaWithNumericPropertyName: RJSFSchema = {
+        type: 'object',
+        properties: {
+          '0': {
+            type: 'string',
+          },
+        },
+      };
+      const fieldPathList = [0] as (string | number)[];
+      expect(
+        schemaUtils.findFieldInSchema(
+          schemaWithNumericPropertyName,
+          fieldPathList.map((s) => String(s)),
+        ),
+      ).toEqual({
+        field: { type: 'string' },
+        isRequired: false,
+      });
+    });
     it('schema has oneOf field in properties key and isRequired true', () => {
       const path = 'answer';
       expect(schemaUtils.findFieldInSchema(testOneOfSchema, path, ANSWER_1)).toEqual({


### PR DESCRIPTION
fixes #4518

Clearing optional strings left `{ key: undefined }`, which fails `type: string` for AJV.  
Unset keys for non-oneOf/anyOf leaves; preserve explicit `undefined` for oneOf/anyOf.
### Reasons for making this change
- After a user typed into a nested optional string and cleared it, `Form` merged the change with lodash `set`, so the in-memory `formData` kept keys whose values were `undefined`. That is not valid 
JSON and AJV treats it like a present value that is not a string, so validation could fail even when the object looked empty again (e.g. objects mixing `patternProperties` / `additionalProperties` 
with fixed `properties`) — see [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518).
- For **oneOf** / **anyOf** fields, an explicit `undefined` must remain so default merging does not immediately re-apply a branch default when the user selects an empty option.


### Checklist
- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature