### PR TITLE
Fix stale enum data after dependency schema changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated `sanitizeDataForNewSchema()` to preserve valid enum values while replacing or clearing stale values across enum, `oneOf`, and `anyOf` schema changes ([#5067](https://github.com/rjsf-team/react-jsonschema-form/pull/5067))
 
+# 6.6.1
+
 ## Dev / docs / playground
 
 - Updated peer dependencies to 6.6.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,15 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
-# 6.6.1
+# 6.6.2
+
+## @rjsf/core
+
+- Fixed schema-change handling so dependent enum updates sanitize invalid scalar field data without over-sanitizing root, object, array, readonly, or disabled field changes ([#5067](https://github.com/rjsf-team/react-jsonschema-form/pull/5067))
+
+## @rjsf/utils
+
+- Updated `sanitizeDataForNewSchema()` to preserve valid enum values while replacing or clearing stale values across enum, `oneOf`, and `anyOf` schema changes ([#5067](https://github.com/rjsf-team/react-jsonschema-form/pull/5067))
 
 ## Dev / docs / playground
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -918,6 +918,7 @@ export default class Form<
     const inputForDefaults = hasOnlyUndefinedValues && wasPreviouslyNull ? undefined : formData;
 
     if (isObject(formData) || Array.isArray(formData)) {
+      const previousRetrievedSchema = retrievedSchema;
       if (newValue === ADDITIONAL_PROPERTY_KEY_REMOVE) {
         // For additional properties, we were given the special remove this key value, so unset it
         _unset(formData, path);
@@ -955,6 +956,26 @@ export default class Form<
       const newState = this.getStateFromProps(this.props, inputForDefaults, undefined, undefined, undefined, true);
       formData = newState.formData;
       retrievedSchema = newState.retrievedSchema;
+
+      if (previousRetrievedSchema && !deepEquals(previousRetrievedSchema, retrievedSchema)) {
+        const sanitizedFormData = schemaUtils.sanitizeDataForNewSchema(
+          retrievedSchema,
+          previousRetrievedSchema,
+          formData,
+        );
+        if (!deepEquals(sanitizedFormData, formData)) {
+          const sanitizedState = this.getStateFromProps(
+            this.props,
+            sanitizedFormData,
+            undefined,
+            undefined,
+            undefined,
+            true,
+          );
+          formData = sanitizedState.formData;
+          retrievedSchema = sanitizedState.retrievedSchema;
+        }
+      }
     }
 
     const mustValidate = !noValidate && (liveValidate === true || liveValidate === 'onChange');

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -1051,8 +1051,8 @@ export default class Form<
         customErrors,
       };
     }
-    // Keep the resolved dependency branch in state after sanitizing, so the next change uses the same schema as
-    // the cleaned formData.
+    // Keep the resolved dependency branch in state after sanitizing, so the next dependent-field change compares
+    // against the same schema branch as the cleaned formData.
     state = {
       ...state,
       retrievedSchema,

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -957,7 +957,16 @@ export default class Form<
       formData = newState.formData;
       retrievedSchema = newState.retrievedSchema;
 
-      if (previousRetrievedSchema && !deepEquals(previousRetrievedSchema, retrievedSchema)) {
+      if (
+        previousRetrievedSchema &&
+        !isRootPath &&
+        !isObject(newValue) &&
+        !Array.isArray(newValue) &&
+        !this.props.disabled &&
+        !this.props.readonly &&
+        _get(schema, 'readOnly') !== true &&
+        !deepEquals(previousRetrievedSchema, retrievedSchema)
+      ) {
         const sanitizedFormData = schemaUtils.sanitizeDataForNewSchema(
           retrievedSchema,
           previousRetrievedSchema,
@@ -1042,6 +1051,11 @@ export default class Form<
         customErrors,
       };
     }
+    state = {
+      ...state,
+      retrievedSchema,
+    };
+
     this.setState(state as FormState<T, S, F>, () => {
       if (onChange) {
         onChange(toIChangeEvent({ ...this.state, ...state }), id);

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -967,6 +967,7 @@ export default class Form<
         _get(schema, 'readOnly') !== true &&
         !deepEquals(previousRetrievedSchema, retrievedSchema)
       ) {
+        // If this is a writable scalar field and the schema changed, sanitize the data to remove bad data
         const sanitizedFormData = schemaUtils.sanitizeDataForNewSchema(
           retrievedSchema,
           previousRetrievedSchema,

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -893,7 +893,7 @@ export default class Form<
     this._isProcessingUserChange = true;
     const { newValue, path, id } = this.pendingChanges[0];
     const { newErrorSchema } = this.pendingChanges[0];
-    const { extraErrors, omitExtraData, liveOmit, noValidate, liveValidate, onChange } = this.props;
+    const { extraErrors, omitExtraData, liveOmit, noValidate, liveValidate, onChange, disabled, readonly } = this.props;
     const { formData: oldFormData, schemaUtils, schema, fieldPathId, schemaValidationErrorSchema, errors } = this.state;
     let { customErrors } = this.state;
     // Use the un-merged AJV-only schema as the base for re-merging extraErrors. Mirrors the
@@ -962,8 +962,8 @@ export default class Form<
         !isRootPath &&
         !isObject(newValue) &&
         !Array.isArray(newValue) &&
-        !this.props.disabled &&
-        !this.props.readonly &&
+        !disabled &&
+        !readonly &&
         _get(schema, 'readOnly') !== true &&
         !deepEquals(previousRetrievedSchema, retrievedSchema)
       ) {
@@ -1051,6 +1051,8 @@ export default class Form<
         customErrors,
       };
     }
+    // Keep the resolved dependency branch in state after sanitizing, so the next change uses the same schema as
+    // the cleaned formData.
     state = {
       ...state,
       retrievedSchema,

--- a/packages/core/src/components/fields/LayoutMultiSchemaField.tsx
+++ b/packages/core/src/components/fields/LayoutMultiSchemaField.tsx
@@ -159,6 +159,9 @@ export default function LayoutMultiSchemaField<
    *      will use it as the index of the new option to select
    */
   const onOptionChange = (opt?: unknown) => {
+    if (disabled || readonly) {
+      return;
+    }
     const newOption = getSelectedOption<S>(enumOptions, selectorField, opt);
     const oldOption = getSelectedOption<S>(enumOptions, selectorField, selectedOption);
 

--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -116,7 +116,10 @@ class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
    */
   onOptionChange = (option?: string) => {
     const { selectedOption, retrievedOptions } = this.state;
-    const { formData, onChange, registry, fieldPathId } = this.props;
+    const { disabled = false, formData, onChange, readonly = false, registry, fieldPathId } = this.props;
+    if (disabled || readonly) {
+      return;
+    }
     const { schemaUtils } = registry;
     const intOption = option !== undefined ? parseInt(option, 10) : -1;
     if (intOption === selectedOption) {

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -3104,6 +3104,66 @@ describeRepeated('Form common', (createFormComponent) => {
           'root_branch',
         );
       });
+
+      it('should sanitize stale enum data when dependencies change available options', () => {
+        const dependentEnumSchema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            animal: {
+              type: 'string',
+              enum: ['Cat', 'Fish'],
+            },
+          },
+          dependencies: {
+            animal: {
+              oneOf: [
+                {
+                  properties: {
+                    animal: {
+                      enum: ['Cat'],
+                    },
+                    food: {
+                      type: 'string',
+                      enum: ['meat'],
+                    },
+                  },
+                },
+                {
+                  properties: {
+                    animal: {
+                      enum: ['Fish'],
+                    },
+                    food: {
+                      type: 'string',
+                      enum: ['worms'],
+                    },
+                    water: {
+                      type: 'string',
+                      enum: ['lake'],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        };
+        const { node, onChange } = createFormComponent({
+          schema: dependentEnumSchema,
+          formData: { animal: 'Fish', food: 'worms', water: 'lake' },
+        });
+
+        act(() => {
+          fireEvent.change(node.querySelector('#root_animal')!, {
+            target: { value: 0 },
+          });
+        });
+
+        expectToHaveBeenCalledWithFormData(
+          onChange,
+          { animal: 'Cat', food: 'meat', water: undefined },
+          'root_animal',
+        );
+      });
     });
 
     describe('customValidate errors, live validation', () => {

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -3105,7 +3105,7 @@ describeRepeated('Form common', (createFormComponent) => {
         );
       });
 
-      it('should sanitize stale enum data and persist the retrieved dependency schema', () => {
+      it('should sanitize stale enum data and persist the retrieved dependency schema', async () => {
         const formRef = createRef<Form<any, RJSFSchema, any>>();
         const dependentEnumSchema: RJSFSchema = {
           type: 'object',
@@ -3154,11 +3154,7 @@ describeRepeated('Form common', (createFormComponent) => {
           formData: { animal: 'Fish', food: 'worms', water: 'lake' },
         });
 
-        act(() => {
-          fireEvent.change(node.querySelector('#root_animal')!, {
-            target: { value: 0 },
-          });
-        });
+        await user.selectOptions(node.querySelector<HTMLSelectElement>('#root_animal')!, '0');
 
         expectToHaveBeenCalledWithFormData(onChange, { animal: 'Cat', food: 'meat', water: undefined }, 'root_animal');
         const retrievedSchema = formRef.current!.state.retrievedSchema as RJSFSchema;
@@ -3169,9 +3165,7 @@ describeRepeated('Form common', (createFormComponent) => {
         );
         expect(retrievedSchema.properties).not.toHaveProperty('water');
 
-        fireEvent.change(node.querySelector('#root_food')!, {
-          target: { value: 0 },
-        });
+        await user.selectOptions(node.querySelector<HTMLSelectElement>('#root_food')!, '0');
         expect((formRef.current!.state.retrievedSchema as RJSFSchema).properties).not.toHaveProperty('water');
       });
     });

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -3105,7 +3105,7 @@ describeRepeated('Form common', (createFormComponent) => {
         );
       });
 
-      it('should sanitize stale enum data when dependencies change available options', () => {
+      it('should sanitize stale enum data and persist the retrieved dependency schema', () => {
         const formRef = createRef<Form<any, RJSFSchema, any>>();
         const dependentEnumSchema: RJSFSchema = {
           type: 'object',
@@ -3168,6 +3168,11 @@ describeRepeated('Form common', (createFormComponent) => {
           }),
         );
         expect(retrievedSchema.properties).not.toHaveProperty('water');
+
+        fireEvent.change(node.querySelector('#root_food')!, {
+          target: { value: 0 },
+        });
+        expect((formRef.current!.state.retrievedSchema as RJSFSchema).properties).not.toHaveProperty('water');
       });
     });
 

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -3158,11 +3158,7 @@ describeRepeated('Form common', (createFormComponent) => {
           });
         });
 
-        expectToHaveBeenCalledWithFormData(
-          onChange,
-          { animal: 'Cat', food: 'meat', water: undefined },
-          'root_animal',
-        );
+        expectToHaveBeenCalledWithFormData(onChange, { animal: 'Cat', food: 'meat', water: undefined }, 'root_animal');
       });
     });
 

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -3106,6 +3106,7 @@ describeRepeated('Form common', (createFormComponent) => {
       });
 
       it('should sanitize stale enum data when dependencies change available options', () => {
+        const formRef = createRef<Form<any, RJSFSchema, any>>();
         const dependentEnumSchema: RJSFSchema = {
           type: 'object',
           properties: {
@@ -3148,6 +3149,7 @@ describeRepeated('Form common', (createFormComponent) => {
           },
         };
         const { node, onChange } = createFormComponent({
+          ref: formRef,
           schema: dependentEnumSchema,
           formData: { animal: 'Fish', food: 'worms', water: 'lake' },
         });
@@ -3159,6 +3161,13 @@ describeRepeated('Form common', (createFormComponent) => {
         });
 
         expectToHaveBeenCalledWithFormData(onChange, { animal: 'Cat', food: 'meat', water: undefined }, 'root_animal');
+        const retrievedSchema = formRef.current!.state.retrievedSchema as RJSFSchema;
+        expect(retrievedSchema.properties).toEqual(
+          expect.objectContaining({
+            food: expect.objectContaining({ enum: ['meat'] }),
+          }),
+        );
+        expect(retrievedSchema.properties).not.toHaveProperty('water');
       });
     });
 

--- a/packages/utils/src/schema/sanitizeDataForNewSchema.ts
+++ b/packages/utils/src/schema/sanitizeDataForNewSchema.ts
@@ -1,6 +1,7 @@
 import get from 'lodash/get';
 import has from 'lodash/has';
 
+import deepEquals from '../deepEquals';
 import { PROPERTIES_KEY, REF_KEY } from '../constants';
 import {
   Experimental_CustomMergeAllOf,
@@ -13,6 +14,42 @@ import {
 import retrieveSchema from './retrieveSchema';
 
 const NO_VALUE = Symbol('no Value');
+
+function enumValuesForSchema<S extends StrictRJSFSchema = RJSFSchema>(schema: S): any[] | undefined {
+  if (Array.isArray(schema.enum)) {
+    return schema.enum;
+  }
+
+  const options = (schema.oneOf || schema.anyOf) as S[] | undefined;
+  if (!Array.isArray(options)) {
+    return undefined;
+  }
+
+  const values = options
+    .map((option) => {
+      if ('const' in option) {
+        return option.const;
+      }
+      return Array.isArray(option.enum) && option.enum.length === 1 ? option.enum[0] : NO_VALUE;
+    })
+    .filter((value) => value !== NO_VALUE);
+
+  return values.length > 0 ? values : undefined;
+}
+
+function replacementForInvalidEnumValue<S extends StrictRJSFSchema = RJSFSchema>(schema: S, formValue: any) {
+  const enumValues = enumValuesForSchema(schema);
+  if (!enumValues || enumValues.some((value) => deepEquals(value, formValue))) {
+    return NO_VALUE;
+  }
+
+  const defaultValue = get(schema, 'default', NO_VALUE);
+  if (defaultValue !== NO_VALUE && enumValues.some((value) => deepEquals(value, defaultValue))) {
+    return defaultValue;
+  }
+
+  return enumValues.length === 1 ? enumValues[0] : undefined;
+}
 
 /** Sanitize the `data` associated with the `oldSchema` so it is considered appropriate for the `newSchema`. If the new
  * schema does not contain any properties, then `undefined` is returned to clear all the form data. Due to the nature
@@ -159,6 +196,13 @@ export default function sanitizeDataForNewSchema<
           if (newOptionConst !== NO_VALUE && newOptionConst !== formValue) {
             // Since this is a const, if the old value matches, replace the value with the new const otherwise clear it
             removeOldSchemaData[key] = oldOptionConst === formValue ? newOptionConst : undefined;
+          }
+
+          if (has(data, key)) {
+            const enumReplacement = replacementForInvalidEnumValue(newKeyedSchema, formValue);
+            if (enumReplacement !== NO_VALUE) {
+              removeOldSchemaData[key] = enumReplacement;
+            }
           }
         }
       }

--- a/packages/utils/src/schema/sanitizeDataForNewSchema.ts
+++ b/packages/utils/src/schema/sanitizeDataForNewSchema.ts
@@ -1,8 +1,8 @@
 import get from 'lodash/get';
 import has from 'lodash/has';
 
+import { CONST_KEY, DEFAULT_KEY, PROPERTIES_KEY, REF_KEY } from '../constants';
 import deepEquals from '../deepEquals';
-import { PROPERTIES_KEY, REF_KEY } from '../constants';
 import {
   Experimental_CustomMergeAllOf,
   FormContextType,
@@ -27,8 +27,8 @@ function enumValuesForSchema<S extends StrictRJSFSchema = RJSFSchema>(schema: S)
 
   const values = options
     .map((option) => {
-      if ('const' in option) {
-        return option.const;
+      if (CONST_KEY in option) {
+        return option[CONST_KEY];
       }
       return Array.isArray(option.enum) && option.enum.length === 1 ? option.enum[0] : NO_VALUE;
     })
@@ -43,7 +43,7 @@ function replacementForInvalidEnumValue<S extends StrictRJSFSchema = RJSFSchema>
     return NO_VALUE;
   }
 
-  const defaultValue = get(schema, 'default', NO_VALUE);
+  const defaultValue = get(schema, DEFAULT_KEY, NO_VALUE);
   if (defaultValue !== NO_VALUE && enumValues.some((value) => deepEquals(value, defaultValue))) {
     return defaultValue;
   }
@@ -179,8 +179,8 @@ export default function sanitizeDataForNewSchema<
           // Ok, the non-object types match, let's make sure that a default or a const of a different value is replaced
           // with the new default or const. This allows the case where two schemas differ that only by the default/const
           // value to be properly selected
-          const newOptionDefault = get(newKeyedSchema, 'default', NO_VALUE);
-          const oldOptionDefault = get(oldKeyedSchema, 'default', NO_VALUE);
+          const newOptionDefault = get(newKeyedSchema, DEFAULT_KEY, NO_VALUE);
+          const oldOptionDefault = get(oldKeyedSchema, DEFAULT_KEY, NO_VALUE);
           if (newOptionDefault !== NO_VALUE && newOptionDefault !== formValue) {
             if (oldOptionDefault === formValue) {
               // If the old default matches the formValue, we'll update the new value to match the new default
@@ -191,8 +191,8 @@ export default function sanitizeDataForNewSchema<
             }
           }
 
-          const newOptionConst = get(newKeyedSchema, 'const', NO_VALUE);
-          const oldOptionConst = get(oldKeyedSchema, 'const', NO_VALUE);
+          const newOptionConst = get(newKeyedSchema, CONST_KEY, NO_VALUE);
+          const oldOptionConst = get(oldKeyedSchema, CONST_KEY, NO_VALUE);
           if (newOptionConst !== NO_VALUE && newOptionConst !== formValue) {
             // Since this is a const, if the old value matches, replace the value with the new const otherwise clear it
             removeOldSchemaData[key] = oldOptionConst === formValue ? newOptionConst : undefined;

--- a/packages/utils/test/schema/sanitizeDataForNewSchemaTest.ts
+++ b/packages/utils/test/schema/sanitizeDataForNewSchemaTest.ts
@@ -258,6 +258,169 @@ export default function sanitizeDataForNewSchemaTest(testValidator: TestValidato
         }),
       ).toEqual({});
     });
+    it('replaces invalid enum data with the only allowed enum value', () => {
+      const oldSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            enum: ['oldData'],
+          },
+        },
+      };
+      const newSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            enum: ['newData'],
+          },
+        },
+      };
+      expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, { enumField: 'oldData' })).toEqual({
+        enumField: 'newData',
+      });
+    });
+    it('keeps enum data that is still allowed by the new schema', () => {
+      const oldSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            enum: ['keptData'],
+          },
+        },
+      };
+      const newSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            enum: ['keptData', 'newData'],
+          },
+        },
+      };
+      expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, { enumField: 'keptData' })).toEqual({
+        enumField: 'keptData',
+      });
+    });
+    it('replaces invalid enum data with a valid new default when multiple enum values are allowed', () => {
+      const oldSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            enum: ['oldData'],
+          },
+        },
+      };
+      const newSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            enum: ['newData', 'defaultData'],
+            default: 'defaultData',
+          },
+        },
+      };
+      expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, { enumField: 'oldData' })).toEqual({
+        enumField: 'defaultData',
+      });
+    });
+    it('clears invalid enum data when multiple values are allowed and no valid default exists', () => {
+      const oldSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            enum: ['oldData'],
+          },
+        },
+      };
+      const newSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            enum: ['newData', 'otherData'],
+          },
+        },
+      };
+      expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, { enumField: 'oldData' })).toEqual({
+        enumField: undefined,
+      });
+    });
+    it('replaces invalid oneOf const and enum data', () => {
+      const oldSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            enum: ['oldData'],
+          },
+        },
+      };
+      const newSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            oneOf: [{ const: 'newData' }, { enum: ['otherData'] }, { enum: ['ignoredData', 'extraIgnoredData'] }],
+            default: 'otherData',
+          },
+        },
+      };
+      expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, { enumField: 'oldData' })).toEqual({
+        enumField: 'otherData',
+      });
+    });
+    it('replaces invalid anyOf const data with the only allowed value', () => {
+      const oldSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            enum: ['oldData'],
+          },
+        },
+      };
+      const newSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            anyOf: [{ const: 'newData' }],
+          },
+        },
+      };
+      expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, { enumField: 'oldData' })).toEqual({
+        enumField: 'newData',
+      });
+    });
+    it('keeps invalid data when oneOf does not provide enum-like values', () => {
+      const oldSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            enum: ['oldData'],
+          },
+        },
+      };
+      const newSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          enumField: {
+            type: 'string',
+            oneOf: [{ enum: ['ignoredData', 'extraIgnoredData'] }],
+          },
+        },
+      };
+      expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, { enumField: 'oldData' })).toEqual({
+        enumField: 'oldData',
+      });
+    });
     it('returns empty formData after resolving schema refs', () => {
       const rootSchema: RJSFSchema = {
         definitions: {


### PR DESCRIPTION
## Summary
- sanitize form data when dependency-driven schema resolution changes after a field update
- replace stale enum/oneOf enum values with a valid default or sole option, otherwise clear them
- add a regression test for dependent enum options changing from Fish/worms/lake to Cat/meat

Fixes #3838.

## Testing
- `git show --check --oneline HEAD`

Not run: full package tests, because this sparse checkout has no installed monorepo dependencies and the local C: drive is very low on free space.