### PR TITLE
refactor(utils): add SchemaFieldPath for getFromSchema / findFieldInSchema; pass FieldPathList from Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,9 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
+- Fixed `processPendingChange` leaving optional object keys as `undefined` after clearing text inputs (invalid for AJV `type: "string"`), by unsetting keys for resolved non-oneOf/anyOf leaves while preserving explicit `undefined` for oneOf/anyOf branches, fixing [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518)
 - Added support for the JSON Schema `deprecated` keyword in `SchemaField`, providing options to hide, disable, or label deprecated fields via a new `deprecatedHandling` global UI option, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
 - Pass `FieldPathList` through to `findFieldInSchema` without per-segment string mapping now that `SchemaFieldPath` is supported in `@rjsf/utils` (follow-up to [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix)
-- Fixed `processPendingChange` leaving optional object keys as `undefined` after clearing text inputs (invalid for AJV `type: "string"`), by unsetting keys for resolved non-oneOf/anyOf leaves while preserving explicit `undefined` for oneOf/anyOf branches, fixing [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518)
 
 ## @rjsf/utils
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
+- Pass `FieldPathList` through to `findFieldInSchema` without per-segment string mapping now that `SchemaFieldPath` is supported in `@rjsf/utils` (follow-up to [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix)
 - Fixed `processPendingChange` leaving optional object keys as `undefined` after clearing text inputs (invalid for AJV `type: "string"`), by unsetting keys for resolved non-oneOf/anyOf leaves while preserving explicit `undefined` for oneOf/anyOf branches, fixing [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518)
 - Fixed `processPendingChange()` using `originalErrorSchema` (which already contains merged `extraErrors`) as the base for `mergeErrors()`, causing sibling-field `extraErrors` to accumulate duplicate entries on every array mutation, fixing [#5041](https://github.com/rjsf-team/react-jsonschema-form/issues/5041)
 - Added `ObjectField` test for renaming a nested `additionalProperties` key using `userEvent` and `reset()` via a form ref, verifying fix for [#4948](https://github.com/rjsf-team/react-jsonschema-form/issues/4948)
@@ -34,6 +35,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
+- Added `SchemaFieldPath` (`string | FieldPathList`) for `getFromSchema` / `findFieldInSchema`; fixed schema descent when a segment is numeric `0` (previously skipped due to falsy check); use string keys for `required` / oneOf fallback matching
 - Switched `deepEquals` from `lodash.isEqualWith` to `fast-equals.createCustomEqual` with cycle detection enabled, and replaced direct `lodash.isEqual` usage in `useDeepCompareMemo`, `isRootSchema`, and `findSelectedOptionInXxxOf` with `deepEquals`, fixing [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291)
 - Fixed `getObjectDefaults` re-injecting stale schema-level `default` keys into an `additionalProperties` object when `formData` already contains its own keys (e.g. after a key rename), preventing ghost entries from reappearing, fixing [#4948](https://github.com/rjsf-team/react-jsonschema-form/issues/4948)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,21 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
-# 6.5.2
+# 6.5.3
 
 ## @rjsf/core
 
 - Pass `FieldPathList` through to `findFieldInSchema` without per-segment string mapping now that `SchemaFieldPath` is supported in `@rjsf/utils` (follow-up to [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix)
 - Fixed `processPendingChange` leaving optional object keys as `undefined` after clearing text inputs (invalid for AJV `type: "string"`), by unsetting keys for resolved non-oneOf/anyOf leaves while preserving explicit `undefined` for oneOf/anyOf branches, fixing [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518)
+
+## @rjsf/utils
+
+- Added `SchemaFieldPath` (`string | FieldPathList`) for `getFromSchema` / `findFieldInSchema`; fixed schema descent when a segment is numeric `0` (previously skipped due to falsy check); use string keys for `required` / oneOf fallback matching
+
+# 6.5.2
+
+## @rjsf/core
+
 - Fixed `processPendingChange()` using `originalErrorSchema` (which already contains merged `extraErrors`) as the base for `mergeErrors()`, causing sibling-field `extraErrors` to accumulate duplicate entries on every array mutation, fixing [#5041](https://github.com/rjsf-team/react-jsonschema-form/issues/5041)
 - Added `ObjectField` test for renaming a nested `additionalProperties` key using `userEvent` and `reset()` via a form ref, verifying fix for [#4948](https://github.com/rjsf-team/react-jsonschema-form/issues/4948)
 - Updated `ArrayField`'s change handling to only `null` out data for paths that are directly an array indexed value and not object properties within them, fixing [#4952](https://github.com/rjsf-team/react-jsonschema-form/issues/4952)
@@ -35,7 +44,6 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
-- Added `SchemaFieldPath` (`string | FieldPathList`) for `getFromSchema` / `findFieldInSchema`; fixed schema descent when a segment is numeric `0` (previously skipped due to falsy check); use string keys for `required` / oneOf fallback matching
 - Switched `deepEquals` from `lodash.isEqualWith` to `fast-equals.createCustomEqual` with cycle detection enabled, and replaced direct `lodash.isEqual` usage in `useDeepCompareMemo`, `isRootSchema`, and `findSelectedOptionInXxxOf` with `deepEquals`, fixing [#4291](https://github.com/rjsf-team/react-jsonschema-form/issues/4291)
 - Fixed `getObjectDefaults` re-injecting stale schema-level `default` keys into an `additionalProperties` object when `formData` already contains its own keys (e.g. after a key rename), preventing ghost entries from reappearing, fixing [#4948](https://github.com/rjsf-team/react-jsonschema-form/issues/4948)
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -935,12 +935,7 @@ export default class Form<
             // Array items: match ArrayField `handleChange` — AJV needs `null`, not undefined.
             valueForPath = null as unknown as T;
           } else {
-            const { field } = schemaUtils.findFieldInSchema(
-              schema,
-              // `FieldPathList` allows numeric segments; normalize so `findFieldInSchema` receives `string[]`.
-              path.map((segment) => String(segment)),
-              oldFormData,
-            );
+            const { field } = schemaUtils.findFieldInSchema(schema, path, oldFormData);
             const leaf = field as RJSFSchema | undefined;
             const isOneOfOrAnyOfLeaf = leaf && (ONE_OF_KEY in leaf || ANY_OF_KEY in leaf);
             // Plain leaves: omit the key instead of `{ key: undefined }`, which breaks `type: "string"` validation in

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -7,6 +7,7 @@ import {
   GlobalUISchemaOptions,
   PathSchema,
   RJSFSchema,
+  SchemaFieldPath,
   SchemaUtilsType,
   StrictRJSFSchema,
   UiSchema,
@@ -127,7 +128,7 @@ class SchemaUtils<
    * @returns - An object that contains the field and its required state. If no field can be found then
    *            `{ field: undefined, isRequired: undefined }` is returned.
    */
-  findFieldInSchema(schema: S, path: string | string[], formData?: T): FoundFieldType<S> {
+  findFieldInSchema(schema: S, path: SchemaFieldPath, formData?: T): FoundFieldType<S> {
     return findFieldInSchema(
       this.validator,
       this.rootSchema,
@@ -259,9 +260,9 @@ class SchemaUtils<
    * @param defaultValue - The value to return if a value is not found for the `pathList` path
    * @returns - The internal schema from the `schema` for the given `path` or the `defaultValue` if not found
    */
-  getFromSchema(schema: S, path: string | string[], defaultValue: T): T;
-  getFromSchema(schema: S, path: string | string[], defaultValue: S): S;
-  getFromSchema(schema: S, path: string | string[], defaultValue: T | S): T | S {
+  getFromSchema(schema: S, path: SchemaFieldPath, defaultValue: T): T;
+  getFromSchema(schema: S, path: SchemaFieldPath, defaultValue: S): S;
+  getFromSchema(schema: S, path: SchemaFieldPath, defaultValue: T | S): T | S {
     return getFromSchema<T, S, F>(
       this.validator,
       this.rootSchema,

--- a/packages/utils/src/schema/findFieldInSchema.ts
+++ b/packages/utils/src/schema/findFieldInSchema.ts
@@ -9,6 +9,7 @@ import {
   FormContextType,
   FoundFieldType,
   RJSFSchema,
+  SchemaFieldPath,
   StrictRJSFSchema,
   ValidatorType,
 } from '../types';
@@ -37,7 +38,7 @@ export default function findFieldInSchema<
   validator: ValidatorType<T, S, F>,
   rootSchema: S,
   schema: S,
-  path: string | string[],
+  path: SchemaFieldPath,
   formData: T = {} as T,
   experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>,
 ): FoundFieldType<S> {
@@ -46,6 +47,7 @@ export default function findFieldInSchema<
 
   // store the desired field into a variable and removing it from the `pathList`
   const fieldName = pathList.pop()!;
+  const fieldNameKey = String(fieldName);
 
   if (pathList.length) {
     // drilling into the schema for each sub-path and taking into account of the any/oneOfs
@@ -64,7 +66,7 @@ export default function findFieldInSchema<
           validator,
           rootSchema,
           parentField,
-          fieldName,
+          fieldNameKey,
           ONE_OF_KEY,
           get(formData, subPath),
           experimental_customMergeAllOf,
@@ -75,7 +77,7 @@ export default function findFieldInSchema<
           validator,
           rootSchema,
           parentField,
-          fieldName,
+          fieldNameKey,
           ANY_OF_KEY,
           get(formData, subPath),
           experimental_customMergeAllOf,
@@ -90,7 +92,7 @@ export default function findFieldInSchema<
       validator,
       rootSchema,
       parentField,
-      fieldName,
+      fieldNameKey,
       ONE_OF_KEY,
       formData,
       experimental_customMergeAllOf,
@@ -101,7 +103,7 @@ export default function findFieldInSchema<
       validator,
       rootSchema,
       parentField,
-      fieldName,
+      fieldNameKey,
       ANY_OF_KEY,
       formData,
       experimental_customMergeAllOf,
@@ -131,7 +133,7 @@ export default function findFieldInSchema<
   );
   let isRequired: boolean | undefined;
   if (field && Array.isArray(requiredArray)) {
-    isRequired = requiredArray.includes(fieldName);
+    isRequired = requiredArray.includes(fieldNameKey);
   }
 
   return { field, isRequired };

--- a/packages/utils/src/schema/getFromSchema.ts
+++ b/packages/utils/src/schema/getFromSchema.ts
@@ -3,7 +3,14 @@ import has from 'lodash/has';
 import isEmpty from 'lodash/isEmpty';
 
 import retrieveSchema from './retrieveSchema';
-import { Experimental_CustomMergeAllOf, FormContextType, RJSFSchema, StrictRJSFSchema, ValidatorType } from '../types';
+import {
+  Experimental_CustomMergeAllOf,
+  FormContextType,
+  RJSFSchema,
+  SchemaFieldPath,
+  StrictRJSFSchema,
+  ValidatorType,
+} from '../types';
 import { REF_KEY } from '../constants';
 
 /** Internal helper function that acts like lodash's `get` but additionally retrieves `$ref`s as needed to get the path
@@ -20,7 +27,7 @@ function getFromSchemaInternal<T = any, S extends StrictRJSFSchema = RJSFSchema,
   validator: ValidatorType<T, S, F>,
   rootSchema: S,
   schema: S,
-  path: string | string[],
+  path: SchemaFieldPath,
   experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>,
 ): T | S | undefined {
   let fieldSchema = schema;
@@ -30,9 +37,9 @@ function getFromSchemaInternal<T = any, S extends StrictRJSFSchema = RJSFSchema,
   if (isEmpty(path)) {
     return fieldSchema;
   }
-  const pathList = Array.isArray(path) ? path : path.split('.');
+  const pathList = Array.isArray(path) ? [...path] : path.split('.');
   const [part, ...nestedPath] = pathList;
-  if (part && has(fieldSchema, part)) {
+  if (part !== undefined && part !== '' && has(fieldSchema, part)) {
     fieldSchema = get(fieldSchema, part) as S;
     return getFromSchemaInternal<T, S, F>(
       validator,
@@ -64,7 +71,7 @@ export default function getFromSchema<
   validator: ValidatorType<T, S, F>,
   rootSchema: S,
   schema: S,
-  path: string | string[],
+  path: SchemaFieldPath,
   defaultValue: T,
   experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>,
 ): T;
@@ -76,7 +83,7 @@ export default function getFromSchema<
   validator: ValidatorType<T, S, F>,
   rootSchema: S,
   schema: S,
-  path: string | string[],
+  path: SchemaFieldPath,
   defaultValue: S,
   experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>,
 ): S;
@@ -88,7 +95,7 @@ export default function getFromSchema<
   validator: ValidatorType<T, S, F>,
   rootSchema: S,
   schema: S,
-  path: string | string[],
+  path: SchemaFieldPath,
   defaultValue: T | S,
   experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>,
 ): T | S {

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -185,6 +185,9 @@ export type InputPropsType = {
  */
 export type FieldPathList = (string | number)[];
 
+/** Dot string or segment list for `getFromSchema` / `findFieldInSchema` (same segment rules as {@link FieldPathList}). */
+export type SchemaFieldPath = string | FieldPathList;
+
 /** Type describing an id and path used for a field */
 export type FieldPathId = {
   /** The id for a field */
@@ -1328,7 +1331,7 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    * @returns - An object that contains the field and its required state. If no field can be found then
    *            `{ field: undefined, isRequired: undefined }` is returned.
    */
-  findFieldInSchema(schema: S, path: string | string[], formData?: T): FoundFieldType<S>;
+  findFieldInSchema(schema: S, path: SchemaFieldPath, formData?: T): FoundFieldType<S>;
   /** Finds the oneOf option inside the `schema['any/oneOf']` list which has the `properties[selectorField].default` that
    * matches the `formData[selectorField]` value. For the purposes of this function, `selectorField` is either
    * `schema.discriminator.propertyName` or `fallbackField`.
@@ -1403,9 +1406,9 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    * @param defaultValue - The value to return if a value is not found for the `pathList` path
    * @returns - The internal schema from the `schema` for the given `path` or the `defaultValue` if not found
    */
-  getFromSchema(schema: S, path: string | string[], defaultValue: T): T;
-  getFromSchema(schema: S, path: string | string[], defaultValue: S): S;
-  getFromSchema(schema: S, path: string | string[], defaultValue: T | S): S | T;
+  getFromSchema(schema: S, path: SchemaFieldPath, defaultValue: T): T;
+  getFromSchema(schema: S, path: SchemaFieldPath, defaultValue: S): S;
+  getFromSchema(schema: S, path: SchemaFieldPath, defaultValue: T | S): S | T;
   /** Checks to see if the `schema` and `uiSchema` combination represents an array of files
    *
    * @param schema - The schema for which check for array of files flag is desired

--- a/packages/utils/test/schema/findFieldInSchemaTest.ts
+++ b/packages/utils/test/schema/findFieldInSchemaTest.ts
@@ -87,7 +87,7 @@ export default function findFieldInSchemaTest(testValidator: TestValidatorType) 
         isRequired: false,
       });
     });
-    it('resolves fields when path segments are numeric (coerced to string keys, as from FieldPathList)', () => {
+    it('resolves numeric path segments (FieldPathList) the same as string keys', () => {
       const schemaWithNumericPropertyName: RJSFSchema = {
         type: 'object',
         properties: {
@@ -97,12 +97,7 @@ export default function findFieldInSchemaTest(testValidator: TestValidatorType) 
         },
       };
       const fieldPathList = [0] as (string | number)[];
-      expect(
-        schemaUtils.findFieldInSchema(
-          schemaWithNumericPropertyName,
-          fieldPathList.map((s) => String(s)),
-        ),
-      ).toEqual({
+      expect(schemaUtils.findFieldInSchema(schemaWithNumericPropertyName, fieldPathList)).toEqual({
         field: { type: 'string' },
         isRequired: false,
       });

--- a/packages/utils/test/schema/getFromSchemaTest.ts
+++ b/packages/utils/test/schema/getFromSchemaTest.ts
@@ -90,6 +90,16 @@ export default function getFromSchemaTest(testValidator: TestValidatorType) {
       const field = schemaUtils.getFromSchema(testSchema, [PROPERTIES_KEY, 'patient', 'telecom'], defaultValue);
       expect(field).toEqual(defaultValue);
     });
+    it('descends into a property whose key is the number 0 (FieldPathList segment)', () => {
+      const schemaNumericKey: RJSFSchema = {
+        type: 'object',
+        properties: {
+          '0': { type: 'string', title: 'zero' },
+        },
+      };
+      const got = schemaUtils.getFromSchema(schemaNumericKey, [PROPERTIES_KEY, 0], undefined);
+      expect(got).toEqual({ type: 'string', title: 'zero' });
+    });
     it('returns the default schema value when passed an invalid path', () => {
       const defaultValue = { title: 'nothing' } as RJSFSchema;
       const field = schemaUtils.getFromSchema(testSchema, [PROPERTIES_KEY, 'patient', 'telecom'], defaultValue);


### PR DESCRIPTION
Follow-up to merge of the https://github.com/rjsf-team/react-jsonschema-form/pull/5056 (per @heath-freenome): **`Form` passes `path` as-is** to `findFieldInSchema` instead of mapping each segment with `String`.
- Add **`SchemaFieldPath`** (`string | FieldPathList`); fix **`getFromSchema`** descent when a segment is numeric **`0`** (avoid treating **`0`** as a missing key).
- Use **`String(fieldName)`** only for **`required`** matching and **`findSelectedOptionInXxxOf`**’s string `fallbackField`, not for **`properties`** lookup.
- Tests for a schema property keyed as **`"0"`** with a numeric path segment; **CHANGELOG** updated.
### Reasons for making this change
Maintainers asked for a follow-up so we do not rely on **`path.map((s) => String(s))` in `Form`**, which adds a small per-change cost and duplicates information the schema layer can accept directly. Threading **`FieldPathList`** through **`getFromSchema`** / **`findFieldInSchema`** keeps one consistent path type from the form to schema navigation and fixes a real bug where segment **`0`** was skipped because of a falsy check.
Related: [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) (closed with the first PR). This PR does not reopen it.

### Checklist
- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature