### PR TITLE
Chore: Replace fireEvent with RTL async calls (part 1)

### DIFF
--- a/packages/core/test/ArrayField.test.tsx
+++ b/packages/core/test/ArrayField.test.tsx
@@ -13,12 +13,14 @@ import {
   WidgetProps,
   FormValidation,
 } from '@rjsf/utils';
-import { fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { createFormComponent, expectToHaveBeenCalledWithFormData, submitForm } from './testUtils';
 import SchemaField from '../src/components/fields/SchemaField';
 import ArrayField from '../src/components/fields/ArrayField';
 import { TextWidgetTest } from './StringField.test';
+
+const user = userEvent.setup();
 
 const ArrayKeyDataAttr = 'data-rjsf-itemkey';
 const ExposedArrayKeyItemTemplate = function (props: ArrayFieldItemTemplateProps) {
@@ -449,30 +451,26 @@ describe('ArrayField', () => {
       expect(node.querySelector('.rjsf-array-item-add button')).toBeNull();
     });
 
-    it('should add a new field when clicking the add button', () => {
+    it('should add a new field when clicking the add button', async () => {
       const { node } = createFormComponent({ schema });
 
-      act(() => {
-        fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-      });
+      await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
       expect(node.querySelectorAll('.rjsf-field-string')).toHaveLength(1);
     });
 
-    it('should assign new keys/ids when clicking the add button', () => {
+    it('should assign new keys/ids when clicking the add button', async () => {
       const { node } = createFormComponent({
         schema,
         templates: { ArrayFieldTemplate: ExposedArrayKeyTemplate, ArrayFieldItemTemplate: ExposedArrayKeyItemTemplate },
       });
 
-      act(() => {
-        fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-      });
+      await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
       expect(node.querySelector('.rjsf-array-item')).toHaveAttribute(ArrayKeyDataAttr);
     });
 
-    it('should add a field when clicking add button even if event is not passed to onAddClick', () => {
+    it('should add a field when clicking add button even if event is not passed to onAddClick', async () => {
       const { node } = createFormComponent({
         schema,
         templates: {
@@ -481,9 +479,7 @@ describe('ArrayField', () => {
         },
       });
 
-      act(() => {
-        fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-      });
+      await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
       expect(node.querySelector('.rjsf-array-item')).not.toBeNull();
     });
@@ -506,7 +502,7 @@ describe('ArrayField', () => {
       expect(node.querySelector('.rjsf-array-item-add button')).not.toBeNull();
     });
 
-    it('should retain existing row keys/ids when adding new row', () => {
+    it('should retain existing row keys/ids when adding new row', async () => {
       const { node } = createFormComponent({
         schema: { maxItems: 2, ...schema },
         formData: ['foo'],
@@ -517,9 +513,7 @@ describe('ArrayField', () => {
       const startRow1_key = startRows[0].getAttribute(ArrayKeyDataAttr);
       const startRow2_key = startRows[1] ? startRows[1].getAttribute(ArrayKeyDataAttr) : undefined;
 
-      act(() => {
-        fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-      });
+      await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
       const endRows = node.querySelectorAll('.rjsf-array-item');
       const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
@@ -561,12 +555,10 @@ describe('ArrayField', () => {
       expect(node.querySelector('.rjsf-array-item-add button')).toBeNull();
     });
 
-    it('should mark a non-null array item widget as required', () => {
+    it('should mark a non-null array item widget as required', async () => {
       const { node } = createFormComponent({ schema });
 
-      act(() => {
-        fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-      });
+      await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
       expect(node.querySelector('.rjsf-field-string input[type=text]')).toBeRequired();
     });
@@ -600,16 +592,14 @@ describe('ArrayField', () => {
       expect(node.querySelector('.rjsf-array-item-move-down')).not.toBeNull();
     });
 
-    it('should move down a field from the list', () => {
+    it('should move down a field from the list', async () => {
       const { node } = createFormComponent({
         schema,
         formData: ['foo', 'bar', 'baz'],
       });
       const moveDownBtns = node.querySelectorAll('.rjsf-array-item-move-down');
 
-      act(() => {
-        fireEvent.click(moveDownBtns[0]);
-      });
+      await user.click(moveDownBtns[0]);
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       expect(inputs).toHaveLength(3);
@@ -618,16 +608,14 @@ describe('ArrayField', () => {
       expect(inputs[2]).toHaveValue('baz');
     });
 
-    it('should move up a field from the list', () => {
+    it('should move up a field from the list', async () => {
       const { node } = createFormComponent({
         schema,
         formData: ['foo', 'bar', 'baz'],
       });
       const moveUpBtns = node.querySelectorAll('.rjsf-array-item-move-up');
 
-      act(() => {
-        fireEvent.click(moveUpBtns[2]);
-      });
+      await user.click(moveUpBtns[2]);
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       expect(inputs).toHaveLength(3);
@@ -636,7 +624,7 @@ describe('ArrayField', () => {
       expect(inputs[2]).toHaveValue('bar');
     });
 
-    it('should retain row keys/ids when moving down', () => {
+    it('should retain row keys/ids when moving down', async () => {
       const { node } = createFormComponent({
         schema,
         formData: ['foo', 'bar', 'baz'],
@@ -648,9 +636,7 @@ describe('ArrayField', () => {
       const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
       const startRow3_key = startRows[2].getAttribute(ArrayKeyDataAttr);
 
-      act(() => {
-        fireEvent.click(moveDownBtns[0]);
-      });
+      await user.click(moveDownBtns[0]);
 
       const endRows = node.querySelectorAll('.rjsf-array-item');
       const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
@@ -666,7 +652,7 @@ describe('ArrayField', () => {
       expect(endRows[2]).toHaveAttribute(ArrayKeyDataAttr);
     });
 
-    it('should retain row keys/ids when moving up', () => {
+    it('should retain row keys/ids when moving up', async () => {
       const { node } = createFormComponent({
         schema,
         formData: ['foo', 'bar', 'baz'],
@@ -678,9 +664,7 @@ describe('ArrayField', () => {
       const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
       const startRow3_key = startRows[2].getAttribute(ArrayKeyDataAttr);
 
-      act(() => {
-        fireEvent.click(moveUpBtns[2]);
-      });
+      await user.click(moveUpBtns[2]);
 
       const endRows = node.querySelectorAll('.rjsf-array-item');
       const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
@@ -749,45 +733,40 @@ describe('ArrayField', () => {
       expect(moveDownBtns).toBeNull();
     });
 
-    it('should remove a field from the list', () => {
+    it('should remove a field from the list', async () => {
       const { node } = createFormComponent({
         schema,
         formData: ['foo', 'bar'],
       });
       const dropBtns = node.querySelectorAll('.rjsf-array-item-remove');
 
-      act(() => {
-        fireEvent.click(dropBtns[0]);
-      });
+      await user.click(dropBtns[0]);
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       expect(inputs).toHaveLength(1);
       expect(inputs[0]).toHaveValue('bar');
     });
 
-    it('should delete item from list and correct indices', () => {
+    it('should delete item from list and correct indices', async () => {
       const { node } = createFormComponent({
         schema,
         formData: ['foo', 'bar', 'baz'],
       });
       const deleteBtns = node.querySelectorAll('.rjsf-array-item-remove');
 
-      act(() => {
-        fireEvent.click(deleteBtns[0]);
-      });
+      await user.click(deleteBtns[0]);
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
 
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'fuzz' } });
-      });
+      await user.clear(inputs[0]);
+      await user.type(inputs[0], 'fuzz');
 
       expect(inputs).toHaveLength(2);
       expect(inputs[0]).toHaveValue('fuzz');
       expect(inputs[1]).toHaveValue('baz');
     });
 
-    it('should retain row keys/ids of remaining rows when a row is removed', () => {
+    it('should retain row keys/ids of remaining rows when a row is removed', async () => {
       const { node } = createFormComponent({
         schema,
         formData: ['foo', 'bar'],
@@ -798,9 +777,7 @@ describe('ArrayField', () => {
       const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
 
       const dropBtns = node.querySelectorAll('.rjsf-array-item-remove');
-      act(() => {
-        fireEvent.click(dropBtns[0]);
-      });
+      await user.click(dropBtns[0]);
 
       const endRows = node.querySelectorAll('.rjsf-array-item');
       const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
@@ -842,7 +819,7 @@ describe('ArrayField', () => {
       expect(dropBtn).toBeNull();
     });
 
-    it('should force revalidation when a field is removed', () => {
+    it('should force revalidation when a field is removed', async () => {
       // refs #195
       const { node } = createFormComponent({
         schema: {
@@ -853,9 +830,7 @@ describe('ArrayField', () => {
       });
 
       try {
-        act(() => {
-          fireEvent.submit(node);
-        });
+        submitForm(node);
       } catch {
         // Silencing error thrown as failure is expected here
       }
@@ -864,9 +839,7 @@ describe('ArrayField', () => {
 
       const dropBtns = node.querySelectorAll('.rjsf-array-item-remove');
 
-      act(() => {
-        fireEvent.click(dropBtns[0]);
-      });
+      await user.click(dropBtns[0]);
 
       expect(node.querySelectorAll('.has-error .error-detail')).toHaveLength(0);
     });
@@ -914,7 +887,7 @@ describe('ArrayField', () => {
       expect(dropBtn).not.toBeNull();
     });
 
-    it('should copy a field in the list just below the item clicked', () => {
+    it('should copy a field in the list just below the item clicked', async () => {
       const { node } = createFormComponent({
         schema,
         formData: ['foo', 'bar'],
@@ -922,9 +895,7 @@ describe('ArrayField', () => {
       });
       const copyBtns = node.querySelectorAll('.rjsf-array-item-copy');
 
-      act(() => {
-        fireEvent.click(copyBtns[0]);
-      });
+      await user.click(copyBtns[0]);
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       expect(inputs).toHaveLength(3);
@@ -933,7 +904,7 @@ describe('ArrayField', () => {
       expect(inputs[2]).toHaveValue('bar');
     });
 
-    it('should handle cleared field values in the array', () => {
+    it('should handle cleared field values in the array', async () => {
       const schema: RJSFSchema = {
         type: 'array',
         items: { type: 'integer' },
@@ -945,11 +916,7 @@ describe('ArrayField', () => {
         formData,
       });
 
-      act(() => {
-        fireEvent.change(node.querySelector('#root_1')!, {
-          target: { value: '' },
-        });
-      });
+      await user.clear(node.querySelector('#root_1')!);
 
       expect(onChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -1262,51 +1229,32 @@ describe('ArrayField', () => {
         const { node, onChange } = createFormComponent({ schema });
 
         const select = node.querySelector<HTMLSelectElement>('.rjsf-field select')!;
-        const options = select.querySelectorAll('option');
-        act(() => {
-          // Preselect the options on the select before firing the evant
-          options[0].selected = true;
-          options[1].selected = true;
-          options[2].selected = false;
-
-          fireEvent.change(select);
-        });
+        const options = select.querySelectorAll<HTMLOptionElement>('option');
+        await user.selectOptions(select, [options[0], options[1]]);
 
         expectToHaveBeenCalledWithFormData(onChange, ['foo', 'bar'], 'root');
       });
 
-      it('should handle a blur event', () => {
+      it('should handle a blur event', async () => {
         const onBlur = jest.fn();
         const { node } = createFormComponent({ schema, onBlur });
 
-        const select = node.querySelector('.rjsf-field select')!;
-        const options = select.querySelectorAll('option');
-        act(() => {
-          options[0].selected = true;
-          options[1].selected = true;
-          options[2].selected = false;
+        const select = node.querySelector<HTMLSelectElement>('.rjsf-field select')!;
+        const options = select.querySelectorAll<HTMLOptionElement>('option');
+        await user.selectOptions(select, [options[0], options[1]]);
+        await user.tab();
 
-          fireEvent.blur(select);
-        });
-
-        expect(onBlur).toHaveBeenLastCalledWith(select?.id, ['foo', 'bar']);
+        expect(onBlur).toHaveBeenLastCalledWith(select.id, ['foo', 'bar']);
       });
 
-      it('should handle a focus event', () => {
+      it('should handle a focus event', async () => {
         const onFocus = jest.fn();
-        const { node } = createFormComponent({ schema, onFocus });
+        const { node } = createFormComponent({ schema, onFocus, formData: ['foo', 'bar'] });
 
-        const select = node.querySelector('.rjsf-field select')!;
-        const options = select.querySelectorAll('option');
-        act(() => {
-          options[0].selected = true;
-          options[1].selected = true;
-          options[2].selected = false;
+        const select = node.querySelector<HTMLSelectElement>('.rjsf-field select')!;
+        await user.click(select);
 
-          fireEvent.focus(select);
-        });
-
-        expect(onFocus).toHaveBeenLastCalledWith(select?.id, ['foo', 'bar']);
+        expect(onFocus).toHaveBeenLastCalledWith(select.id, ['foo', 'bar']);
       });
 
       it('should fill field with data', () => {
@@ -1435,23 +1383,19 @@ describe('ArrayField', () => {
         expect(labels).toEqual(['foo', 'bar', 'fuzz']);
       });
 
-      it('should handle a change event', () => {
+      it('should handle a change event', async () => {
         const { node, onChange } = createFormComponent({
           schema,
           uiSchema,
         });
 
-        act(() => {
-          fireEvent.click(node.querySelectorAll('[type=checkbox]')[0]);
-        });
-        act(() => {
-          fireEvent.click(node.querySelectorAll('[type=checkbox]')[2]);
-        });
+        await user.click(node.querySelectorAll('[type=checkbox]')[0]);
+        await user.click(node.querySelectorAll('[type=checkbox]')[2]);
 
         expectToHaveBeenCalledWithFormData(onChange, ['foo', 'fuzz'], 'root');
       });
 
-      it('should fill properly field with data that is not an array and handle change event', () => {
+      it('should fill properly field with data that is not an array and handle change event', async () => {
         const { node, onChange } = createFormComponent({
           schema,
           uiSchema,
@@ -1461,9 +1405,7 @@ describe('ArrayField', () => {
         let labels = [].map.call(node.querySelectorAll('[type=checkbox]'), (node: HTMLInputElement) => node.checked);
         expect(labels).toEqual([true, false, false]);
 
-        act(() => {
-          fireEvent.click(node.querySelectorAll('[type=checkbox]')[2]);
-        });
+        await user.click(node.querySelectorAll('[type=checkbox]')[2]);
 
         expectToHaveBeenCalledWithFormData(onChange, ['foo', 'fuzz'], 'root');
         labels = [].map.call(node.querySelectorAll('[type=checkbox]'), (node: HTMLInputElement) => node.checked);
@@ -1585,31 +1527,17 @@ describe('ArrayField', () => {
     it('should handle a two change events that results in two items in the list', async () => {
       const { node, onChange } = createFormComponent({ schema });
 
-      act(() => {
-        fireEvent.change(node.querySelector('.rjsf-field input[type=file]')!, {
-          target: {
-            files: [{ name: 'file1.txt', size: 1, type: 'type' }],
-          },
-        });
-      });
-
-      await act(() => {
-        new Promise(setImmediate);
-      });
+      await user.upload(
+        node.querySelector('.rjsf-field input[type=file]')!,
+        new File([''], 'file1.txt', { type: 'text/plain' }),
+      );
 
       expectToHaveBeenCalledWithFormData(onChange, ['data:text/plain;name=file1.txt;base64,x='], 'root');
 
-      act(() => {
-        fireEvent.change(node.querySelector('.rjsf-field input[type=file]')!, {
-          target: {
-            files: [{ name: 'file2.txt', size: 2, type: 'type' }],
-          },
-        });
-      });
-
-      await act(() => {
-        new Promise(setImmediate);
-      });
+      await user.upload(
+        node.querySelector('.rjsf-field input[type=file]')!,
+        new File([''], 'file2.txt', { type: 'text/plain' }),
+      );
 
       expectToHaveBeenCalledWithFormData(
         onChange,
@@ -1621,20 +1549,10 @@ describe('ArrayField', () => {
     it('should handle a change event with multiple files that results the same items in the list', async () => {
       const { node, onChange } = createFormComponent({ schema });
 
-      act(() => {
-        fireEvent.change(node.querySelector('.rjsf-field input[type=file]')!, {
-          target: {
-            files: [
-              { name: 'file1.txt', size: 1, type: 'type' },
-              { name: 'file2.txt', size: 2, type: 'type' },
-            ],
-          },
-        });
-      });
-
-      await act(() => {
-        new Promise(setImmediate);
-      });
+      await user.upload(node.querySelector('.rjsf-field input[type=file]')!, [
+        new File([''], 'file1.txt', { type: 'text/plain' }),
+        new File([''], 'file2.txt', { type: 'text/plain' }),
+      ]);
 
       expectToHaveBeenCalledWithFormData(
         onChange,
@@ -1741,13 +1659,11 @@ describe('ArrayField', () => {
       expect(node.querySelectorAll('fieldset fieldset')).toHaveLength(2);
     });
 
-    it('should add an inner list when clicking the add button', () => {
+    it('should add an inner list when clicking the add button', async () => {
       const { node } = createFormComponent({ schema });
       expect(node.querySelectorAll('fieldset fieldset')).toHaveLength(0);
 
-      act(() => {
-        fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-      });
+      await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
       expect(node.querySelectorAll('fieldset fieldset')).toHaveLength(1);
     });
@@ -1869,18 +1785,13 @@ describe('ArrayField', () => {
       expect(numInput).toHaveValue(42);
     });
 
-    it('should handle change events', () => {
+    it('should handle change events', async () => {
       const { node, onChange } = createFormComponent({ schema });
-      const strInput = node.querySelector('fieldset .rjsf-field-string input[type=text]');
-      const numInput = node.querySelector('fieldset .rjsf-field-number input[type=number]');
+      const strInput = node.querySelector('fieldset .rjsf-field-string input[type=text]')!;
+      const numInput = node.querySelector('fieldset .rjsf-field-number input[type=number]')!;
 
-      act(() => {
-        fireEvent.change(strInput!, { target: { value: 'bar' } });
-      });
-
-      act(() => {
-        fireEvent.change(numInput!, { target: { value: '101' } });
-      });
+      await user.type(strInput, 'bar');
+      await user.type(numInput, '101');
 
       expectToHaveBeenCalledWithFormData(onChange, ['bar', 101], 'root_1');
     });
@@ -2030,7 +1941,7 @@ describe('ArrayField', () => {
     });
 
     describe('operations for additional items', () => {
-      it('should add a field when clicking add button', () => {
+      it('should add a field when clicking add button', async () => {
         const { node, onChange } = createFormComponent({
           schema: schemaAdditional,
           formData: [1, 2, 'foo'],
@@ -2042,16 +1953,14 @@ describe('ArrayField', () => {
 
         const addBtn = node.querySelector('.rjsf-array-item-add button');
 
-        act(() => {
-          fireEvent.click(addBtn!);
-        });
+        await user.click(addBtn!);
 
         expect(node.querySelectorAll('.rjsf-field-string')).toHaveLength(2);
 
         expectToHaveBeenCalledWithFormData(onChange, [1, 2, 'foo', undefined], 'root');
       });
 
-      it('should retain existing row keys/ids when adding additional items', () => {
+      it('should retain existing row keys/ids when adding additional items', async () => {
         const { node } = createFormComponent({
           schema: schemaAdditional,
           formData: [1, 2, 'foo'],
@@ -2069,9 +1978,7 @@ describe('ArrayField', () => {
 
         const addBtn = node.querySelector('.rjsf-array-item-add button');
 
-        act(() => {
-          fireEvent.click(addBtn!);
-        });
+        await user.click(addBtn!);
 
         const endRows = node.querySelectorAll('.rjsf-array-item');
         const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
@@ -2091,7 +1998,7 @@ describe('ArrayField', () => {
         expect(endRows[3]).toHaveAttribute(ArrayKeyDataAttr);
       });
 
-      it('should change the state when changing input value', () => {
+      it('should change the state when changing input value', async () => {
         const { node, onChange } = createFormComponent({
           schema: schemaAdditional,
           formData: [1, 2, 'foo'],
@@ -2103,24 +2010,18 @@ describe('ArrayField', () => {
 
         const addBtn = node.querySelector('.rjsf-array-item-add button');
 
-        act(() => {
-          fireEvent.click(addBtn!);
-        });
+        await user.click(addBtn!);
 
         const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
 
-        act(() => {
-          fireEvent.change(inputs[0], { target: { value: 'bar' } });
-        });
-
-        act(() => {
-          fireEvent.change(inputs[1], { target: { value: 'baz' } });
-        });
+        await user.clear(inputs[0]);
+        await user.type(inputs[0], 'bar');
+        await user.type(inputs[1], 'baz');
 
         expectToHaveBeenCalledWithFormData(onChange, [1, 2, 'bar', 'baz'], 'root_3');
       });
 
-      it('should remove array items when clicking remove buttons', () => {
+      it('should remove array items when clicking remove buttons', async () => {
         const { node, onChange } = createFormComponent({
           schema: schemaAdditional,
           formData: [1, 2, 'foo'],
@@ -2132,28 +2033,20 @@ describe('ArrayField', () => {
 
         const addBtn = node.querySelector('.rjsf-array-item-add button');
 
-        act(() => {
-          fireEvent.click(addBtn!);
-        });
+        await user.click(addBtn!);
 
         let dropBtns = node.querySelectorAll('.rjsf-array-item-remove');
 
-        act(() => {
-          fireEvent.click(dropBtns[0]);
-        });
+        await user.click(dropBtns[0]);
 
         expect(node.querySelectorAll('.rjsf-field-string')).toHaveLength(1);
         const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-        act(() => {
-          fireEvent.change(inputs[0], { target: { value: 'baz' } });
-        });
+        await user.type(inputs[0], 'baz');
 
         expectToHaveBeenCalledWithFormData(onChange, [1, 2, 'baz'], 'root_2');
 
         dropBtns = node.querySelectorAll('.rjsf-array-item-remove');
-        act(() => {
-          fireEvent.click(dropBtns[0]);
-        });
+        await user.click(dropBtns[0]);
 
         expect(node.querySelectorAll('.rjsf-field-string')).toHaveLength(0);
         expectToHaveBeenCalledWithFormData(onChange, [1, 2], 'root');
@@ -2172,18 +2065,12 @@ describe('ArrayField', () => {
       uniqueItems: true,
     };
 
-    it("should convert array of strings to numbers if type of items is 'number'", () => {
+    it("should convert array of strings to numbers if type of items is 'number'", async () => {
       const { node, onChange } = createFormComponent({ schema });
 
-      const select = node.querySelector('.rjsf-field select')!;
-      const options = select.querySelectorAll('option');
-      act(() => {
-        options[0].selected = true;
-        options[1].selected = true;
-        options[2].selected = false;
-
-        fireEvent.change(select);
-      });
+      const select = node.querySelector<HTMLSelectElement>('.rjsf-field select')!;
+      const options = select.querySelectorAll<HTMLOptionElement>('option');
+      await user.selectOptions(select, [options[0], options[1]]);
 
       expectToHaveBeenCalledWithFormData(onChange, [1, 2], 'root');
     });
@@ -2468,7 +2355,7 @@ describe('ArrayField', () => {
         },
       ];
 
-      it("Should show indexed title for the `CheckboxWidget` widget if no title is mentioned in it's UI Schema", () => {
+      it("Should show indexed title for the `CheckboxWidget` widget if no title is mentioned in it's UI Schema", async () => {
         const CheckboxWidget = (props: WidgetProps) => <div id={`title-${props.label}`} />;
 
         const widgets = { CheckboxWidget };
@@ -2486,14 +2373,12 @@ describe('ArrayField', () => {
           widgets,
         });
 
-        act(() => {
-          fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-        });
+        await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
         expect(node.querySelector('#title-Array-1')).not.toBeNull();
       });
 
-      it("Should not show indexed title for the `CheckboxWidget` widget if title is mentioned in it's UI Schema", () => {
+      it("Should not show indexed title for the `CheckboxWidget` widget if title is mentioned in it's UI Schema", async () => {
         const CheckboxWidget = (props: WidgetProps) => <div id={`title-${props.label}`} />;
 
         const widgets = { CheckboxWidget };
@@ -2512,9 +2397,7 @@ describe('ArrayField', () => {
           widgets,
         });
 
-        act(() => {
-          fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-        });
+        await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
         expect(node.querySelector('#title-Boolean')).not.toBeNull();
         expect(node.querySelector('#title-Array-1')).toBeNull();
@@ -2522,7 +2405,7 @@ describe('ArrayField', () => {
 
       it.each(widgetTestData)(
         "Should show indexed title for the `$widgetName` widget if no title is mentioned in it's UI Schema",
-        ({ itemSchema, itemUiSchema }) => {
+        async ({ itemSchema, itemUiSchema }) => {
           const schema: RJSFSchema = {
             type: 'array',
             title: 'Array',
@@ -2538,9 +2421,7 @@ describe('ArrayField', () => {
             uiSchema,
           });
 
-          act(() => {
-            fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-          });
+          await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
           expect(node.querySelector('label[for="root_0"]')).toHaveTextContent('Array-1');
         },
@@ -2548,7 +2429,7 @@ describe('ArrayField', () => {
 
       it.each(widgetTestData)(
         "Should not show indexed title for the `$widgetName` widget if title is mentioned in it's UI Schema",
-        ({ itemSchema, itemUiSchema }) => {
+        async ({ itemSchema, itemUiSchema }) => {
           const schema: RJSFSchema = {
             type: 'array',
             title: 'Array',
@@ -2567,9 +2448,7 @@ describe('ArrayField', () => {
             uiSchema,
           });
 
-          act(() => {
-            fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-          });
+          await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
           const widgetLabelText = node.querySelector('label[for="root_0"]');
 
@@ -2658,7 +2537,7 @@ describe('ArrayField', () => {
 
       it.each(fieldTestDataWithLegend)(
         "Should show indexed title for the $fieldName field if no title is mentioned in it's UI Schema",
-        ({ itemSchema }) => {
+        async ({ itemSchema }) => {
           const schema: RJSFSchema = {
             type: 'array',
             title: 'Array',
@@ -2669,9 +2548,7 @@ describe('ArrayField', () => {
             schema,
           });
 
-          act(() => {
-            fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-          });
+          await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
           expect(node.querySelector('legend#root_0__title')).toHaveTextContent('Array-1');
         },
@@ -2679,7 +2556,7 @@ describe('ArrayField', () => {
 
       it.each(fieldTestDataWithLegend)(
         "Should not show indexed title for the $fieldName field if title is mentioned in it's UI Schema",
-        ({ itemSchema }) => {
+        async ({ itemSchema }) => {
           const schema: RJSFSchema = {
             type: 'array',
             title: 'Array',
@@ -2693,9 +2570,7 @@ describe('ArrayField', () => {
             schema,
           });
 
-          act(() => {
-            fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-          });
+          await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
           const legendText = node.querySelector('legend#root_0__title');
 
@@ -2706,7 +2581,7 @@ describe('ArrayField', () => {
 
       it.each(fieldTestDataWithLabel)(
         "Should show indexed title for the $fieldName field if no title is mentioned in it's UI Schema",
-        ({ itemSchema }) => {
+        async ({ itemSchema }) => {
           const schema: RJSFSchema = {
             type: 'array',
             title: 'Array',
@@ -2717,9 +2592,7 @@ describe('ArrayField', () => {
             schema,
           });
 
-          act(() => {
-            fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-          });
+          await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
           expect(node.querySelector('label[for="root_0"]')).toHaveTextContent('Array-1');
         },
@@ -2727,7 +2600,7 @@ describe('ArrayField', () => {
 
       it.each(fieldTestDataWithLabel)(
         "Should not show indexed title for the $fieldName field if title is mentioned in it's UI Schema",
-        ({ itemSchema }) => {
+        async ({ itemSchema }) => {
           const schema: RJSFSchema = {
             type: 'array',
             title: 'Array',
@@ -2741,9 +2614,7 @@ describe('ArrayField', () => {
             schema,
           });
 
-          act(() => {
-            fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-          });
+          await user.click(node.querySelector('.rjsf-array-item-add button')!);
 
           const labelText = node.querySelector('label[for="root_0"]');
 
@@ -2821,9 +2692,7 @@ describe('ArrayField', () => {
         customValidate,
       });
 
-      act(() => {
-        fireEvent.submit(node);
-      });
+      submitForm(node);
 
       const inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputs[0]).toHaveAttribute('id', 'root_foo_0_bar');
@@ -2841,7 +2710,7 @@ describe('ArrayField', () => {
         customValidate,
         showErrorList: false,
       });
-      fireEvent.submit(node);
+      submitForm(node);
 
       const inputsNoError = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputsNoError).toHaveLength(0);
@@ -2955,22 +2824,18 @@ describe('ArrayField', () => {
       },
     ];
 
-    it('swaps errors when swapping elements', () => {
+    it('swaps errors when swapping elements', async () => {
       const { node, onChange } = createFormComponent({
         schema,
         formData,
         templates,
       });
 
-      act(() => {
-        submitForm(node);
-      });
+      submitForm(node);
 
       const button = node.querySelector('[title="move-up"]');
 
-      act(() => {
-        button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
+      await user.click(button!);
 
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenLastCalledWith(
@@ -2988,22 +2853,18 @@ describe('ArrayField', () => {
       );
     });
 
-    it('leaves errors when removing higher elements', () => {
+    it('leaves errors when removing higher elements', async () => {
       const { node, onChange } = createFormComponent({
         schema,
         formData,
         templates,
       });
 
-      act(() => {
-        submitForm(node);
-      });
+      submitForm(node);
 
       const button = node.querySelectorAll('[title="remove"]')[1];
 
-      act(() => {
-        button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
+      await user.click(button);
 
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenLastCalledWith(
@@ -3021,22 +2882,18 @@ describe('ArrayField', () => {
       );
     });
 
-    it('removes errors when removing elements', () => {
+    it('removes errors when removing elements', async () => {
       const { node, onChange } = createFormComponent({
         schema,
         formData,
         templates,
       });
 
-      act(() => {
-        submitForm(node);
-      });
+      submitForm(node);
 
       const button = node.querySelector('[title="remove"]');
 
-      act(() => {
-        button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
+      await user.click(button!);
 
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenLastCalledWith(
@@ -3048,22 +2905,18 @@ describe('ArrayField', () => {
       );
     });
 
-    it('leaves errors in place when inserting elements', () => {
+    it('leaves errors in place when inserting elements', async () => {
       const { node, onChange } = createFormComponent({
         schema,
         formData,
         templates,
       });
 
-      act(() => {
-        submitForm(node);
-      });
+      submitForm(node);
 
       const button = node.querySelector('[title="insert"]');
 
-      act(() => {
-        button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
+      await user.click(button!);
 
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenLastCalledWith(
@@ -3081,22 +2934,18 @@ describe('ArrayField', () => {
       );
     });
 
-    it('moves errors when inserting elements', () => {
+    it('moves errors when inserting elements', async () => {
       const { node, onChange } = createFormComponent({
         schema,
         formData: [{ text: 'y' }, {}],
         templates,
       });
 
-      act(() => {
-        submitForm(node);
-      });
+      submitForm(node);
 
       const button = node.querySelector('[title="insert"]');
 
-      act(() => {
-        button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
+      await user.click(button!);
 
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenLastCalledWith(
@@ -3114,7 +2963,7 @@ describe('ArrayField', () => {
       );
     });
 
-    it('leaves errors in place when copying elements', () => {
+    it('leaves errors in place when copying elements', async () => {
       const { node, onChange } = createFormComponent({
         schema,
         uiSchema,
@@ -3122,15 +2971,11 @@ describe('ArrayField', () => {
         templates,
       });
 
-      act(() => {
-        submitForm(node);
-      });
+      submitForm(node);
 
       const button = node.querySelector('[title="copy"]');
 
-      act(() => {
-        button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
+      await user.click(button!);
 
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenLastCalledWith(
@@ -3148,7 +2993,7 @@ describe('ArrayField', () => {
       );
     });
 
-    it('moves errors when copying elements', () => {
+    it('moves errors when copying elements', async () => {
       const { node, onChange } = createFormComponent({
         schema,
         uiSchema,
@@ -3156,15 +3001,11 @@ describe('ArrayField', () => {
         templates,
       });
 
-      act(() => {
-        submitForm(node);
-      });
+      submitForm(node);
 
       const button = node.querySelector('[title="copy"]');
 
-      act(() => {
-        button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
+      await user.click(button!);
 
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenLastCalledWith(
@@ -3202,7 +3043,7 @@ describe('ArrayField', () => {
       expect(node.querySelectorAll('#root_0_text__error')).toHaveLength(0);
     });
 
-    it('raise an error and check if the error is displayed', () => {
+    it('raise an error and check if the error is displayed', async () => {
       const { node } = createFormComponent({
         schema,
         formData: [
@@ -3217,9 +3058,8 @@ describe('ArrayField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'test' } });
-      });
+      await user.clear(inputs[0]);
+      await user.type(inputs[0], 'test');
 
       const errorMessages = node.querySelectorAll('#root_0_text__error');
       expect(errorMessages).toHaveLength(1);
@@ -3227,7 +3067,7 @@ describe('ArrayField', () => {
       expect(errorMessage).toHaveTextContent('Value must be "Appie"');
     });
 
-    it('should not raise an error if value is correct', () => {
+    it('should not raise an error if value is correct', async () => {
       const { node } = createFormComponent({
         schema,
         formData: [
@@ -3242,15 +3082,14 @@ describe('ArrayField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'Appie' } });
-      });
+      await user.clear(inputs[0]);
+      await user.type(inputs[0], 'Appie');
 
       const errorMessages = node.querySelectorAll('#root_0_text__error');
       expect(errorMessages).toHaveLength(0);
     });
 
-    it('should clear an error if value is entered correctly', () => {
+    it('should clear an error if value is entered correctly', async () => {
       const { node } = createFormComponent({
         schema,
         formData: [
@@ -3265,24 +3104,22 @@ describe('ArrayField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'test' } });
-      });
+      await user.clear(inputs[0]);
+      await user.type(inputs[0], 'test');
 
       let errorMessages = node.querySelectorAll('#root_0_text__error');
       expect(errorMessages).toHaveLength(1);
       const errorMessage = node.querySelector('#root_0_text__error .text-danger');
       expect(errorMessage).toHaveTextContent('Value must be "Appie"');
 
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'Appie' } });
-      });
+      await user.clear(inputs[0]);
+      await user.type(inputs[0], 'Appie');
 
       errorMessages = node.querySelectorAll('#root_0_text__error');
       expect(errorMessages).toHaveLength(0);
     });
 
-    it('raise an error and check if the error is displayed using custom text widget', () => {
+    it('raise an error and check if the error is displayed using custom text widget', async () => {
       const { node } = createFormComponent({
         schema,
         formData: [
@@ -3297,9 +3134,8 @@ describe('ArrayField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'hello' } });
-      });
+      await user.clear(inputs[0]);
+      await user.type(inputs[0], 'hello');
 
       const errorMessages = node.querySelectorAll('#root_0_text__error');
       expect(errorMessages).toHaveLength(1);
@@ -3307,7 +3143,7 @@ describe('ArrayField', () => {
       expect(errorMessage).toHaveTextContent('Value must be "test"');
     });
 
-    it('should not raise an error if value is correct using custom text widget', () => {
+    it('should not raise an error if value is correct using custom text widget', async () => {
       const { node } = createFormComponent({
         schema,
         formData: [
@@ -3322,15 +3158,14 @@ describe('ArrayField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'test' } });
-      });
+      await user.clear(inputs[0]);
+      await user.type(inputs[0], 'test');
 
       const errorMessages = node.querySelectorAll('#root_0_text__error');
       expect(errorMessages).toHaveLength(0);
     });
 
-    it('should clear an error if value is entered correctly using custom text widget', () => {
+    it('should clear an error if value is entered correctly using custom text widget', async () => {
       const { node } = createFormComponent({
         schema,
         formData: [
@@ -3345,18 +3180,16 @@ describe('ArrayField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'hello' } });
-      });
+      await user.clear(inputs[0]);
+      await user.type(inputs[0], 'hello');
 
       let errorMessages = node.querySelectorAll('#root_0_text__error');
       expect(errorMessages).toHaveLength(1);
       const errorMessage = node.querySelector('#root_0_text__error .text-danger');
       expect(errorMessage).toHaveTextContent('Value must be "test"');
 
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'test' } });
-      });
+      await user.clear(inputs[0]);
+      await user.type(inputs[0], 'test');
 
       errorMessages = node.querySelectorAll('#root_0_text__error');
       expect(errorMessages).toHaveLength(0);
@@ -3669,7 +3502,7 @@ describe('ArrayField', () => {
       expect(addButton).toBeInTheDocument();
     });
 
-    it('should update dynamically when array items are added', () => {
+    it('should update dynamically when array items are added', async () => {
       const schema: RJSFSchema = {
         type: 'array',
         items: {
@@ -3702,9 +3535,7 @@ describe('ArrayField', () => {
 
       // Add a new item
       const addButton = node.querySelector('.rjsf-array-item-add button');
-      act(() => {
-        fireEvent.click(addButton!);
-      });
+      await user.click(addButton!);
 
       // Should now have called function for both items (3 total: 1 initial + 2 for re-render)
       expect(callCount).toBeGreaterThanOrEqual(3);
@@ -3788,14 +3619,14 @@ describe('ArrayField', () => {
       },
     };
 
-    it('should not save null when clearing an optional number field and submitting', () => {
+    it('should not save null when clearing an optional number field and submitting', async () => {
       const { node, onSubmit } = createFormComponent({
         schema,
         formData: { arrayList: [{ name: 'John', age: 25 }] },
       });
 
-      const ageInput = node.querySelector('#root_arrayList_0_age') as HTMLInputElement;
-      fireEvent.change(ageInput, { target: { value: '' } });
+      const ageInput = node.querySelector<HTMLInputElement>('#root_arrayList_0_age')!;
+      await user.clear(ageInput);
       submitForm(node);
 
       expectToHaveBeenCalledWithFormData(onSubmit, { arrayList: [{ name: 'John' }] }, true);

--- a/packages/core/test/ArrayFieldTemplate.test.tsx
+++ b/packages/core/test/ArrayFieldTemplate.test.tsx
@@ -1,8 +1,10 @@
 import { PureComponent } from 'react';
 import { ArrayFieldTemplateProps, ArrayFieldItemTemplateProps, RJSFSchema, getUiOptions } from '@rjsf/utils';
-import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { createFormComponent } from './testUtils';
+
+const user = userEvent.setup();
 
 const formData = ['one', 'two', 'three'];
 
@@ -298,7 +300,7 @@ describe('ArrayFieldTemplate', () => {
       });
     });
 
-    it('should pass formData so it is in sync with items', () => {
+    it('should pass formData so it is in sync with items', async () => {
       const ArrayFieldTemplate = ({ formData, items, onAddClick }: ArrayFieldTemplateProps) => {
         if (formData.length !== items.length) {
           throw 'Error';
@@ -323,7 +325,7 @@ describe('ArrayFieldTemplate', () => {
       expect(data).toHaveLength(formData.length);
       const button = node.querySelector('.rjsf-array-item-add');
       expect(button).toBeInTheDocument();
-      fireEvent.click(button!);
+      await user.click(button!);
       data = node.querySelectorAll('.test-data');
       expect(data).toHaveLength(formData.length + 1);
     });

--- a/packages/core/test/BooleanField.test.tsx
+++ b/packages/core/test/BooleanField.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, act } from '@testing-library/react';
 import { RJSFSchema, WidgetProps } from '@rjsf/utils';
+import userEvent from '@testing-library/user-event';
 
 import {
   createFormComponent,
@@ -7,6 +7,8 @@ import {
   getSelectedOptionValue,
   submitForm,
 } from './testUtils';
+
+const user = userEvent.setup();
 
 const CustomWidget = () => <div id='custom' />;
 
@@ -258,8 +260,10 @@ describe('BooleanField', () => {
     let errorInputs = node.querySelectorAll('.form-group.rjsf-field-error input[id^=root_bool]');
     expect(errorInputs).toHaveLength(0);
     // Since programmatically triggering focus does not call onFocus, change the focus method to a spy
-    (inputs[0] as HTMLInputElement).focus = focusSpys[0];
-    (inputs[1] as HTMLInputElement).focus = focusSpys[1];
+    // Object.defineProperty is used because userEvent.setup() patches HTMLElement.prototype.focus as
+    // a getter-only, making simple assignment throw in strict mode
+    Object.defineProperty(inputs[0], 'focus', { value: focusSpys[0], writable: true, configurable: true });
+    Object.defineProperty(inputs[1], 'focus', { value: focusSpys[1], writable: true, configurable: true });
     submitForm(node);
     expect(onError).toHaveBeenLastCalledWith([
       expect.objectContaining({ message: "must have required property 'bool'" }),
@@ -290,8 +294,10 @@ describe('BooleanField', () => {
     let errorInputs = node.querySelectorAll('.form-group.rjsf-field-error input[id^=root_bool]');
     expect(errorInputs).toHaveLength(0);
     // Since programmatically triggering focus does not call onFocus, change the focus method to a spy
-    (inputs[0] as HTMLInputElement).focus = focusSpys[0];
-    (inputs[1] as HTMLInputElement).focus = focusSpys[1];
+    // Object.defineProperty is used because userEvent.setup() patches HTMLElement.prototype.focus as
+    // a getter-only, making simple assignment throw in strict mode
+    Object.defineProperty(inputs[0], 'focus', { value: focusSpys[0], writable: true, configurable: true });
+    Object.defineProperty(inputs[1], 'focus', { value: focusSpys[1], writable: true, configurable: true });
     submitForm(node);
     expect(onError).toHaveBeenLastCalledWith([
       expect.objectContaining({ message: "must have required property 'bool'" }),
@@ -302,7 +308,7 @@ describe('BooleanField', () => {
     expect(errorInputs).toHaveLength(0);
   });
 
-  it('should handle a change event', () => {
+  it('should handle a change event', async () => {
     const { node, onChange } = createFormComponent({
       schema: {
         type: 'boolean',
@@ -310,9 +316,7 @@ describe('BooleanField', () => {
       },
     });
 
-    act(() => {
-      fireEvent.click(node.querySelector('input')!);
-    });
+    await user.click(node.querySelector('input')!);
 
     expectToHaveBeenCalledWithFormData(onChange, true, 'root');
   });
@@ -479,7 +483,7 @@ describe('BooleanField', () => {
     expect(node.querySelectorAll('.radio-inline')).toHaveLength(2);
   });
 
-  it('should handle a focus event for radio widgets', () => {
+  it('should handle a focus event for radio widgets', async () => {
     const onFocus = jest.fn();
     const { node } = createFormComponent({
       schema: {
@@ -493,15 +497,11 @@ describe('BooleanField', () => {
     });
 
     const element = node.querySelector('.field-radio-group');
-    fireEvent.focus(node.querySelector('input')!, {
-      target: {
-        value: 1, // use index
-      },
-    });
+    await user.click(node.querySelectorAll('input')[1]); // click "No" (false) radio at index 1
     expect(onFocus).toHaveBeenLastCalledWith(element?.id, false);
   });
 
-  it('should handle a blur event for radio widgets', () => {
+  it('should handle a blur event for radio widgets', async () => {
     const onBlur = jest.fn();
     const { node } = createFormComponent({
       schema: {
@@ -515,11 +515,8 @@ describe('BooleanField', () => {
     });
 
     const element = node.querySelector('.field-radio-group');
-    fireEvent.blur(node.querySelector('input')!, {
-      target: {
-        value: 1, // use index
-      },
-    });
+    await user.click(node.querySelectorAll('input')[1]); // focus "No" (false) radio at index 1
+    await user.tab();
     expect(onBlur).toHaveBeenLastCalledWith(element?.id, false);
   });
 
@@ -534,7 +531,7 @@ describe('BooleanField', () => {
     expect(labels).toEqual(['', 'Si!', 'No!']);
   });
 
-  it('should handle a focus event with checkbox', () => {
+  it('should handle a focus event with checkbox', async () => {
     const onFocus = jest.fn();
     const { node } = createFormComponent({
       schema: {
@@ -548,15 +545,11 @@ describe('BooleanField', () => {
     });
 
     const element = node.querySelector('select');
-    fireEvent.focus(element!, {
-      target: {
-        value: 1, // use index
-      },
-    });
+    await user.click(element!); // focus select (currently has "false" selected at index 1)
     expect(onFocus).toHaveBeenLastCalledWith(element?.id, false);
   });
 
-  it('should handle a blur event with select', () => {
+  it('should handle a blur event with select', async () => {
     const onBlur = jest.fn();
     const { node } = createFormComponent({
       schema: {
@@ -570,11 +563,8 @@ describe('BooleanField', () => {
     });
 
     const element = node.querySelector('select');
-    fireEvent.blur(element!, {
-      target: {
-        value: 1, // use index
-      },
-    });
+    await user.click(element!); // focus select (currently has "false" selected at index 1)
+    await user.tab();
     expect(onBlur).toHaveBeenLastCalledWith(element?.id, false);
   });
 
@@ -601,7 +591,7 @@ describe('BooleanField', () => {
     expect(node.querySelector('#custom')).toBeInTheDocument();
   });
 
-  it('should handle a focus event with checkbox', () => {
+  it('should handle a focus event with checkbox', async () => {
     const onFocus = jest.fn();
     const { node } = createFormComponent({
       schema: {
@@ -615,15 +605,11 @@ describe('BooleanField', () => {
     });
 
     const element = node.querySelector('input');
-    fireEvent.focus(element!, {
-      target: {
-        checked: false,
-      },
-    });
+    await user.tab(); // tab to focus the checkbox without toggling it
     expect(onFocus).toHaveBeenLastCalledWith(element?.id, false);
   });
 
-  it('should handle a blur event with checkbox', () => {
+  it('should handle a blur event with checkbox', async () => {
     const onBlur = jest.fn();
     const { node } = createFormComponent({
       schema: {
@@ -637,11 +623,8 @@ describe('BooleanField', () => {
     });
 
     const element = node.querySelector('input');
-    fireEvent.blur(element!, {
-      target: {
-        checked: false,
-      },
-    });
+    await user.tab(); // tab to focus the checkbox
+    await user.tab(); // tab again to blur it
     expect(onBlur).toHaveBeenLastCalledWith(element?.id, false);
   });
 
@@ -706,7 +689,7 @@ describe('BooleanField', () => {
       expect(node.querySelectorAll('.rjsf-field select')).toHaveLength(1);
     });
 
-    it('should infer the value from an enum on change', () => {
+    it('should infer the value from an enum on change', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           enum: [true, false],
@@ -716,12 +699,9 @@ describe('BooleanField', () => {
       expect(node.querySelectorAll('.rjsf-field select')).toHaveLength(1);
       const $select = node.querySelector<HTMLSelectElement>('.rjsf-field select');
       expect($select).toHaveValue('');
+      const options = $select!.querySelectorAll('option');
 
-      act(() => {
-        fireEvent.change($select!, {
-          target: { value: 0 }, // use index
-        });
-      });
+      await user.selectOptions($select!, options[1]); // skip blank option, select enum[0] = true
       expect(getSelectedOptionValue($select!)).toEqual('true');
       expectToHaveBeenCalledWithFormData(onChange, true, 'root');
     });
@@ -747,18 +727,16 @@ describe('BooleanField', () => {
       expectToHaveBeenCalledWithFormData(onChange, true);
     });
 
-    it('should handle a change event', () => {
+    it('should handle a change event', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           enum: [true, false],
         },
       });
 
-      act(() => {
-        fireEvent.change(node.querySelector('select')!, {
-          target: { value: 1 }, // use index
-        });
-      });
+      const $select = node.querySelector<HTMLSelectElement>('select')!;
+      const options = $select.querySelectorAll('option');
+      await user.selectOptions($select, options[2]); // skip blank option, select enum[1] = false
 
       expectToHaveBeenCalledWithFormData(onChange, false, 'root');
     });

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -136,7 +136,6 @@ describeRepeated('Form common', (createFormComponent) => {
       options = node.querySelectorAll<HTMLOptionElement>('select option');
       // Change the fallback type to 'boolean'
       await user.selectOptions(select, options[2]);
-      console.log('boolean', node.innerHTML);
       expect(options[2]).toHaveTextContent('boolean');
       expect(options[2].selected).toBe(true);
       expect(node.querySelector<HTMLInputElement>('input[type=checkbox]')).toBeInTheDocument();

--- a/packages/core/test/NumberField.test.tsx
+++ b/packages/core/test/NumberField.test.tsx
@@ -1,6 +1,6 @@
 import { createRef } from 'react';
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
-import { act, fireEvent } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import isEmpty from 'lodash/isEmpty';
 
@@ -152,7 +152,7 @@ describe('NumberField', () => {
         expectToHaveBeenCalledWithFormData(onChange, 2, 'root');
       });
 
-      it('should handle a blur event', () => {
+      it('should handle a blur event', async () => {
         const onBlur = jest.fn();
         const { node } = createFormComponent({
           schema: {
@@ -162,15 +162,14 @@ describe('NumberField', () => {
           onBlur,
         });
 
-        const input = node.querySelector('input');
-        fireEvent.blur(input!, {
-          target: { value: '2' },
-        });
+        const input = node.querySelector('input')!;
+        await user.type(input, '2');
+        await user.tab();
 
-        expect(onBlur).toHaveBeenCalledWith(input?.id, '2');
+        expect(onBlur).toHaveBeenCalledWith(input.id, '2');
       });
 
-      it('should handle a focus event', () => {
+      it('should handle a focus event', async () => {
         const onFocus = jest.fn();
         const { node } = createFormComponent({
           schema: {
@@ -178,14 +177,13 @@ describe('NumberField', () => {
           },
           uiSchema,
           onFocus,
+          formData: 2,
         });
 
-        const input = node.querySelector('input');
-        fireEvent.focus(input!, {
-          target: { value: '2' },
-        });
+        const input = node.querySelector('input')!;
+        await user.click(input);
 
-        expect(onFocus).toHaveBeenCalledWith(input?.id, '2');
+        expect(onFocus).toHaveBeenCalledWith(input.id, '2');
       });
 
       it('should fill field with data', () => {
@@ -427,7 +425,7 @@ describe('NumberField', () => {
       expect(node.querySelectorAll('.rjsf-field select')).toHaveLength(1);
     });
 
-    it('should infer the value from an enum on change', () => {
+    it('should infer the value from an enum on change', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           enum: [1, 2],
@@ -435,15 +433,13 @@ describe('NumberField', () => {
       });
 
       expect(node.querySelectorAll('.rjsf-field select')).toHaveLength(1);
-      const $select = node.querySelector<HTMLSelectElement>('.rjsf-field select');
+      const $select = node.querySelector<HTMLSelectElement>('.rjsf-field select')!;
       expect($select).not.toHaveAttribute('value');
+      const options = $select.querySelectorAll('option');
 
-      act(() => {
-        fireEvent.change(node.querySelector('.rjsf-field select')!, {
-          target: { value: 0 }, // use index
-        });
-      });
-      expect(getSelectedOptionValue($select!)).toEqual('1');
+      await user.selectOptions($select, options[1]); // skip blank option, select enum[0] = 1
+
+      expect(getSelectedOptionValue($select)).toEqual('1');
       expectToHaveBeenCalledWithFormData(onChange, 1, 'root');
     });
 
@@ -473,7 +469,7 @@ describe('NumberField', () => {
       expectToHaveBeenCalledWithFormData(onChange, 1);
     });
 
-    it('should handle a change event', () => {
+    it('should handle a change event', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           type: 'number',
@@ -481,11 +477,9 @@ describe('NumberField', () => {
         },
       });
 
-      act(() => {
-        fireEvent.change(node.querySelector('select')!, {
-          target: { value: 1 }, // useIndex
-        });
-      });
+      const $select = node.querySelector<HTMLSelectElement>('select')!;
+      const options = $select.querySelectorAll('option');
+      await user.selectOptions($select, options[2]); // skip blank option, select enum[1] = 2
 
       expectToHaveBeenCalledWithFormData(onChange, 2, 'root');
     });
@@ -576,7 +570,6 @@ describe('NumberField', () => {
         schema,
       });
 
-      console.log(node.innerHTML);
       const selects = node.querySelectorAll('select');
       expect(selects[0]).not.toHaveAttribute('value');
 

--- a/packages/core/test/ObjectField.test.tsx
+++ b/packages/core/test/ObjectField.test.tsx
@@ -9,7 +9,7 @@ import {
   DescriptionFieldProps,
   GenericObjectType,
 } from '@rjsf/utils';
-import { fireEvent, act } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import Form from '../src';
@@ -36,15 +36,13 @@ const ObjectFieldTest = (props: FieldProps) => {
 
 describe('ObjectField', () => {
   describe('schema', () => {
+    const schemaDefaults = { foo: 'hey', bar: true };
     const schema: RJSFSchema = {
       type: 'object',
       title: 'my object',
       description: 'my description',
       required: ['foo'],
-      default: {
-        foo: 'hey',
-        bar: true,
-      },
+      default: schemaDefaults,
       properties: {
         foo: {
           title: 'Foo',
@@ -126,7 +124,7 @@ describe('ObjectField', () => {
     it('should handle a default object value', () => {
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelector('.rjsf-field input[type=text]')).toHaveValue('hey');
+      expect(node.querySelector('.rjsf-field input[type=text]')).toHaveValue(schemaDefaults.foo);
       expect(node.querySelector('.rjsf-field input[type=checkbox]')).toBeChecked();
     });
 
@@ -139,50 +137,48 @@ describe('ObjectField', () => {
     });
 
     it('should fill fields with form data', () => {
-      const { node } = createFormComponent({
-        schema,
-        formData: {
-          foo: 'hey',
-          bar: true,
-        },
-      });
+      const formData = {
+        foo: 'heyyou',
+        bar: true,
+      };
+      const { node } = createFormComponent({ schema, formData });
 
-      expect(node.querySelector('.rjsf-field input[type=text]')).toHaveValue('hey');
+      expect(node.querySelector('.rjsf-field input[type=text]')).toHaveValue(formData.foo);
       expect(node.querySelector('.rjsf-field input[type=checkbox]')).toBeChecked();
     });
 
-    it('should handle object fields change events', () => {
+    it('should handle object fields change events', async () => {
       const { node, onChange } = createFormComponent({ schema });
 
-      fireEvent.change(node.querySelector('input[type=text]')!, {
-        target: { value: 'changed' },
-      });
+      const input = node.querySelector('input[type=text]')!;
+      // Select the existing default 'hey' before typing so it gets replaced rather than appended to.
+      // initialSelectionStart/End use setSelectionRange() directly
+      await user.type(input, 'changed', { initialSelectionStart: 0, initialSelectionEnd: schemaDefaults.foo.length });
 
       expectToHaveBeenCalledWithFormData(onChange, expect.objectContaining({ foo: 'changed' }), 'root_foo');
     });
 
-    it('should handle object fields with blur events', () => {
+    it('should handle object fields with blur events', async () => {
       const onBlur = jest.fn();
       const { node } = createFormComponent({ schema, onBlur });
 
-      const input = node.querySelector('input[type=text]');
-      fireEvent.blur(input!, {
-        target: { value: 'changed' },
-      });
+      const input = node.querySelector('input[type=text]')!;
+      // Select the existing default 'hey' before typing so it gets replaced rather than appended to.
+      // initialSelectionStart/End use setSelectionRange() directly
+      await user.type(input, 'changed', { initialSelectionStart: 0, initialSelectionEnd: schemaDefaults.foo.length });
+      await user.tab();
 
-      expect(onBlur).toHaveBeenCalledWith(input?.id, 'changed');
+      expect(onBlur).toHaveBeenCalledWith(input.id, 'changed');
     });
 
-    it('should handle object fields with focus events', () => {
+    it('should handle object fields with focus events', async () => {
       const onFocus = jest.fn();
-      const { node } = createFormComponent({ schema, onFocus });
+      const { node } = createFormComponent({ schema, onFocus, formData: { foo: 'changed', bar: true } });
 
-      const input = node.querySelector('input[type=text]');
-      fireEvent.focus(input!, {
-        target: { value: 'changed' },
-      });
+      const input = node.querySelector('input[type=text]')!;
+      await user.click(input);
 
-      expect(onFocus).toHaveBeenCalledWith(input?.id, 'changed');
+      expect(onFocus).toHaveBeenCalledWith(input.id, 'changed');
     });
 
     it('should render the widget with the expected id', () => {
@@ -223,7 +219,7 @@ describe('ObjectField', () => {
       });
     });
 
-    it('Check schema with if/then/else conditions and activate the then/else subschemas, the onChange event should reflect the actual validation errors', () => {
+    it('Check schema with if/then/else conditions and activate the then/else subschemas, the onChange event should reflect the actual validation errors', async () => {
       const schema: RJSFSchema = {
         type: 'object',
         _const: 'test',
@@ -260,7 +256,7 @@ describe('ObjectField', () => {
       });
 
       // Uncheck the checkbox
-      fireEvent.click(node.querySelector('input[type=checkbox]')!);
+      await user.click(node.querySelector('input[type=checkbox]')!);
 
       expect(onChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -340,7 +336,7 @@ describe('ObjectField', () => {
       expect(node.querySelectorAll('#root_foo__error')).toHaveLength(0);
     });
 
-    it('raise an error and check if the error is displayed', () => {
+    it('raise an error and check if the error is displayed', async () => {
       const { node } = createFormComponent({
         schema,
         fields: {
@@ -349,9 +345,7 @@ describe('ObjectField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'hello' } });
-      });
+      await user.type(inputs[0], 'hello');
 
       const errorMessages = node.querySelectorAll('#root_foo__error');
       expect(errorMessages).toHaveLength(1);
@@ -359,7 +353,7 @@ describe('ObjectField', () => {
       expect(errorMessageContent).toHaveTextContent('Value must be "test"');
     });
 
-    it('should not raise an error if value is correct', () => {
+    it('should not raise an error if value is correct', async () => {
       const { node } = createFormComponent({
         schema,
         fields: {
@@ -368,15 +362,16 @@ describe('ObjectField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'test' } });
+      await user.type(inputs[0], 'test', {
+        initialSelectionStart: 0,
+        initialSelectionEnd: schemaDefaults.foo.length,
       });
 
       const errorMessages = node.querySelectorAll('#root_foo__error');
       expect(errorMessages).toHaveLength(0);
     });
 
-    it('should clear an error if value is entered correctly', () => {
+    it('should clear an error if value is entered correctly', async () => {
       const { node } = createFormComponent({
         schema,
         fields: {
@@ -384,9 +379,11 @@ describe('ObjectField', () => {
         },
       });
 
+      const newValue = 'hello';
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'hello' } });
+      await user.type(inputs[0], newValue, {
+        initialSelectionStart: 0,
+        initialSelectionEnd: schemaDefaults.foo.length,
       });
 
       let errorMessages = node.querySelectorAll('#root_foo__error');
@@ -394,15 +391,16 @@ describe('ObjectField', () => {
       const errorMessageContent = node.querySelector('#root_foo__error .text-danger');
       expect(errorMessageContent).toHaveTextContent('Value must be "test"');
 
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'test' } });
+      await user.type(inputs[0], 'test', {
+        initialSelectionStart: 0,
+        initialSelectionEnd: newValue.length,
       });
 
       errorMessages = node.querySelectorAll('#root_foo__error');
       expect(errorMessages).toHaveLength(0);
     });
 
-    it('raise an error and check if the error is displayed using custom text widget', () => {
+    it('raise an error and check if the error is displayed using custom text widget', async () => {
       const { node } = createFormComponent({
         schema,
         widgets: {
@@ -411,9 +409,7 @@ describe('ObjectField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'hello' } });
-      });
+      await user.type(inputs[0], 'hello');
 
       const errorMessages = node.querySelectorAll('#root_foo__error');
       expect(errorMessages).toHaveLength(1);
@@ -421,7 +417,7 @@ describe('ObjectField', () => {
       expect(errorMessageContent).toHaveTextContent('Value must be "test"');
     });
 
-    it('should not raise an error if value is correct using custom text widget', () => {
+    it('should not raise an error if value is correct using custom text widget', async () => {
       const { node } = createFormComponent({
         schema,
         widgets: {
@@ -430,15 +426,16 @@ describe('ObjectField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'test' } });
+      await user.type(inputs[0], 'test', {
+        initialSelectionStart: 0,
+        initialSelectionEnd: schemaDefaults.foo.length,
       });
 
       const errorMessages = node.querySelectorAll('#root_foo__error');
       expect(errorMessages).toHaveLength(0);
     });
 
-    it('should clear an error if value is entered correctly using custom text widget', () => {
+    it('should clear an error if value is entered correctly using custom text widget', async () => {
       const { node } = createFormComponent({
         schema,
         widgets: {
@@ -446,17 +443,21 @@ describe('ObjectField', () => {
         },
       });
 
+      const newValue = 'hello';
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'hello' } });
+      await user.type(inputs[0], newValue, {
+        initialSelectionStart: 0,
+        initialSelectionEnd: schemaDefaults.foo.length,
       });
 
       let errorMessages = node.querySelectorAll('#root_foo__error');
       expect(errorMessages).toHaveLength(1);
       const errorMessageContent = node.querySelector('#root_foo__error .text-danger');
       expect(errorMessageContent).toHaveTextContent('Value must be "test"');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'test' } });
+
+      await user.type(inputs[0], 'test', {
+        initialSelectionStart: 0,
+        initialSelectionEnd: newValue.length,
       });
 
       errorMessages = node.querySelectorAll('#root_foo__error');
@@ -491,7 +492,6 @@ describe('ObjectField', () => {
       const { node } = createFormComponent({ schema, formData });
       // click submit
       submitForm(node);
-      console.log(node.innerHTML);
       const fooDotBarErrors = node.querySelectorAll('#root_Foo.Bar__error');
       expect(fooDotBarErrors).toHaveLength(0);
       const fooBarErrors = node.querySelectorAll('#root_Foo_Bar__error');
@@ -873,21 +873,21 @@ describe('ObjectField', () => {
       expect(node.querySelector('#root_first')).toHaveValue('1');
     });
 
-    it('should rename formData key if key input is renamed', () => {
+    it('should rename formData key if key input is renamed', async () => {
       const { node, onChange } = createFormComponent({
         schema,
         formData: { first: 1 },
       });
 
-      const textNode = node.querySelector('#root_first-key');
-      fireEvent.blur(textNode!, {
-        target: { value: 'newFirst' },
-      });
+      const textNode = node.querySelector('#root_first-key')!;
+      await user.clear(textNode);
+      await user.type(textNode, 'newFirst');
+      await user.tab();
 
       expectToHaveBeenCalledWithFormData(onChange, { newFirst: 1, first: undefined }, 'root');
     });
 
-    it('should retain and display user-input data if key-value pair has a title present in the schema when renaming key', () => {
+    it('should retain and display user-input data if key-value pair has a title present in the schema when renaming key', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           type: 'object',
@@ -899,10 +899,10 @@ describe('ObjectField', () => {
         formData: { 'Custom title': 1 },
       });
 
-      const textNode = node.querySelector('#root_Custom\\ title-key');
-      fireEvent.blur(textNode!, {
-        target: { value: 'Renamed custom title' },
-      });
+      const textNode = node.querySelector('#root_Custom\\ title-key')!;
+      await user.clear(textNode);
+      await user.type(textNode, 'Renamed custom title');
+      await user.tab();
 
       expectToHaveBeenCalledWithFormData(onChange, { 'Renamed custom title': 1 }, 'root');
 
@@ -913,7 +913,7 @@ describe('ObjectField', () => {
       expect(keyInputLabel).toHaveTextContent('Renamed custom title Key');
     });
 
-    it('should retain object title when renaming key', () => {
+    it('should retain object title when renaming key', async () => {
       const { node } = createFormComponent({
         schema: {
           title: 'Object title',
@@ -925,25 +925,25 @@ describe('ObjectField', () => {
         formData: { 'Custom title': 1 },
       });
 
-      const textNode = node.querySelector('#root_Custom\\ title-key');
-      fireEvent.blur(textNode!, {
-        target: { value: 'Renamed custom title' },
-      });
+      const textNode = node.querySelector('#root_Custom\\ title-key')!;
+      await user.clear(textNode);
+      await user.type(textNode, 'Renamed custom title');
+      await user.tab();
 
       const title = node.querySelector('#root__title');
       expect(title).toHaveTextContent('Object title');
     });
 
-    it('should keep order of renamed key-value pairs while renaming key', () => {
+    it('should keep order of renamed key-value pairs while renaming key', async () => {
       const { node, onChange } = createFormComponent({
         schema,
         formData: { first: 1, second: 2, third: 3 },
       });
 
-      const textNode = node.querySelector('#root_second-key');
-      fireEvent.blur(textNode!, {
-        target: { value: 'newSecond' },
-      });
+      const textNode = node.querySelector('#root_second-key')!;
+      await user.clear(textNode);
+      await user.type(textNode, 'newSecond');
+      await user.tab();
 
       expectToHaveBeenCalledWithFormData(onChange, { first: 1, newSecond: 2, third: 3 }, 'root');
     });
@@ -989,7 +989,7 @@ describe('ObjectField', () => {
       expectToHaveBeenCalledWithFormData(onChange, { options: { efsKey: { option_name: 'EFS' } } }, 'root_options');
     });
 
-    it('should attach suffix to formData key if new key already exists when key input is renamed', () => {
+    it('should attach suffix to formData key if new key already exists when key input is renamed', async () => {
       const formData = {
         first: 1,
         second: 2,
@@ -999,15 +999,15 @@ describe('ObjectField', () => {
         formData,
       });
 
-      const textNode = node.querySelector('#root_first-key');
-      fireEvent.blur(textNode!, {
-        target: { value: 'second' },
-      });
+      const textNode = node.querySelector('#root_first-key')!;
+      await user.clear(textNode);
+      await user.type(textNode, 'second');
+      await user.tab();
 
       expectToHaveBeenCalledWithFormData(onChange, { second: 2, 'second-1': 1 }, 'root');
     });
 
-    it('uses a custom separator between the duplicate key name and the suffix', () => {
+    it('uses a custom separator between the duplicate key name and the suffix', async () => {
       const formData = {
         first: 1,
         second: 2,
@@ -1020,15 +1020,15 @@ describe('ObjectField', () => {
         },
       });
 
-      const textNode = node.querySelector('#root_first-key');
-      fireEvent.blur(textNode!, {
-        target: { value: 'second' },
-      });
+      const textNode = node.querySelector('#root_first-key')!;
+      await user.clear(textNode);
+      await user.type(textNode, 'second');
+      await user.tab();
 
       expectToHaveBeenCalledWithFormData(onChange, { second: 2, second_1: 1 }, 'root');
     });
 
-    it('uses a global custom separator between the duplicate key name and the suffix', () => {
+    it('uses a global custom separator between the duplicate key name and the suffix', async () => {
       const formData = {
         first: 1,
         second: 2,
@@ -1043,15 +1043,15 @@ describe('ObjectField', () => {
         },
       });
 
-      const textNode = node.querySelector('#root_first-key');
-      fireEvent.blur(textNode!, {
-        target: { value: 'second' },
-      });
+      const textNode = node.querySelector('#root_first-key')!;
+      await user.clear(textNode);
+      await user.type(textNode, 'second');
+      await user.tab();
 
       expectToHaveBeenCalledWithFormData(onChange, { second: 2, second_1: 1 }, 'root');
     });
 
-    it('should not attach suffix when input is only clicked', () => {
+    it('should not attach suffix when input is only clicked', async () => {
       const formData = {
         first: 1,
       };
@@ -1060,13 +1060,14 @@ describe('ObjectField', () => {
         formData,
       });
 
-      const textNode = node.querySelector('#root_first-key');
-      fireEvent.blur(textNode!);
+      const textNode = node.querySelector('#root_first-key')!;
+      await user.click(textNode);
+      await user.tab();
 
       expect(onChange).not.toHaveBeenCalled();
     });
 
-    it('should continue incrementing suffix to formData key until that key name is unique after a key input collision', () => {
+    it('should continue incrementing suffix to formData key until that key name is unique after a key input collision', async () => {
       const formData = {
         first: 1,
         second: 2,
@@ -1082,10 +1083,10 @@ describe('ObjectField', () => {
         formData,
       });
 
-      const textNode = node.querySelector('#root_first-key');
-      fireEvent.blur(textNode!, {
-        target: { value: 'second' },
-      });
+      const textNode = node.querySelector('#root_first-key')!;
+      await user.clear(textNode);
+      await user.type(textNode, 'second');
+      await user.tab();
 
       expectToHaveBeenCalledWithFormData(
         onChange,
@@ -1103,57 +1104,63 @@ describe('ObjectField', () => {
       );
     });
 
-    it('should preserve focus on value field after renaming key via Tab', () => {
+    it('should preserve focus on value field after renaming key via Tab', async () => {
       const { node } = createFormComponent({
         schema,
         formData: { first: 1 },
       });
 
-      const keyInput = node.querySelector('#root_first-key') as HTMLInputElement;
-      keyInput.focus();
-      fireEvent.blur(keyInput, { target: { value: 'renamed' } });
+      const keyInput = node.querySelector<HTMLInputElement>('#root_first-key')!;
+      await user.clear(keyInput);
+      await user.type(keyInput, 'renamed');
+      await user.tab();
 
       // After rename, the value input for the renamed key should exist
       const valueInput = node.querySelector('#root_renamed');
       expect(valueInput).not.toBeNull();
     });
 
-    it('should not produce duplicate React keys when adding a property with the old name after rename', () => {
+    it('should not produce duplicate React keys when adding a property with the old name after rename', async () => {
       const { node } = createFormComponent({
         schema,
         formData: { first: 1 },
       });
 
       // Rename "first" to "second"
-      const keyInput = node.querySelector('#root_first-key');
-      fireEvent.blur(keyInput!, { target: { value: 'second' } });
+      const keyInput = node.querySelector('#root_first-key')!;
+      await user.clear(keyInput);
+      await user.type(keyInput, 'second');
+      await user.tab();
 
       // Add a new property
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       // Rename the new property to "first" (the old name)
       const newKeyInput = node.querySelector('#root_newKey-key');
       expect(newKeyInput).not.toBeNull();
-      fireEvent.blur(newKeyInput!, { target: { value: 'first' } });
+      await user.clear(newKeyInput!);
+      await user.type(newKeyInput!, 'first');
+      await user.tab();
 
       // Both properties should render without errors
       expect(node.querySelector('#root_second')).not.toBeNull();
       expect(node.querySelector('#root_first')).not.toBeNull();
     });
 
-    it('should not duplicate values when clicking Add button during key rename', () => {
+    it('should not duplicate values when clicking Add button during key rename', async () => {
       const { node, onChange } = createFormComponent({
         schema,
         formData: { first: 1 },
       });
 
       // Start editing the key
-      const keyInput = node.querySelector('#root_first-key') as HTMLInputElement;
-      keyInput.focus();
+      const keyInput = node.querySelector<HTMLInputElement>('#root_first-key')!;
+      await user.clear(keyInput);
+      await user.type(keyInput, 'renamed');
 
       // Blur triggers rename, then click Add
-      fireEvent.blur(keyInput, { target: { value: 'renamed' } });
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.tab();
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       // The last onChange call should have both renamed + new property, no value duplication
       expectToHaveBeenCalledWithFormData(
@@ -1167,7 +1174,7 @@ describe('ObjectField', () => {
       );
     });
 
-    it('should preserve all properties when two keys are renamed in quick succession', () => {
+    it('should preserve all properties when two keys are renamed in quick succession', async () => {
       const formData = {
         first: 1,
         second: 2,
@@ -1178,36 +1185,38 @@ describe('ObjectField', () => {
         formData,
       });
 
-      const firstKeyNode = node.querySelector('#root_first-key');
-      const secondKeyNode = node.querySelector('#root_second-key');
+      const firstKeyNode = node.querySelector('#root_first-key')!;
+      const secondKeyNode = node.querySelector('#root_second-key')!;
 
-      act(() => {
-        fireEvent.blur(firstKeyNode!, {
-          target: { value: 'renamedFirst' },
-        });
-        fireEvent.blur(secondKeyNode!, {
-          target: { value: 'renamedSecond' },
-        });
-      });
+      await user.clear(firstKeyNode);
+      await user.type(firstKeyNode, 'renamedFirst');
+      await user.tab();
+      await user.clear(secondKeyNode);
+      await user.type(secondKeyNode, 'renamedSecond');
+      await user.tab();
 
       expect(onChange).toHaveBeenCalledTimes(2);
       expectToHaveBeenCalledWithFormData(onChange, { renamedFirst: 1, renamedSecond: 2, third: 3 }, 'root');
     });
 
-    it('should preserve focus across consecutive renames of the same property', () => {
+    it('should preserve focus across consecutive renames of the same property', async () => {
       const { node } = createFormComponent({
         schema,
         formData: { first: 1 },
       });
 
       // First rename
-      const keyInput1 = node.querySelector('#root_first-key');
-      fireEvent.blur(keyInput1!, { target: { value: 'second' } });
+      const keyInput1 = node.querySelector('#root_first-key')!;
+      await user.clear(keyInput1);
+      await user.type(keyInput1, 'second');
+      await user.tab();
 
       // Second rename of the same property
       const keyInput2 = node.querySelector('#root_second-key');
       expect(keyInput2).not.toBeNull();
-      fireEvent.blur(keyInput2!, { target: { value: 'third' } });
+      await user.clear(keyInput2!);
+      await user.type(keyInput2!, 'third');
+      await user.tab();
 
       // The property should exist with the final name
       const keyInput3 = node.querySelector('#root_third-key');
@@ -1215,27 +1224,29 @@ describe('ObjectField', () => {
       expect(node.querySelector('#root_third')).not.toBeNull();
     });
 
-    it('should handle rename after removing a property', () => {
+    it('should handle rename after removing a property', async () => {
       const { node, onChange } = createFormComponent({
         schema,
         formData: { first: 1 },
       });
 
       // Remove "first"
-      fireEvent.click(node.querySelector('.rjsf-object-property-remove')!);
+      await user.click(node.querySelector('.rjsf-object-property-remove')!);
 
       // Add a new property
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       // Rename the new property
       const keyInput = node.querySelector('#root_newKey-key');
       expect(keyInput).not.toBeNull();
-      fireEvent.blur(keyInput!, { target: { value: 'renamed' } });
+      await user.clear(keyInput!);
+      await user.type(keyInput!, 'renamed');
+      await user.tab();
 
       expectToHaveBeenCalledWithFormData(onChange, { renamed: 'New Value' }, 'root');
     });
 
-    it('should generate unique stable keys that do not collide with existing property names', () => {
+    it('should generate unique stable keys that do not collide with existing property names', async () => {
       const { node } = createFormComponent({
         schema,
         formData: { first: 1, 'first-1': 2 },
@@ -1243,125 +1254,140 @@ describe('ObjectField', () => {
 
       // Rename "first" to "other" — previousKey should not be "first" (collision)
       // nor "first-1" (also exists). It should be "first-2" or similar
-      const keyInput = node.querySelector('#root_first-key');
-      fireEvent.blur(keyInput!, { target: { value: 'other' } });
+      const keyInput = node.querySelector('#root_first-key')!;
+      await user.clear(keyInput);
+      await user.type(keyInput, 'other');
+      await user.tab();
 
       // Both remaining properties should render correctly
       expect(node.querySelector('#root_other')).not.toBeNull();
       expect(node.querySelector('#root_first-1')).not.toBeNull();
     });
 
-    it('should preserve stable React key when renaming a newly added property for the first time', () => {
+    it('should preserve stable React key when renaming a newly added property for the first time', async () => {
       const { node } = createFormComponent({
         schema,
         formData: { first: 1 },
       });
 
       // Add a new property
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       // Rename the newly added property for the first time
-      const newKeyInput = node.querySelector('#root_newKey-key') as HTMLInputElement;
+      const newKeyInput = node.querySelector<HTMLInputElement>('#root_newKey-key')!;
       expect(newKeyInput).not.toBeNull();
-      newKeyInput.focus();
-      fireEvent.blur(newKeyInput, { target: { value: 'second' } });
+      await user.clear(newKeyInput);
+      await user.type(newKeyInput, 'second');
+      await user.tab();
 
       // The renamed key and its value input should exist (component was reused, not remounted)
       expect(node.querySelector('#root_second-key')).not.toBeNull();
       expect(node.querySelector('#root_second')).not.toBeNull();
     });
 
-    it('should not collide React keys when a new property is added after rename and gets the old name', () => {
+    it('should not collide React keys when a new property is added after rename and gets the old name', async () => {
       const { node } = createFormComponent({
         schema,
         formData: { first: 1 },
       });
 
       // Rename "first" → "renamed"
-      const keyInput = node.querySelector('#root_first-key');
-      fireEvent.blur(keyInput!, { target: { value: 'renamed' } });
+      const keyInput = node.querySelector('#root_first-key')!;
+      await user.clear(keyInput);
+      await user.type(keyInput, 'renamed');
+      await user.tab();
 
       // Add a new property (resets previousKey so "first" won't be reused as a React key)
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       // Rename new property to "first" (the old name)
       const newKeyInput = node.querySelector('#root_newKey-key');
       expect(newKeyInput).not.toBeNull();
-      fireEvent.blur(newKeyInput!, { target: { value: 'first' } });
+      await user.clear(newKeyInput!);
+      await user.type(newKeyInput!, 'first');
+      await user.tab();
 
       // Both properties should render without React key collision
       expect(node.querySelector('#root_renamed')).not.toBeNull();
       expect(node.querySelector('#root_first')).not.toBeNull();
     });
 
-    it('should not carry over renamed key input value to newly added property', () => {
+    it('should not carry over renamed key input value to newly added property', async () => {
       const { node } = createFormComponent({
         schema,
         formData: {},
       });
 
       // Add a property
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       // Rename "newKey" → "first"
-      const keyInput = node.querySelector('#root_newKey-key') as HTMLInputElement;
-      fireEvent.blur(keyInput, { target: { value: 'first' } });
+      const keyInput = node.querySelector<HTMLInputElement>('#root_newKey-key')!;
+      await user.clear(keyInput);
+      await user.type(keyInput, 'first');
+      await user.tab();
 
       // Add another property
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       // The new property's key input should show "newKey", not "first"
-      const newKeyInput = node.querySelector('#root_newKey-key') as HTMLInputElement;
+      const newKeyInput = node.querySelector<HTMLInputElement>('#root_newKey-key')!;
       expect(newKeyInput).not.toBeNull();
       expect(newKeyInput.value).toBe('newKey');
     });
 
-    it('should not corrupt key input when renaming two properties sequentially', () => {
+    it('should not corrupt key input when renaming two properties sequentially', async () => {
       const { node } = createFormComponent({
         schema,
         formData: {},
       });
 
       // Add first property and rename to "first"
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
-      const keyInput1 = node.querySelector('#root_newKey-key') as HTMLInputElement;
-      fireEvent.blur(keyInput1, { target: { value: 'first' } });
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
+      const keyInput1 = node.querySelector<HTMLInputElement>('#root_newKey-key')!;
+      await user.clear(keyInput1);
+      await user.type(keyInput1, 'first');
+      await user.tab();
 
       // Add second property and rename to "second"
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
-      const keyInput2 = node.querySelector('#root_newKey-key') as HTMLInputElement;
-      fireEvent.blur(keyInput2, { target: { value: 'second' } });
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
+      const keyInput2 = node.querySelector<HTMLInputElement>('#root_newKey-key')!;
+      await user.clear(keyInput2);
+      await user.type(keyInput2, 'second');
+      await user.tab();
 
       // Both properties should exist with correct values
       expect(node.querySelector('#root_first')).not.toBeNull();
       expect(node.querySelector('#root_second')).not.toBeNull();
 
       // Key inputs should show their actual property names, not carry over values
-      const firstKeyInput = node.querySelector('#root_first-key') as HTMLInputElement;
-      const secondKeyInput = node.querySelector('#root_second-key') as HTMLInputElement;
+      const firstKeyInput = node.querySelector<HTMLInputElement>('#root_first-key')!;
+      const secondKeyInput = node.querySelector<HTMLInputElement>('#root_second-key')!;
       expect(firstKeyInput.value).toBe('first');
       expect(secondKeyInput.value).toBe('second');
     });
 
-    it('should preserve value input in DOM when renaming to a duplicate key', () => {
+    it('should preserve value input in DOM when renaming to a duplicate key', async () => {
       const { node } = createFormComponent({
         schema,
         formData: { first: 1 },
       });
 
       // Add a new property
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       // Rename "newKey" to "first" (duplicate — will become "first-1")
-      const keyInput = node.querySelector('#root_newKey-key') as HTMLInputElement;
-      fireEvent.blur(keyInput, { target: { value: 'first' } });
+      const keyInput = node.querySelector<HTMLInputElement>('#root_newKey-key')!;
+      await user.clear(keyInput);
+      await user.type(keyInput, 'first');
+      await user.tab();
 
       // The value input for "first-1" should exist (component stayed mounted via stable key)
       const valueInput = node.querySelector('#root_first-1');
       expect(valueInput).not.toBeNull();
 
       // The key input should show the actual property name "first-1", not "first"
-      const renamedKeyInput = node.querySelector('#root_first-1-key') as HTMLInputElement;
+      const renamedKeyInput = node.querySelector<HTMLInputElement>('#root_first-1-key')!;
       expect(renamedKeyInput).not.toBeNull();
       expect(renamedKeyInput.value).toBe('first-1');
     });
@@ -1381,25 +1407,25 @@ describe('ObjectField', () => {
       expect(node.querySelector('.rjsf-object-property-expand button')).toBeNull();
     });
 
-    it('should add a new property when clicking the expand button', () => {
+    it('should add a new property when clicking the expand button', async () => {
       const { node, onChange } = createFormComponent({ schema });
 
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       expectToHaveBeenCalledWithFormData(onChange, { newKey: 'New Value' }, 'root');
     });
 
-    it("should add a new property with suffix when clicking the expand button and 'newKey' already exists", () => {
+    it("should add a new property with suffix when clicking the expand button and 'newKey' already exists", async () => {
       const { node, onChange } = createFormComponent({
         schema,
         formData: { newKey: 1 },
       });
 
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
       expectToHaveBeenCalledWithFormData(onChange, { newKey: 1, 'newKey-1': 'New Value' }, 'root');
     });
 
-    it('should add a property matching the additionalProperties schema', () => {
+    it('should add a property matching the additionalProperties schema', async () => {
       // Specify that additionalProperties must be an array of strings
       const additionalPropertiesArraySchema: RJSFSchema = {
         ...schema,
@@ -1415,12 +1441,12 @@ describe('ObjectField', () => {
         formData: {},
       });
 
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       expectToHaveBeenCalledWithFormData(onChange, { newKey: [] }, 'root');
     });
 
-    it('should add a string item if additionalProperties is true', () => {
+    it('should add a string item if additionalProperties is true', async () => {
       // Specify that additionalProperties is true
       const customSchema: RJSFSchema = {
         ...schema,
@@ -1431,12 +1457,12 @@ describe('ObjectField', () => {
         formData: {},
       });
 
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       expectToHaveBeenCalledWithFormData(onChange, { newKey: 'New Value' }, 'root');
     });
 
-    it("should add a new default item if default is provided in the additionalProperties' schema", () => {
+    it("should add a new default item if default is provided in the additionalProperties' schema", async () => {
       const customSchema: RJSFSchema = {
         ...schema,
         additionalProperties: {
@@ -1449,12 +1475,12 @@ describe('ObjectField', () => {
         formData: {},
       });
 
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       expectToHaveBeenCalledWithFormData(onChange, { newKey: 'default value' }, 'root');
     });
 
-    it('should add a new default item even if the schema of default value is invalid', () => {
+    it('should add a new default item even if the schema of default value is invalid', async () => {
       const customSchema: RJSFSchema = {
         ...schema,
         additionalProperties: {
@@ -1467,7 +1493,7 @@ describe('ObjectField', () => {
         formData: {},
       });
 
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       expectToHaveBeenCalledWithFormData(onChange, { newKey: 1 }, 'root');
     });
@@ -1504,7 +1530,7 @@ describe('ObjectField', () => {
       expectToHaveBeenCalledWithFormData(onChange, { defaultKey: 'defaultValue', someData: 'someValue' });
     });
 
-    it('should edit the specified default key without duplicating', () => {
+    it('should edit the specified default key without duplicating', async () => {
       const customSchema: RJSFSchema = {
         ...schema,
         default: {
@@ -1516,12 +1542,15 @@ describe('ObjectField', () => {
         formData: {},
       });
 
-      fireEvent.blur(node.querySelector('#root_defaultKey-key')!, { target: { value: 'newDefaultKey' } });
+      const defaultKeyInput = node.querySelector('#root_defaultKey-key')!;
+      await user.clear(defaultKeyInput);
+      await user.type(defaultKeyInput, 'newDefaultKey');
+      await user.tab();
 
       expectToHaveBeenCalledWithFormData(onChange, { newDefaultKey: 'defaultValue' }, 'root');
     });
 
-    it('should remove the specified default key/value input item', () => {
+    it('should remove the specified default key/value input item', async () => {
       const customSchema: RJSFSchema = {
         ...schema,
         default: {
@@ -1533,7 +1562,7 @@ describe('ObjectField', () => {
         formData: {},
       });
 
-      fireEvent.click(node.querySelector('.rjsf-object-property-remove')!);
+      await user.click(node.querySelector('.rjsf-object-property-remove')!);
 
       expectToHaveBeenCalledWithFormData(onChange, {}, 'root');
     });
@@ -1577,7 +1606,7 @@ describe('ObjectField', () => {
       });
     });
 
-    it('should remove nested additional property default key/value input', () => {
+    it('should remove nested additional property default key/value input', async () => {
       const customSchema: RJSFSchema = {
         ...schema,
         properties: {
@@ -1603,7 +1632,7 @@ describe('ObjectField', () => {
         formData: {},
       });
 
-      fireEvent.click(node.querySelector('.rjsf-object-property-remove')!);
+      await user.click(node.querySelector('.rjsf-object-property-remove')!);
 
       expectToHaveBeenCalledWithFormData(onChange, { nested: { bar: {} } }, 'root_nested_bar');
     });
@@ -1660,7 +1689,7 @@ describe('ObjectField', () => {
       expect(node.querySelector('.form-group > .btn-danger')).toBeNull();
     });
 
-    it('should have delete button if expand button has been clicked', () => {
+    it('should have delete button if expand button has been clicked', async () => {
       const { node } = createFormComponent({
         schema,
       });
@@ -1669,47 +1698,45 @@ describe('ObjectField', () => {
         node.querySelector('.form-group > .form-additional > .form-additional + .col-xs-2 .btn-danger'),
       ).toBeNull();
 
-      fireEvent.click(node.querySelector('.rjsf-object-property-expand button')!);
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       expect(node.querySelector('.form-group > .row > .form-additional + .col-xs-2 > .btn-danger')).not.toBeNull();
     });
 
-    it('delete button should delete key-value pair', () => {
+    it('delete button should delete key-value pair', async () => {
       const { node } = createFormComponent({
         schema,
         formData: { first: 1 },
       });
       expect(node.querySelector('#root_first-key')).toHaveValue('first');
-      fireEvent.click(node.querySelector('.form-group > .row > .form-additional + .col-xs-2 > .btn-danger')!);
+      await user.click(node.querySelector('.form-group > .row > .form-additional + .col-xs-2 > .btn-danger')!);
       expect(node.querySelector('#root_first-key')).not.toBeInTheDocument();
     });
 
-    it('delete button should delete correct pair', () => {
+    it('delete button should delete correct pair', async () => {
       const { node } = createFormComponent({
         schema,
         formData: { first: 1, second: 2, third: 3 },
       });
       const selector = '.form-group > .row > .form-additional + .col-xs-2 > .btn-danger';
       expect(node.querySelectorAll(selector)).toHaveLength(3);
-      fireEvent.click(node.querySelectorAll(selector)[1]);
+      await user.click(node.querySelectorAll(selector)[1]);
       expect(node.querySelector('#root_second-key')).not.toBeInTheDocument();
       expect(node.querySelectorAll(selector)).toHaveLength(2);
     });
 
-    it('deleting content of value input should not delete pair', () => {
+    it('deleting content of value input should not delete pair', async () => {
       const { node, onChange } = createFormComponent({
         schema,
         formData: { first: 1 },
       });
 
-      fireEvent.change(node.querySelector('#root_first')!, {
-        target: { value: '' },
-      });
+      await user.clear(node.querySelector('#root_first')!);
 
       expectToHaveBeenCalledWithFormData(onChange, { first: '' }, 'root_first');
     });
 
-    it('should change content of value input to boolean false', () => {
+    it('should change content of value input to boolean false', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           ...schema,
@@ -1718,14 +1745,12 @@ describe('ObjectField', () => {
         formData: { first: true },
       });
 
-      act(() => {
-        fireEvent.click(node.querySelector('#root_first')!);
-      });
+      await user.click(node.querySelector('#root_first')!);
 
       expectToHaveBeenCalledWithFormData(onChange, { first: false }, 'root_first');
     });
 
-    it('should change content of value input to number 0', () => {
+    it('should change content of value input to number 0', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           ...schema,
@@ -1734,24 +1759,19 @@ describe('ObjectField', () => {
         formData: { first: 1 },
       });
 
-      fireEvent.change(node.querySelector('#root_first')!, {
-        target: { value: 0 },
-      });
+      const input = node.querySelector<HTMLInputElement>('#root_first')!;
+      await user.type(input, '0', { initialSelectionStart: 0, initialSelectionEnd: input.value.length });
 
       expectToHaveBeenCalledWithFormData(onChange, { first: 0 }, 'root_first');
     });
 
-    it('should change content of value input to null', () => {
+    it('should change content of value input to null', async () => {
       const { node, onChange } = createFormComponent({
         schema,
         formData: { first: 'str' },
       });
 
-      act(() => {
-        fireEvent.change(node.querySelector('#root_first')!, {
-          target: { value: null },
-        });
-      });
+      await user.clear(node.querySelector('#root_first')!);
 
       expectToHaveBeenCalledWithFormData(onChange, { first: '' }, 'root_first');
     });

--- a/packages/core/test/StringField.test.tsx
+++ b/packages/core/test/StringField.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   parseDateString,
   toDateString,
@@ -59,6 +60,8 @@ export function TextWidgetTest(props: WidgetProps) {
   };
   return <TextWidget {...props} onChange={onChangeTest} />;
 }
+
+const user = userEvent.setup();
 
 describe('StringField', () => {
   const CustomWidget = () => <div id='custom' />;
@@ -188,23 +191,19 @@ describe('StringField', () => {
       expectToHaveBeenCalledWithFormData(onSubmit, undefined, true);
     });
 
-    it('should handle a change event', () => {
+    it('should handle a change event', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           type: 'string',
         },
       });
 
-      act(() => {
-        fireEvent.change(node.querySelector('input')!, {
-          target: { value: 'yo' },
-        });
-      });
+      await user.type(node.querySelector('input')!, 'yo');
 
       expectToHaveBeenCalledWithFormData(onChange, 'yo', 'root');
     });
 
-    it('should handle a blur event', () => {
+    it('should handle a blur event', async () => {
       const onBlur = jest.fn();
       const { node } = createFormComponent({
         schema: {
@@ -212,58 +211,52 @@ describe('StringField', () => {
         },
         onBlur,
       });
-      const input = node.querySelector('input');
-      fireEvent.blur(input!, {
-        target: { value: 'yo' },
-      });
+      const input = node.querySelector('input')!;
+      await user.type(input, 'yo');
+      await user.tab();
 
-      expect(onBlur).toHaveBeenLastCalledWith(input?.id, 'yo');
+      expect(onBlur).toHaveBeenLastCalledWith(input.id, 'yo');
     });
 
-    it('should handle a focus event', () => {
+    it('should handle a focus event', async () => {
       const onFocus = jest.fn();
       const { node } = createFormComponent({
         schema: {
           type: 'string',
         },
         onFocus,
+        formData: 'yo',
       });
-      const input = node.querySelector('input');
-      fireEvent.focus(input!, {
-        target: { value: 'yo' },
-      });
+      const input = node.querySelector('input')!;
+      await user.click(input);
 
-      expect(onFocus).toHaveBeenLastCalledWith(input?.id, 'yo');
+      expect(onFocus).toHaveBeenLastCalledWith(input.id, 'yo');
     });
 
-    it('should handle an empty string change event', () => {
+    it('should handle an empty string change event', async () => {
       const { node, onChange } = createFormComponent({
         schema: { type: 'string' },
         formData: 'x',
       });
 
-      fireEvent.change(node.querySelector('input')!, {
-        target: { value: '' },
-      });
+      await user.clear(node.querySelector('input')!);
 
       expectToHaveBeenCalledWithFormData(onChange, undefined, 'root');
     });
 
-    it('should handle an empty string change event with custom ui:emptyValue', () => {
+    it('should handle an empty string change event with custom ui:emptyValue', async () => {
       const { node, onChange } = createFormComponent({
         schema: { type: 'string' },
         uiSchema: { 'ui:emptyValue': 'default' },
         formData: 'x',
       });
 
-      fireEvent.change(node.querySelector('input')!, {
-        target: { value: '' },
-      });
+      await user.clear(node.querySelector('input')!);
 
       expectToHaveBeenCalledWithFormData(onChange, 'default', 'root');
     });
 
-    it('should handle an empty string change event with defaults set', () => {
+    it('should handle an empty string change event with defaults set', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           type: 'string',
@@ -271,9 +264,7 @@ describe('StringField', () => {
         },
       });
 
-      fireEvent.change(node.querySelector('input')!, {
-        target: { value: '' },
-      });
+      await user.clear(node.querySelector('input')!);
 
       expectToHaveBeenCalledWithFormData(onChange, undefined, 'root');
     });
@@ -342,7 +333,7 @@ describe('StringField', () => {
       expect(node.querySelectorAll('#root__error')).toHaveLength(0);
     });
 
-    it('raise an error and check if the error is displayed', () => {
+    it('raise an error and check if the error is displayed', async () => {
       const { node } = createFormComponent({
         schema: { type: 'string' },
         fields: {
@@ -351,9 +342,7 @@ describe('StringField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'hello' } });
-      });
+      await user.type(inputs[0] as HTMLElement, 'hello');
 
       const errorMessages = node.querySelectorAll('#root__error');
       expect(errorMessages).toHaveLength(1);
@@ -361,7 +350,7 @@ describe('StringField', () => {
       expect(errorMessageContent).toHaveTextContent('Value must be "test"');
     });
 
-    it('should not raise an error if value is correct', () => {
+    it('should not raise an error if value is correct', async () => {
       const { node } = createFormComponent({
         schema: { type: 'string' },
         fields: {
@@ -370,15 +359,13 @@ describe('StringField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'test' } });
-      });
+      await user.type(inputs[0] as HTMLElement, 'test');
 
       const errorMessages = node.querySelectorAll('#root__error');
       expect(errorMessages).toHaveLength(0);
     });
 
-    it('should clear an error if value is entered correctly', () => {
+    it('should clear an error if value is entered correctly', async () => {
       const { node } = createFormComponent({
         schema: { type: 'string' },
         fields: {
@@ -387,24 +374,21 @@ describe('StringField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'hello' } });
-      });
+      await user.type(inputs[0] as HTMLElement, 'hello');
 
       let errorMessages = node.querySelectorAll('#root__error');
       expect(errorMessages).toHaveLength(1);
       const errorMessageContent = node.querySelector('#root__error .text-danger');
       expect(errorMessageContent).toHaveTextContent('Value must be "test"');
 
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'test' } });
-      });
+      await user.clear(inputs[0] as HTMLElement);
+      await user.type(inputs[0] as HTMLElement, 'test');
 
       errorMessages = node.querySelectorAll('#root__error');
       expect(errorMessages).toHaveLength(0);
     });
 
-    it('raise an error and check if the error is displayed using custom text widget', () => {
+    it('raise an error and check if the error is displayed using custom text widget', async () => {
       const { node } = createFormComponent({
         schema: { type: 'string' },
         widgets: {
@@ -413,9 +397,7 @@ describe('StringField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'hello' } });
-      });
+      await user.type(inputs[0] as HTMLElement, 'hello');
 
       const errorMessages = node.querySelectorAll('#root__error');
       expect(errorMessages).toHaveLength(1);
@@ -423,7 +405,7 @@ describe('StringField', () => {
       expect(errorMessageContent).toHaveTextContent('Value must be "test"');
     });
 
-    it('should not raise an error if value is correct using custom text widget', () => {
+    it('should not raise an error if value is correct using custom text widget', async () => {
       const { node } = createFormComponent({
         schema: { type: 'string' },
         widgets: {
@@ -432,9 +414,7 @@ describe('StringField', () => {
       });
 
       const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
-      act(() => {
-        fireEvent.change(inputs[0], { target: { value: 'test' } });
-      });
+      await user.type(inputs[0] as HTMLElement, 'test');
 
       const errorMessages = node.querySelectorAll('#root__error');
       expect(errorMessages).toHaveLength(0);
@@ -516,70 +496,61 @@ describe('StringField', () => {
       expectToHaveBeenCalledWithFormData(onSubmit, 'bar', true);
     });
 
-    it('should reflect the change in the change event', () => {
+    it('should reflect the change in the change event', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           type: 'string',
           enum: ['foo', 'bar'],
         },
       });
-      act(() => {
-        fireEvent.change(node.querySelector('select')!, {
-          target: { value: 0 }, // use index
-        });
-      });
+      const $select = node.querySelector<HTMLSelectElement>('select')!;
+      const options = $select.querySelectorAll('option');
+      await user.selectOptions($select, options[1]); // skip blank, select 'foo' (enum[0])
       expectToHaveBeenCalledWithFormData(onChange, 'foo', 'root');
     });
 
-    it('should reflect undefined in change event if empty option selected', () => {
+    it('should reflect undefined in change event if empty option selected', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           type: 'string',
           enum: ['foo', 'bar'],
         },
       });
-
-      act(() => {
-        fireEvent.change(node.querySelector('select')!, {
-          target: { value: '' },
-        });
-      });
+      const $select = node.querySelector<HTMLSelectElement>('select')!;
+      const options = $select.querySelectorAll('option');
+      await user.selectOptions($select, options[1]); // select 'foo' first so blank becomes a real change
+      await user.selectOptions($select, options[0]); // select blank → undefined
 
       expectToHaveBeenCalledWithFormData(onChange, undefined, 'root');
     });
 
-    it('should reflect the change into the dom', () => {
+    it('should reflect the change into the dom', async () => {
       const { node } = createFormComponent({
         schema: {
           type: 'string',
           enum: ['foo', 'bar'],
         },
       });
+      const $select = node.querySelector<HTMLSelectElement>('select')!;
+      const options = $select.querySelectorAll('option');
+      await user.selectOptions($select, options[1]); // skip blank, select 'foo' (enum[0])
 
-      act(() => {
-        fireEvent.change(node.querySelector('select')!, {
-          target: { value: 0 }, // use index
-        });
-      });
-
-      expect(getSelectedOptionValue(node.querySelector('select')!)).toEqual('foo');
+      expect(getSelectedOptionValue($select)).toEqual('foo');
     });
 
-    it('should reflect undefined value into the dom as empty option', () => {
+    it('should reflect undefined value into the dom as empty option', async () => {
       const { node } = createFormComponent({
         schema: {
           type: 'string',
           enum: ['foo', 'bar'],
         },
       });
+      const $select = node.querySelector<HTMLSelectElement>('select')!;
+      const options = $select.querySelectorAll('option');
+      await user.selectOptions($select, options[1]); // select 'foo' first
+      await user.selectOptions($select, options[0]); // select blank
 
-      act(() => {
-        fireEvent.change(node.querySelector('select')!, {
-          target: { value: '' },
-        });
-      });
-
-      expect(getSelectedOptionValue(node.querySelector('select')!)).toEqual('');
+      expect(getSelectedOptionValue($select)).toEqual('');
     });
 
     it('should fill field with data', () => {
@@ -685,23 +656,19 @@ describe('StringField', () => {
   });
 
   describe('TextareaWidget', () => {
-    it('should handle an empty string change event', () => {
+    it('should handle an empty string change event', async () => {
       const { node, onChange } = createFormComponent({
         schema: { type: 'string' },
         uiSchema: { 'ui:widget': 'textarea' },
         formData: 'x',
       });
 
-      act(() => {
-        fireEvent.change(node.querySelector('textarea')!, {
-          target: { value: '' },
-        });
-      });
+      await user.clear(node.querySelector('textarea')!);
 
       expectToHaveBeenCalledWithFormData(onChange, undefined, 'root');
     });
 
-    it('should handle an empty string change event with custom ui:emptyValue', () => {
+    it('should handle an empty string change event with custom ui:emptyValue', async () => {
       const { node, onChange } = createFormComponent({
         schema: { type: 'string' },
         uiSchema: {
@@ -711,11 +678,7 @@ describe('StringField', () => {
         formData: 'x',
       });
 
-      act(() => {
-        fireEvent.change(node.querySelector('textarea')!, {
-          target: { value: '' },
-        });
-      });
+      await user.clear(node.querySelector('textarea')!);
 
       expectToHaveBeenCalledWithFormData(onChange, 'default', 'root');
     });
@@ -759,7 +722,7 @@ describe('StringField', () => {
       expectToHaveBeenCalledWithFormData(onSubmit, datetime, true);
     });
 
-    it('should reflect the change into the dom', () => {
+    it('should reflect the change into the dom', async () => {
       const { node } = createFormComponent({
         schema: {
           type: 'string',
@@ -771,13 +734,9 @@ describe('StringField', () => {
       // to @testing-library/react results in the event handler not being fired due to the `datetime-local` input type
       // not accepting the trailing Z in the string, thus we remove it via utcToLocal
       const newDatetime = utcToLocal(new Date().toJSON());
-      const dateNode = node.querySelector('[type=datetime-local]');
-
-      act(() => {
-        fireEvent.change(dateNode!, {
-          target: { value: newDatetime },
-        });
-      });
+      const dateNode = node.querySelector<HTMLInputElement>('[type=datetime-local]')!;
+      await user.click(dateNode);
+      await user.paste(newDatetime);
 
       expect(dateNode).toHaveValue(newDatetime);
     });
@@ -865,7 +824,7 @@ describe('StringField', () => {
       expectToHaveBeenCalledWithFormData(onSubmit, datetime, true);
     });
 
-    it('should reflect the change into the dom', () => {
+    it('should reflect the change into the dom', async () => {
       const { node } = createFormComponent({
         schema: {
           type: 'string',
@@ -875,15 +834,12 @@ describe('StringField', () => {
       });
 
       const newDatetime = '2012-12-12';
-
-      act(() => {
-        fireEvent.change(node.querySelector('[type=date]')!, {
-          target: { value: newDatetime },
-        });
-      });
+      const input = node.querySelector<HTMLInputElement>('[type=date]')!;
+      await user.click(input);
+      await user.paste(newDatetime);
 
       // XXX import and use conversion helper
-      expect(node.querySelector('[type=date]')).toHaveValue(newDatetime.slice(0, 10));
+      expect(input).toHaveValue(newDatetime.slice(0, 10));
     });
 
     it('should fill field with data', () => {
@@ -912,7 +868,7 @@ describe('StringField', () => {
       expect(node.querySelector('[type=date]')).toHaveAttribute('id', 'root');
     });
 
-    it('should accept a valid entered date', () => {
+    it('should accept a valid entered date', async () => {
       const { node, onError, onChange } = createFormComponent({
         schema: {
           type: 'string',
@@ -922,11 +878,9 @@ describe('StringField', () => {
         liveValidate: true,
       });
 
-      act(() => {
-        fireEvent.change(node.querySelector('[type=date]')!, {
-          target: { value: '2012-12-12' },
-        });
-      });
+      const input = node.querySelector<HTMLInputElement>('[type=date]')!;
+      await user.click(input);
+      await user.paste('2012-12-12');
 
       expect(onError).not.toHaveBeenCalled();
 
@@ -987,7 +941,7 @@ describe('StringField', () => {
       expectToHaveBeenCalledWithFormData(onSubmit, time, true);
     });
 
-    it('should reflect the change into the dom', () => {
+    it('should reflect the change into the dom', async () => {
       const { node } = createFormComponent({
         schema: {
           type: 'string',
@@ -996,14 +950,11 @@ describe('StringField', () => {
       });
 
       const newTime = '11:10';
+      const input = node.querySelector<HTMLInputElement>('[type=time]')!;
+      await user.click(input);
+      await user.paste(newTime);
 
-      act(() => {
-        fireEvent.change(node.querySelector('[type=time]')!, {
-          target: { value: newTime },
-        });
-      });
-
-      expect(node.querySelector('[type=time]')).toHaveValue(`${newTime}:00`);
+      expect(input).toHaveValue(`${newTime}:00`);
     });
 
     it('should fill field with data', () => {
@@ -1103,7 +1054,7 @@ describe('StringField', () => {
       expectToHaveBeenCalledWithFormData(onSubmit, datetime, true);
     });
 
-    it('should reflect the change into the dom', () => {
+    it('should reflect the change into the dom', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           type: 'string',
@@ -1112,26 +1063,23 @@ describe('StringField', () => {
         uiSchema,
       });
 
-      act(() => {
-        fireEvent.change(node.querySelector('#root_year')!, {
-          target: { value: 2012 - 1900 }, // convert year to index
-        });
-        fireEvent.change(node.querySelector('#root_month')!, {
-          target: { value: 9 }, // Month index
-        });
-        fireEvent.change(node.querySelector('#root_day')!, {
-          target: { value: 1 }, // Day index
-        });
-        fireEvent.change(node.querySelector('#root_hour')!, {
-          target: { value: 1 },
-        });
-        fireEvent.change(node.querySelector('#root_minute')!, {
-          target: { value: 2 },
-        });
-        fireEvent.change(node.querySelector('#root_second')!, {
-          target: { value: 3 },
-        });
-      });
+      const yearSelect = node.querySelector<HTMLSelectElement>('#root_year')!;
+      const monthSelect = node.querySelector<HTMLSelectElement>('#root_month')!;
+      const daySelect = node.querySelector<HTMLSelectElement>('#root_day')!;
+      const hourSelect = node.querySelector<HTMLSelectElement>('#root_hour')!;
+      const minuteSelect = node.querySelector<HTMLSelectElement>('#root_minute')!;
+      const secondSelect = node.querySelector<HTMLSelectElement>('#root_second')!;
+
+      await user.selectOptions(
+        yearSelect,
+        yearSelect.querySelector<HTMLOptionElement>(`option[value="${2012 - 1900}"]`)!,
+      );
+      await user.selectOptions(monthSelect, monthSelect.querySelector<HTMLOptionElement>('option[value="9"]')!);
+      await user.selectOptions(daySelect, daySelect.querySelector<HTMLOptionElement>('option[value="1"]')!);
+      await user.selectOptions(hourSelect, hourSelect.querySelector<HTMLOptionElement>('option[value="1"]')!);
+      await user.selectOptions(minuteSelect, minuteSelect.querySelector<HTMLOptionElement>('option[value="2"]')!);
+      await user.selectOptions(secondSelect, secondSelect.querySelector<HTMLOptionElement>('option[value="3"]')!);
+
       expectToHaveBeenCalledWithFormData(onChange, '2012-10-02T01:02:03.000Z', 'root');
     });
 
@@ -1229,7 +1177,7 @@ describe('StringField', () => {
         expect(buttonLabels).toEqual(['Now', 'Clear']);
       });
 
-      it('should set current date when pressing the Now button', () => {
+      it('should set current date when pressing the Now button', async () => {
         const { node, onChange } = createFormComponent({
           schema: {
             type: 'string',
@@ -1238,9 +1186,8 @@ describe('StringField', () => {
           uiSchema,
         });
 
-        act(() => {
-          fireEvent.click(node.querySelector('a.btn-now')!);
-        });
+        await user.click(node.querySelector('a.btn-now')!);
+
         const formValue = onChange.mock.lastCall[0].formData;
         // Test that the two DATETIMEs are within 5 seconds of each other.
         const now = new Date().getTime();
@@ -1248,7 +1195,7 @@ describe('StringField', () => {
         expect(timeDiff).toBeLessThanOrEqual(5000);
       });
 
-      it('should clear current date when pressing the Clear button', () => {
+      it('should clear current date when pressing the Clear button', async () => {
         const { node, onChange } = createFormComponent({
           schema: {
             type: 'string',
@@ -1257,10 +1204,8 @@ describe('StringField', () => {
           uiSchema,
         });
 
-        act(() => {
-          fireEvent.click(node.querySelector('a.btn-now')!);
-          fireEvent.click(node.querySelector('a.btn-clear')!);
-        });
+        await user.click(node.querySelector('a.btn-now')!);
+        await user.click(node.querySelector('a.btn-clear')!);
 
         expectToHaveBeenCalledWithFormData(onChange, undefined, 'root');
       });
@@ -1464,7 +1409,7 @@ describe('StringField', () => {
       expectToHaveBeenCalledWithFormData(onSubmit, datetime, true);
     });
 
-    it('should call the provided onChange function once all values are filled', () => {
+    it('should call the provided onChange function once all values are filled', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           type: 'string',
@@ -1473,21 +1418,21 @@ describe('StringField', () => {
         uiSchema,
       });
 
-      act(() => {
-        fireEvent.change(node.querySelector('#root_year')!, {
-          target: { value: 2012 - 1900 }, // convert year to index
-        });
-        fireEvent.change(node.querySelector('#root_month')!, {
-          target: { value: 9 }, // Month index
-        });
-        fireEvent.change(node.querySelector('#root_day')!, {
-          target: { value: 1 }, // Day index
-        });
-      });
+      const yearSelect = node.querySelector<HTMLSelectElement>('#root_year')!;
+      const monthSelect = node.querySelector<HTMLSelectElement>('#root_month')!;
+      const daySelect = node.querySelector<HTMLSelectElement>('#root_day')!;
+
+      await user.selectOptions(
+        yearSelect,
+        yearSelect.querySelector<HTMLOptionElement>(`option[value="${2012 - 1900}"]`)!,
+      );
+      await user.selectOptions(monthSelect, monthSelect.querySelector<HTMLOptionElement>('option[value="9"]')!);
+      await user.selectOptions(daySelect, daySelect.querySelector<HTMLOptionElement>('option[value="1"]')!);
+
       expectToHaveBeenCalledWithFormData(onChange, '2012-10-02', 'root');
     });
 
-    it('should reflect the change into the dom, even when not all values are filled', () => {
+    it('should reflect the change into the dom, even when not all values are filled', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           type: 'string',
@@ -1496,14 +1441,15 @@ describe('StringField', () => {
         uiSchema,
       });
 
-      act(() => {
-        fireEvent.change(node.querySelector('#root_year')!, {
-          target: { value: 2012 - 1900 }, // convert year to index
-        });
-        fireEvent.change(node.querySelector('#root_month')!, {
-          target: { value: 9 }, // Month index
-        });
-      });
+      const yearSelect = node.querySelector<HTMLSelectElement>('#root_year')!;
+      const monthSelect = node.querySelector<HTMLSelectElement>('#root_month')!;
+
+      await user.selectOptions(
+        yearSelect,
+        yearSelect.querySelector<HTMLOptionElement>(`option[value="${2012 - 1900}"]`)!,
+      );
+      await user.selectOptions(monthSelect, monthSelect.querySelector<HTMLOptionElement>('option[value="9"]')!);
+
       expect(getSelectedOptionValue(node.querySelector<HTMLSelectElement>('#root_year')!)).toEqual('2012');
       expect(getSelectedOptionValue(node.querySelector<HTMLSelectElement>('#root_month')!)).toEqual('10');
       expect(getSelectedOptionValue(node.querySelector<HTMLSelectElement>('#root_day')!)).toEqual('day');
@@ -1680,7 +1626,7 @@ describe('StringField', () => {
         expect(buttonLabels).toEqual(['Now', 'Clear']);
       });
 
-      it('should set current date when pressing the Now button', () => {
+      it('should set current date when pressing the Now button', async () => {
         const { node, onChange } = createFormComponent({
           schema: {
             type: 'string',
@@ -1689,16 +1635,14 @@ describe('StringField', () => {
           uiSchema,
         });
 
-        act(() => {
-          fireEvent.click(node.querySelector('a.btn-now')!);
-        });
+        await user.click(node.querySelector('a.btn-now')!);
 
         const expected = toDateString(parseDateString(new Date().toJSON()), false);
 
         expectToHaveBeenCalledWithFormData(onChange, expected, 'root');
       });
 
-      it('should clear current date when pressing the Clear button', () => {
+      it('should clear current date when pressing the Clear button', async () => {
         const { node, onChange } = createFormComponent({
           schema: {
             type: 'string',
@@ -1707,10 +1651,8 @@ describe('StringField', () => {
           uiSchema,
         });
 
-        act(() => {
-          fireEvent.click(node.querySelector('a.btn-now')!);
-          fireEvent.click(node.querySelector('a.btn-clear')!);
-        });
+        await user.click(node.querySelector('a.btn-now')!);
+        await user.click(node.querySelector('a.btn-clear')!);
 
         expectToHaveBeenCalledWithFormData(onChange, undefined, 'root');
       });
@@ -1785,7 +1727,7 @@ describe('StringField', () => {
       expectToHaveBeenCalledWithFormData(onSubmit, email, true);
     });
 
-    it('should reflect the change into the dom', () => {
+    it('should reflect the change into the dom', async () => {
       const { node } = createFormComponent({
         schema: {
           type: 'string',
@@ -1794,10 +1736,7 @@ describe('StringField', () => {
       });
 
       const newDatetime = new Date().toJSON();
-
-      fireEvent.change(node.querySelector('[type=email]')!, {
-        target: { value: newDatetime },
-      });
+      await user.type(node.querySelector('[type=email]')!, newDatetime);
 
       expect(node.querySelector('[type=email]')).toHaveValue(newDatetime);
     });
@@ -1827,7 +1766,7 @@ describe('StringField', () => {
       expect(node.querySelector('[type=email]')).toHaveAttribute('id', 'root');
     });
 
-    it('should reject an invalid entered email', () => {
+    it('should reject an invalid entered email', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           type: 'string',
@@ -1836,9 +1775,7 @@ describe('StringField', () => {
         liveValidate: true,
       });
 
-      fireEvent.change(node.querySelector('[type=email]')!, {
-        target: { value: 'invalid' },
-      });
+      await user.type(node.querySelector('[type=email]')!, 'invalid');
 
       expect(onChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -1925,7 +1862,7 @@ describe('StringField', () => {
       expectToHaveBeenCalledWithFormData(onSubmit, url, true);
     });
 
-    it('should reflect the change into the dom', () => {
+    it('should reflect the change into the dom', async () => {
       const { node } = createFormComponent({
         schema: {
           type: 'string',
@@ -1934,9 +1871,7 @@ describe('StringField', () => {
       });
 
       const newDatetime = new Date().toJSON();
-      fireEvent.change(node.querySelector('[type=url]')!, {
-        target: { value: newDatetime },
-      });
+      await user.type(node.querySelector('[type=url]')!, newDatetime);
 
       expect(node.querySelector('[type=url]')).toHaveValue(newDatetime);
     });
@@ -1967,7 +1902,7 @@ describe('StringField', () => {
       expect(node.querySelector('[type=url]')).toHaveAttribute('id', 'root');
     });
 
-    it('should reject an invalid entered url', () => {
+    it('should reject an invalid entered url', async () => {
       const { node, onChange } = createFormComponent({
         schema: {
           type: 'string',
@@ -1976,9 +1911,7 @@ describe('StringField', () => {
         liveValidate: true,
       });
 
-      fireEvent.change(node.querySelector('[type=url]')!, {
-        target: { value: 'invalid' },
-      });
+      await user.type(node.querySelector('[type=url]')!, 'invalid');
 
       expect(onChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -2055,6 +1988,8 @@ describe('StringField', () => {
 
       const newColor = '#654321';
 
+      // fireEvent.change is used instead of user.type() because jsdom enforces the HTML spec sanitization algorithm
+      // for color inputs, rejecting each intermediate value as an invalid string and resetting it to ''.
       act(() => {
         fireEvent.change(node.querySelector('[type=color]')!, {
           target: { value: newColor },
@@ -2088,44 +2023,6 @@ describe('StringField', () => {
 
       expect(node.querySelector('[type=color]')).toHaveAttribute('id', 'root');
     });
-
-    // This test no longer works with @testing-utils/react's fireEvent since the input field does not accept
-    // invalid data, unlike when `Simulate` was being used
-    //
-    // it('should reject an invalid entered color', () => {
-    //   const { node, onChange } = createFormComponent({
-    //     schema: {
-    //       type: 'string',
-    //       format: 'color',
-    //     },
-    //     uiSchema,
-    //     liveValidate: true,
-    //   });
-    //
-    //   act(() => {
-    //     fireEvent.change(node.querySelector('[type=color]')!, {
-    //       target: { value: 'invalid' },
-    //     });
-    //   });
-    //
-    //   expect(onChange).toHaveBeenLastCalledWith(
-    //     expect.objectContaining({
-    //       errorSchema: { __errors: ['must match format "color"'] },
-    //       errors: [
-    //         {
-    //           message: 'must match format "color"',
-    //           name: 'format',
-    //           params: { format: 'color' },
-    //           property: '',
-    //           schemaPath: '#/format',
-    //           stack: 'must match format "color"',
-    //           title: '',
-    //         },
-    //       ],
-    //     }),
-    //     'root',
-    //   );
-    // });
 
     it('should render customized ColorWidget', () => {
       const { node } = createFormComponent({
@@ -2177,13 +2074,7 @@ describe('StringField', () => {
         },
       });
 
-      await act(() => {
-        fireEvent.change(node.querySelector('[type=file]')!, {
-          target: {
-            files: [{ name: 'file1.txt', size: 1, type: 'type' }],
-          },
-        });
-      });
+      await user.upload(node.querySelector('[type=file]')!, new File([''], 'file1.txt', { type: 'text/plain' }));
 
       await new Promise(setImmediate);
 
@@ -2201,33 +2092,15 @@ describe('StringField', () => {
         },
       });
 
-      await act(() => {
-        fireEvent.change(node.querySelector('[type=file]')!, {
-          target: {
-            files: [{ name: 'file1.txt', size: 1, type: 'type' }],
-          },
-        });
-      });
+      await user.upload(node.querySelector('[type=file]')!, new File([''], 'file1.txt', { type: 'text/plain' }));
 
       await new Promise(setImmediate);
 
-      await act(() => {
-        fireEvent.change(node.querySelector('[type=file]')!, {
-          target: {
-            files: [{ name: 'file2.txt', size: 1, type: 'type' }],
-          },
-        });
-      });
+      await user.upload(node.querySelector('[type=file]')!, new File([''], 'file2.txt', { type: 'text/plain' }));
 
       await new Promise(setImmediate);
 
-      await act(() => {
-        fireEvent.change(node.querySelector('[type=file]')!, {
-          target: {
-            files: [{ name: 'file3.txt', size: 1, type: 'type' }],
-          },
-        });
-      });
+      await user.upload(node.querySelector('[type=file]')!, new File([''], 'file3.txt', { type: 'text/plain' }));
 
       await new Promise(setImmediate);
 
@@ -2252,13 +2125,7 @@ describe('StringField', () => {
         },
       });
 
-      await act(() => {
-        fireEvent.change(node.querySelector('[type=file]')!, {
-          target: {
-            files: [{ name: nonUriEncodedValue, size: 1, type: 'type' }],
-          },
-        });
-      });
+      await user.upload(node.querySelector('[type=file]')!, new File([''], nonUriEncodedValue, { type: 'text/plain' }));
       await new Promise(setImmediate);
 
       expectToHaveBeenCalledWithFormData(onChange, `data:text/plain;name=${uriEncodedValue};base64,x=`, 'root');
@@ -2341,7 +2208,7 @@ describe('StringField', () => {
       expect(download).toHaveTextContent(TranslatableString.PreviewLabel);
     });
 
-    it('should delete the file when delete button is pressed (single)', () => {
+    it('should delete the file when delete button is pressed (single)', async () => {
       const formData = 'data:text/plain;name=file1.txt;base64,x=';
       const { node, onChange } = createFormComponent({
         schema: {
@@ -2356,12 +2223,10 @@ describe('StringField', () => {
       expect(deleteButton).toBeInTheDocument();
 
       // Click the delete button
-      act(() => {
-        fireEvent.click(deleteButton!);
-      });
+      await user.click(deleteButton!);
       expectToHaveBeenCalledWithFormData(onChange, undefined, 'root');
     });
-    it('should delete the file when delete button is pressed (multi)', () => {
+    it('should delete the file when delete button is pressed (multi)', async () => {
       const formData = [
         'data:text/plain;name=file1.txt;base64,x=',
         'data:text/plain;name=file2.txt;base64,x=',
@@ -2385,9 +2250,7 @@ describe('StringField', () => {
       // Find the delete button and click it
       const deleteButton = file2.querySelector('button[title="Remove"]');
       expect(deleteButton).toBeInTheDocument();
-      act(() => {
-        fireEvent.click(deleteButton!);
-      });
+      await user.click(deleteButton!);
 
       // Check that the file is deleted
       expect(node.querySelectorAll('li')).toHaveLength(2);

--- a/packages/core/test/uiSchema.test.tsx
+++ b/packages/core/test/uiSchema.test.tsx
@@ -1,5 +1,6 @@
 import { CSSProperties } from 'react';
 import { render, fireEvent, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { GenericObjectType, RJSFSchema, UiSchema, Widget, WidgetProps } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 
@@ -7,6 +8,8 @@ import SelectWidget from '../src/components/widgets/SelectWidget';
 import RadioWidget from '../src/components/widgets/RadioWidget';
 import { createFormComponent, expectToHaveBeenCalledWithFormData, submitForm } from './testUtils';
 import Form from '../src';
+
+const user = userEvent.setup();
 
 describe('uiSchema', () => {
   let consoleWarnSpy: jest.SpyInstance;
@@ -909,7 +912,7 @@ describe('uiSchema', () => {
         expect(node.querySelector('textarea')).toHaveValue('a');
       });
 
-      it('should call onChange handler when text is updated', () => {
+      it('should call onChange handler when text is updated', async () => {
         const { node, onChange } = createFormComponent({
           schema,
           uiSchema,
@@ -918,13 +921,8 @@ describe('uiSchema', () => {
           },
         });
 
-        act(() => {
-          fireEvent.change(node.querySelector('textarea')!, {
-            target: {
-              value: 'b',
-            },
-          });
-        });
+        await user.clear(node.querySelector('textarea')!);
+        await user.type(node.querySelector('textarea')!, 'b');
 
         expectToHaveBeenCalledWithFormData(onChange, { foo: 'b' }, 'root_foo');
       });
@@ -962,7 +960,7 @@ describe('uiSchema', () => {
         expect(node.querySelector('[type=password]')).toHaveValue('a');
       });
 
-      it('should call onChange handler when text is updated is checked', () => {
+      it('should call onChange handler when text is updated is checked', async () => {
         const { node, onChange } = createFormComponent({
           schema,
           uiSchema,
@@ -971,13 +969,8 @@ describe('uiSchema', () => {
           },
         });
 
-        act(() => {
-          fireEvent.change(node.querySelector('[type=password]')!, {
-            target: {
-              value: 'b',
-            },
-          });
-        });
+        await user.clear(node.querySelector('[type=password]')!);
+        await user.type(node.querySelector('[type=password]')!, 'b');
 
         expectToHaveBeenCalledWithFormData(onChange, { foo: 'b' }, 'root_foo');
       });
@@ -1023,6 +1016,10 @@ describe('uiSchema', () => {
           },
         });
 
+        // fireEvent.change is used instead of user.paste() because jsdom does not process paste
+        // events on color inputs — they have no editable text field in the DOM model and ignore
+        // clipboard events entirely. user.type() also fails because jsdom's sanitization algorithm
+        // rejects each intermediate character as an invalid color string.
         act(() => {
           fireEvent.change(node.querySelector('[type=color]')!, {
             target: {
@@ -1112,7 +1109,7 @@ describe('uiSchema', () => {
         expect(node.querySelectorAll('[type=radio]')[1]).toBeChecked();
       });
 
-      it('should call onChange handler when value is updated', () => {
+      it('should call onChange handler when value is updated', async () => {
         const { node, onChange } = createFormComponent({
           schema,
           uiSchema,
@@ -1121,9 +1118,7 @@ describe('uiSchema', () => {
           },
         });
 
-        act(() => {
-          fireEvent.click(node.querySelectorAll('[type=radio]')[1]);
-        });
+        await user.click(node.querySelectorAll('[type=radio]')[1]);
 
         expectToHaveBeenCalledWithFormData(onChange, { foo: 'b' }, 'root_foo');
       });
@@ -1168,7 +1163,7 @@ describe('uiSchema', () => {
         expect(node.querySelector('[type=number]')).toHaveValue(3.14);
       });
 
-      it('should call onChange handler when value is updated', () => {
+      it('should call onChange handler when value is updated', async () => {
         const { node, onChange } = createFormComponent({
           schema,
           uiSchema,
@@ -1177,13 +1172,8 @@ describe('uiSchema', () => {
           },
         });
 
-        act(() => {
-          fireEvent.change(node.querySelector('[type=number]')!, {
-            target: {
-              value: '6.28',
-            },
-          });
-        });
+        await user.clear(node.querySelector('[type=number]')!);
+        await user.type(node.querySelector('[type=number]')!, '6.28');
 
         expectToHaveBeenCalledWithFormData(onChange, { foo: 6.28 }, 'root_foo');
       });
@@ -1261,6 +1251,8 @@ describe('uiSchema', () => {
           },
         });
 
+        // fireEvent.change is used instead of user.type() because jsdom does not process character
+        // input for range inputs — the slider value is controlled by pointer/arrow events, not text input.
         act(() => {
           fireEvent.change(node.querySelector('[type=range]')!, {
             target: {
@@ -1354,10 +1346,7 @@ describe('uiSchema', () => {
           },
         });
 
-        act(() => {
-          // Click on the radio button to change it
-          fireEvent.click(node.querySelectorAll('[type=radio]')[2]);
-        });
+        await user.click(node.querySelectorAll('[type=radio]')[2]);
 
         await waitFor(() => {
           expectToHaveBeenCalledWithFormData(onChange, { foo: 1.4142 }, 'root_foo');
@@ -1441,7 +1430,7 @@ describe('uiSchema', () => {
         expect(node.querySelector('[type=number]')).toHaveValue(3);
       });
 
-      it('should call onChange handler when value is updated', () => {
+      it('should call onChange handler when value is updated', async () => {
         const { node, onChange } = createFormComponent({
           schema,
           uiSchema,
@@ -1450,13 +1439,8 @@ describe('uiSchema', () => {
           },
         });
 
-        act(() => {
-          fireEvent.change(node.querySelector('[type=number]')!, {
-            target: {
-              value: '6',
-            },
-          });
-        });
+        await user.clear(node.querySelector('[type=number]')!);
+        await user.type(node.querySelector('[type=number]')!, '6');
 
         expectToHaveBeenCalledWithFormData(onChange, { foo: 6 }, 'root_foo');
       });
@@ -1496,6 +1480,8 @@ describe('uiSchema', () => {
           },
         });
 
+        // fireEvent.change is used instead of user.type() because jsdom does not process character
+        // input for range inputs — the slider value is controlled by pointer/arrow events, not text input.
         act(() => {
           fireEvent.change(node.querySelector('[type=range]')!, {
             target: {
@@ -1543,7 +1529,7 @@ describe('uiSchema', () => {
         expect(node.querySelectorAll('[type=radio]')[1]).toBeChecked();
       });
 
-      it('should call onChange handler when value is updated', () => {
+      it('should call onChange handler when value is updated', async () => {
         const { node, onChange } = createFormComponent({
           schema,
           uiSchema,
@@ -1552,9 +1538,7 @@ describe('uiSchema', () => {
           },
         });
 
-        act(() => {
-          fireEvent.click(node.querySelectorAll('[type=radio]')[1]);
-        });
+        await user.click(node.querySelectorAll('[type=radio]')[1]);
 
         expectToHaveBeenCalledWithFormData(onChange, { foo: 2 }, 'root_foo');
       });
@@ -1648,7 +1632,7 @@ describe('uiSchema', () => {
         expect(node.querySelectorAll('[type=radio]')[1]).toBeChecked();
       });
 
-      it('should call onChange handler when false is checked', () => {
+      it('should call onChange handler when false is checked', async () => {
         const { node, onChange } = createFormComponent({
           schema,
           uiSchema,
@@ -1657,14 +1641,12 @@ describe('uiSchema', () => {
           },
         });
 
-        act(() => {
-          fireEvent.click(node.querySelectorAll('[type=radio]')[1]);
-        });
+        await user.click(node.querySelectorAll('[type=radio]')[1]);
 
         expectToHaveBeenCalledWithFormData(onChange, { foo: false }, 'root_foo');
       });
 
-      it('should call onChange handler when true is checked', () => {
+      it('should call onChange handler when true is checked', async () => {
         const { node, onChange } = createFormComponent({
           schema,
           uiSchema,
@@ -1673,9 +1655,7 @@ describe('uiSchema', () => {
           },
         });
 
-        act(() => {
-          fireEvent.click(node.querySelectorAll('[type=radio]')[0]);
-        });
+        await user.click(node.querySelectorAll('[type=radio]')[0]);
 
         expectToHaveBeenCalledWithFormData(onChange, { foo: true }, 'root_foo');
       });
@@ -1701,7 +1681,7 @@ describe('uiSchema', () => {
         expect(node.querySelectorAll('option')[2]).toHaveTextContent('No');
       });
 
-      it('should call onChange handler when true is selected', () => {
+      it('should call onChange handler when true is selected', async () => {
         const { node, onChange } = createFormComponent({
           schema,
           uiSchema,
@@ -1710,19 +1690,13 @@ describe('uiSchema', () => {
           },
         });
 
-        act(() => {
-          fireEvent.change(node.querySelector('select')!, {
-            // DOM option change events always return strings
-            target: {
-              value: 0, // use index
-            },
-          });
-        });
+        const $select = node.querySelector<HTMLSelectElement>('select')!;
+        await user.selectOptions($select, $select.querySelectorAll('option')[1]); // 'Yes' → true
 
         expectToHaveBeenCalledWithFormData(onChange, { foo: true }, 'root_foo');
       });
 
-      it('should call onChange handler when false is selected', () => {
+      it('should call onChange handler when false is selected', async () => {
         const { node, onChange } = createFormComponent({
           schema,
           uiSchema,
@@ -1731,13 +1705,8 @@ describe('uiSchema', () => {
           },
         });
 
-        act(() => {
-          fireEvent.change(node.querySelector('select')!, {
-            target: {
-              value: 1, // use index
-            },
-          });
-        });
+        const $select = node.querySelector<HTMLSelectElement>('select')!;
+        await user.selectOptions($select, $select.querySelectorAll('option')[2]); // 'No' → false
 
         expectToHaveBeenCalledWithFormData(onChange, { foo: false }, 'root_foo');
       });

--- a/packages/core/test/validate.test.tsx
+++ b/packages/core/test/validate.test.tsx
@@ -1,9 +1,11 @@
-import { fireEvent, act } from '@testing-library/react';
 import { ErrorListProps, FormValidation, GenericObjectType, RJSFSchema } from '@rjsf/utils';
 import { customizeValidator as customizeV8Validator } from '@rjsf/validator-ajv8';
+import userEvent from '@testing-library/user-event';
 
 import { FormProps } from '../src';
 import { createFormComponent, submitForm } from './testUtils';
+
+const user = userEvent.setup();
 
 describe('Validation', () => {
   describe('Form integration, v8 validator', () => {
@@ -123,7 +125,7 @@ describe('Validation', () => {
         expect(onError).toHaveBeenLastCalledWith([{ property: '.', message: 'Invalid', stack: '. Invalid' }]);
       });
 
-      it('should live validate a simple string value when liveValidate is set to true', () => {
+      it('should live validate a simple string value when liveValidate is set to true', async () => {
         const schema: RJSFSchema = { type: 'string' };
         const formData = 'a';
 
@@ -141,11 +143,9 @@ describe('Validation', () => {
           liveValidate: true,
         });
 
-        act(() => {
-          fireEvent.change(node.querySelector('input')!, {
-            target: { value: '1234' },
-          });
-        });
+        const input = node.querySelector('input')!;
+        await user.clear(input);
+        await user.type(input, '1234');
 
         expect(onChange).toHaveBeenLastCalledWith(
           expect.objectContaining({
@@ -467,7 +467,7 @@ describe('Validation', () => {
         onError = withMetaSchema.onError;
         submitForm(node);
       });
-      it('should be used to validate schema', () => {
+      it('should be used to validate schema', async () => {
         expect(node.querySelectorAll('.errors li')).toHaveLength(1);
         expect(onError).toHaveBeenLastCalledWith([
           {
@@ -482,11 +482,9 @@ describe('Validation', () => {
         ]);
         onError.mockClear();
 
-        act(() => {
-          fireEvent.change(node.querySelector('input')!, {
-            target: { value: '1234' },
-          });
-        });
+        const input = node.querySelector('input')!;
+        await user.clear(input);
+        await user.type(input, '1234');
         expect(node.querySelectorAll('.errors li')).toHaveLength(0);
         expect(onError).not.toHaveBeenCalled();
       });


### PR DESCRIPTION
### Reasons for making this change

Refactored `core` tests to eliminate (as much as possible) the use of `fireEvent()` by replacing them with React Testing Library async calls
- Updated the tests for `ArrayField`, `ArrayFieldTemplate`, `BooleanField`, `NumberField`, `ObjectField`, `StringField` to replace `fireEvent()` where possible
- Updated the `uiSchema.test.tsx` and `validate.test.tsx` to replace `fireEvent()` where possible
- Removed some unnecessary `console.log()` calls in some tests, including `Form`

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
