### PR TITLE
fix(utils): avoid enumerating string defaults in mergeDefaultsWithFormData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Added `deprecatedHandling` to `GlobalUISchemaOptions` and updated `StrictRJSFSchema` to be recursive, ensuring the `deprecated` keyword (and future extensions) are supported in all nested schema structures without requiring type casts, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
 - Also added `DeprecatedLabel` to `TranslatableString` to support internationalization of the deprecated field suffix
-- Added `SchemaFieldPath` (`string | FieldPathList`) for `getFromSchema` / `findFieldInSchema`; fixed schema descent when a segment is numeric `0` (previously skipped due to falsy check); use string keys for `required` / oneOf fallback matching
+  - Added `SchemaFieldPath` (`string | FieldPathList`) for `getFromSchema` / `findFieldInSchema`; fixed schema descent when a segment is numeric `0` (previously skipped due to falsy check); use string keys for `required` / oneOf fallback matching
 - Fixed `mergeDefaultsWithFormData` calling `Object.entries` on non-object defaults (e.g. long `data:` URL strings for single file fields), which iterated every character and caused severe UI freezes, fixing [#5055](https://github.com/rjsf-team/react-jsonschema-form/issues/5055)
 
 # 6.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
+- Fixed `mergeDefaultsWithFormData` calling `Object.entries` on non-object defaults (e.g. long `data:` URL strings for single file fields), which iterated every character and caused severe UI freezes, fixing [#5055](https://github.com/rjsf-team/react-jsonschema-form/issues/5055)
 - Added `deprecatedHandling` to `GlobalUISchemaOptions` and updated `StrictRJSFSchema` to be recursive, ensuring the `deprecated` keyword (and future extensions) are supported in all nested schema structures without requiring type casts, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
   - Also added `DeprecatedLabel` to `TranslatableString` to support internationalization of the deprecated field suffix
 - Added `SchemaFieldPath` (`string | FieldPathList`) for `getFromSchema` / `findFieldInSchema`; fixed schema descent when a segment is numeric `0` (previously skipped due to falsy check); use string keys for `required` / oneOf fallback matching

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - Added `deprecatedHandling` to `GlobalUISchemaOptions` and updated `StrictRJSFSchema` to be recursive, ensuring the `deprecated` keyword (and future extensions) are supported in all nested schema structures without requiring type casts, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
-- Also added `DeprecatedLabel` to `TranslatableString` to support internationalization of the deprecated field suffix
-  - Added `SchemaFieldPath` (`string | FieldPathList`) for `getFromSchema` / `findFieldInSchema`; fixed schema descent when a segment is numeric `0` (previously skipped due to falsy check); use string keys for `required` / oneOf fallback matching
+  - Also added `DeprecatedLabel` to `TranslatableString` to support internationalization of the deprecated field suffix
+- Added `SchemaFieldPath` (`string | FieldPathList`) for `getFromSchema` / `findFieldInSchema`; fixed schema descent when a segment is numeric `0` (previously skipped due to falsy check); use string keys for `required` / oneOf fallback matching
 - Fixed `mergeDefaultsWithFormData` calling `Object.entries` on non-object defaults (e.g. long `data:` URL strings for single file fields), which iterated every character and caused severe UI freezes, fixing [#5055](https://github.com/rjsf-team/react-jsonschema-form/issues/5055)
 
 # 6.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
-- Fixed `mergeDefaultsWithFormData` calling `Object.entries` on non-object defaults (e.g. long `data:` URL strings for single file fields), which iterated every character and caused severe UI freezes, fixing [#5055](https://github.com/rjsf-team/react-jsonschema-form/issues/5055)
 - Added `deprecatedHandling` to `GlobalUISchemaOptions` and updated `StrictRJSFSchema` to be recursive, ensuring the `deprecated` keyword (and future extensions) are supported in all nested schema structures without requiring type casts, fixing [#5024](https://github.com/rjsf-team/react-jsonschema-form/issues/5024)
-  - Also added `DeprecatedLabel` to `TranslatableString` to support internationalization of the deprecated field suffix
+- Also added `DeprecatedLabel` to `TranslatableString` to support internationalization of the deprecated field suffix
 - Added `SchemaFieldPath` (`string | FieldPathList`) for `getFromSchema` / `findFieldInSchema`; fixed schema descent when a segment is numeric `0` (previously skipped due to falsy check); use string keys for `required` / oneOf fallback matching
+- Fixed `mergeDefaultsWithFormData` calling `Object.entries` on non-object defaults (e.g. long `data:` URL strings for single file fields), which iterated every character and caused severe UI freezes, fixing [#5055](https://github.com/rjsf-team/react-jsonschema-form/issues/5055)
 
 # 6.5.2
 

--- a/packages/utils/src/mergeDefaultsWithFormData.ts
+++ b/packages/utils/src/mergeDefaultsWithFormData.ts
@@ -68,7 +68,8 @@ export default function mergeDefaultsWithFormData<T = any>(
       const keyExistsInDefaults = isObject(defaults) && key in (defaults as GenericObjectType);
       const keyExistsInFormData = key in (formData as GenericObjectType);
       const keyDefault = get(defaults, key) ?? {};
-      const defaultValueIsNestedObject = keyExistsInDefaults && Object.entries(keyDefault).some(([, v]) => isObject(v));
+      const defaultValueIsNestedObject =
+        keyExistsInDefaults && isObject(keyDefault) && Object.values(keyDefault).some((v) => isObject(v));
 
       const keyDefaultIsObject = keyExistsInDefaults && isObject(get(defaults, key));
       const keyHasFormDataObject = keyExistsInFormData && isObject(keyValue);

--- a/packages/utils/test/mergeDefaultsWithFormData.test.ts
+++ b/packages/utils/test/mergeDefaultsWithFormData.test.ts
@@ -148,6 +148,14 @@ describe('mergeDefaultsWithFormData()', () => {
     expect(mergeDefaultsWithFormData(obj1, obj2)?.a).toBeInstanceOf(File);
   });
 
+  it('should merge quickly when the default for a key is a long string (e.g. data-url file value)', () => {
+    const largeDefault = `data:application/octet-stream;base64,${'A'.repeat(200_000)}`;
+    const formValue = 'data:application/octet-stream;base64,B';
+    expect(mergeDefaultsWithFormData<{ file: string }>({ file: largeDefault }, { file: formValue })).toEqual({
+      file: formValue,
+    });
+  });
+
   describe('test with overrideFormDataWithDefaults set to true', () => {
     it('should return data in formData when no defaults', () => {
       expect(mergeDefaultsWithFormData(undefined, [2], undefined, undefined, true)).toEqual([2]);


### PR DESCRIPTION
## Reasons for making this change

`mergeDefaultsWithFormData` used `Object.entries(keyDefault)` to detect nested object defaults. For string defaults (e.g. large data URLs from single-file fields), `Object.entries` walks every character, which explains the severe slowdown reported in #5055.

The fix is to align this check with the rest of RJSF by only running it when `keyDefault` is a plain object (`isObject(keyDefault)`), and then using:

```ts
Object.values(keyDefault).some((v) => isObject(v))
```

instead of `Object.entries`.

Strings and other non-object values now skip enumeration entirely, while nested object defaults continue to behave the same as before.

fixes #5055

If this PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda:  
https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

---

## Checklist

- [ ] I'm updating documentation
  - [ ] I've checked the rendering of the Markdown text I've added

- [x] I'm adding or updating code
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated docs if needed
  - [x] I've updated the changelog with a description of the PR

- [ ] I'm adding a new feature
  - [ ] I've updated the playground with an example use of the feature