### PR TITLE
docs: document JSON Schema deprecated support and UI options

### DIFF
--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -59,9 +59,20 @@ The set of globally relevant `UiSchema` options that are read from the root-leve
 import { UiSchema } from '@rjsf/utils';
 
 const uiSchema: UiSchema = {
-  'ui:globalOptions': { copyable: true },
+  'ui:globalOptions': {
+    copyable: true,
+    deprecatedHandling: 'disable',
+  },
 };
 ```
+
+#### deprecatedHandling
+
+Controls how fields marked as `deprecated: true` in the JSON Schema are rendered.
+
+- `'label'` (default): Appends ` (deprecated)` to the field label.
+- `'disable'`: The field is rendered but disabled.
+- `'hide'`: The field is completely hidden.
 
 ### ui:definitions
 
@@ -332,6 +343,34 @@ const uiSchema: UiSchema = {
   'ui:description': 'The best password',
 };
 ```
+
+### deprecated
+
+The JSON Schema `deprecated` keyword can be used to indicate that a field is no longer supported. By default, RJSF will append ` (deprecated)` to the field label. You can customize this behavior using the `deprecatedHandling` option.
+
+```tsx
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+
+const schema: RJSFSchema = {
+  type: 'object',
+  properties: {
+    oldField: {
+      type: 'string',
+      deprecated: true,
+    },
+  },
+};
+
+const uiSchema: UiSchema = {
+  oldField: {
+    'ui:options': {
+      deprecatedHandling: 'hide',
+    },
+  },
+};
+```
+
+See [deprecatedHandling](#deprecatedhandling) for more details on available modes.
 
 ### disabled
 

--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -59,20 +59,9 @@ The set of globally relevant `UiSchema` options that are read from the root-leve
 import { UiSchema } from '@rjsf/utils';
 
 const uiSchema: UiSchema = {
-  'ui:globalOptions': {
-    copyable: true,
-    deprecatedHandling: 'disable',
-  },
+  'ui:globalOptions': { copyable: true },
 };
 ```
-
-#### deprecatedHandling
-
-Controls how fields marked as `deprecated: true` in the JSON Schema are rendered.
-
-- `'label'` (default): Appends ` (deprecated)` to the field label.
-- `'disable'`: The field is rendered but disabled.
-- `'hide'`: The field is completely hidden.
 
 ### ui:definitions
 
@@ -344,9 +333,15 @@ const uiSchema: UiSchema = {
 };
 ```
 
-### deprecated
+### deprecatedHandling
 
-The JSON Schema `deprecated` keyword can be used to indicate that a field is no longer supported. By default, RJSF will append ` (deprecated)` to the field label. You can customize this behavior using the `deprecatedHandling` option.
+The `ui:deprecatedHandling` uiSchema directive controls how a field marked as `deprecated` in the JSON Schema is rendered.
+
+Accepts one of three values:
+
+- `'label'` (default): The field is rendered normally with `"(deprecated)"` appended to its label.
+- `'disable'`: The field is rendered but all its child widgets are disabled.
+- `'hide'`: The field is completely hidden from the form.
 
 ```tsx
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
@@ -354,23 +349,42 @@ import { RJSFSchema, UiSchema } from '@rjsf/utils';
 const schema: RJSFSchema = {
   type: 'object',
   properties: {
-    oldField: {
-      type: 'string',
-      deprecated: true,
-    },
+    legacyField: { type: 'string', deprecated: true },
   },
 };
 
 const uiSchema: UiSchema = {
-  oldField: {
+  legacyField: {
     'ui:options': {
-      deprecatedHandling: 'hide',
+      deprecatedHandling: 'disable',
     },
   },
 };
 ```
 
-See [deprecatedHandling](#deprecatedhandling) for more details on available modes.
+It can also be set globally by specifying the `deprecatedHandling` option in the `ui:globalOptions` uiSchema directive, which applies the chosen behavior to every deprecated field in the form.
+
+```tsx
+import { Form } from '@rjsf/core';
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+import validator from '@rjsf/validator-ajv8';
+
+const schema: RJSFSchema = {
+  type: 'object',
+  properties: {
+    legacyField: { type: 'string', deprecated: true },
+    anotherOldField: { type: 'number', deprecated: true },
+  },
+};
+
+const uiSchema: UiSchema = {
+  'ui:globalOptions': {
+    deprecatedHandling: 'hide',
+  },
+};
+
+render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, document.getElementById('app'));
+```
 
 ### disabled
 

--- a/packages/docs/docs/json-schema/single.md
+++ b/packages/docs/docs/json-schema/single.md
@@ -48,6 +48,8 @@ render(<Form schema={schema} validator={validator} />, document.getElementById('
 
 The JSON Schema `deprecated` keyword can be used to indicate that a field is no longer supported.
 
+The `deprecated` keyword is a JSON Schema Draft 2019-09 feature. You may need to configure your schema validator to properly recognize it. See the [Validation](../usage/validation.md#ajvclass) documentation for more details.
+
 ```tsx
 import { RJSFSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';

--- a/packages/docs/docs/json-schema/single.md
+++ b/packages/docs/docs/json-schema/single.md
@@ -44,6 +44,24 @@ const schema: RJSFSchema = {
 render(<Form schema={schema} validator={validator} />, document.getElementById('app'));
 ```
 
+## Deprecated fields
+
+The JSON Schema `deprecated` keyword can be used to indicate that a field is no longer supported.
+
+```tsx
+import { RJSFSchema } from '@rjsf/utils';
+import validator from '@rjsf/validator-ajv8';
+
+const schema: RJSFSchema = {
+  type: 'string',
+  deprecated: true,
+};
+
+render(<Form schema={schema} validator={validator} />, document.getElementById('app'));
+```
+
+By default, RJSF will append ` (deprecated)` to the field label. You can customize this behavior using the `deprecatedHandling` option in the uiSchema. See [deprecatedHandling](../api-reference/uiSchema.md#deprecatedhandling) for more details.
+
 ## Enumerated values
 
 All base schema types support the `enum` attribute, which restricts the user to select among a list of options. For example:


### PR DESCRIPTION
### Reasons for making this change

This PR adds comprehensive documentation for the newly integrated JSON Schema `deprecated` keyword and the associated `deprecatedHandling` UI option.

**Changes:**
- Added `deprecatedHandling` mode descriptions (`label`, `disable`, `hide`) to the `ui:globalOptions` section in `uiSchema.md`.
- Added a new `deprecated` section with a full code example demonstrating how to use the keyword in the schema and customize its behavior in the `uiSchema`.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
