### PR TITLE
Chore: Improve submitForm() to click button if available

### DIFF
--- a/packages/core/test/ArrayField.test.tsx
+++ b/packages/core/test/ArrayField.test.tsx
@@ -404,7 +404,7 @@ describe('ArrayField', () => {
       expect(item).toHaveAttribute('data-has-parent-uischema', 'true');
     });
 
-    it('should pass rawErrors down to custom array field templates', () => {
+    it('should pass rawErrors down to custom array field templates', async () => {
       const schema: RJSFSchema = {
         type: 'array',
         title: 'my list',
@@ -423,7 +423,7 @@ describe('ArrayField', () => {
       });
 
       // trigger the errors by submitting the form
-      submitForm(node);
+      await submitForm(node, user);
 
       const matches = node.querySelectorAll('#custom');
       expect(matches).toHaveLength(1);
@@ -830,7 +830,7 @@ describe('ArrayField', () => {
       });
 
       try {
-        submitForm(node);
+        await submitForm(node, user);
       } catch {
         // Silencing error thrown as failure is expected here
       }
@@ -937,7 +937,10 @@ describe('ArrayField', () => {
         'root_1',
       );
 
-      submitForm(node);
+      // forceFireEvent=true: clicking the submit button focuses it, blurring the
+      // currently focused field and firing onChange which may mutate formData before
+      // the submit handler runs. fireEvent.submit bypasses that side-effect chain.
+      await submitForm(node, user, true);
       expect(onError).toHaveBeenLastCalledWith(
         expect.arrayContaining([
           {
@@ -1100,7 +1103,7 @@ describe('ArrayField', () => {
       expect(inputs[3]).toHaveValue('Unknown');
     });
 
-    it('should not add minItems extra formData entries when schema item is a multiselect', () => {
+    it('should not add minItems extra formData entries when schema item is a multiselect', async () => {
       const schema: RJSFSchema = {
         type: 'object',
         properties: {
@@ -1128,7 +1131,7 @@ describe('ArrayField', () => {
         liveValidate: true,
         noValidate: true,
       });
-      submitForm(form.node);
+      await submitForm(form.node, user);
 
       expectToHaveBeenCalledWithFormData(form.onSubmit, { multipleChoicesList: [] }, true);
 
@@ -1139,7 +1142,7 @@ describe('ArrayField', () => {
         liveValidate: true,
         noValidate: false,
       });
-      submitForm(form.node);
+      await submitForm(form.node, user);
 
       expect(form.onError).toHaveBeenLastCalledWith(
         expect.arrayContaining([
@@ -1276,7 +1279,7 @@ describe('ArrayField', () => {
         expect(node.querySelector('select')).toHaveAttribute('id', 'root');
       });
 
-      it('should pass rawErrors down to custom widgets', () => {
+      it('should pass rawErrors down to custom widgets', async () => {
         const { node } = createFormComponent({
           schema,
           widgets: {
@@ -1286,7 +1289,7 @@ describe('ArrayField', () => {
           liveValidate: true,
         });
         // trigger the errors by submitting the form since initial render no longer shows them
-        submitForm(node);
+        await submitForm(node, user);
 
         const matches = node.querySelectorAll('#custom');
         expect(matches).toHaveLength(1);
@@ -1443,7 +1446,7 @@ describe('ArrayField', () => {
         expect(node.querySelectorAll('.checkbox-inline')).toHaveLength(3);
       });
 
-      it('should pass rawErrors down to custom widgets', () => {
+      it('should pass rawErrors down to custom widgets', async () => {
         const schema: RJSFSchema = {
           type: 'array',
           title: 'My field',
@@ -1466,7 +1469,7 @@ describe('ArrayField', () => {
         });
 
         // trigger the errors by submitting the form since initial render no longer shows them
-        submitForm(node);
+        await submitForm(node, user);
 
         const matches = node.querySelectorAll('#custom');
         expect(matches).toHaveLength(1);
@@ -1606,7 +1609,7 @@ describe('ArrayField', () => {
       expect(node.querySelector('input[type=file]')).toHaveAttribute('accept', '.pdf');
     });
 
-    it('should pass rawErrors down to custom widgets', () => {
+    it('should pass rawErrors down to custom widgets', async () => {
       const schema: RJSFSchema = {
         type: 'array',
         title: 'My field',
@@ -1627,7 +1630,7 @@ describe('ArrayField', () => {
       });
 
       // trigger the errors by submitting the form since initial render no longer shows them
-      submitForm(node);
+      await submitForm(node, user);
 
       const matches = node.querySelectorAll('#custom');
       expect(matches).toHaveLength(1);
@@ -1668,7 +1671,7 @@ describe('ArrayField', () => {
       expect(node.querySelectorAll('fieldset fieldset')).toHaveLength(1);
     });
 
-    it('should pass rawErrors down to every level of custom widgets', () => {
+    it('should pass rawErrors down to every level of custom widgets', async () => {
       const CustomItem = (props: FieldProps) => <div id='custom-item'>{props.children}</div>;
       const CustomTemplate = (props: ArrayFieldTemplateProps) => {
         return (
@@ -1701,7 +1704,7 @@ describe('ArrayField', () => {
       });
 
       // trigger the errors by submitting the form since initial render no longer shows them
-      submitForm(node);
+      await submitForm(node, user);
 
       const matches = node.querySelectorAll('#custom-error');
       expect(matches).toHaveLength(2);
@@ -1919,7 +1922,7 @@ describe('ArrayField', () => {
       expect(node.querySelectorAll('textarea')).toHaveLength(2);
     });
 
-    it('[fixed] should silently handle additional formData not covered by fixed array', () => {
+    it('[fixed] should silently handle additional formData not covered by fixed array', async () => {
       const { node, onSubmit } = createFormComponent({
         schema: {
           type: 'array',
@@ -1935,7 +1938,7 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar', 'baz'],
       });
       expect(node.querySelectorAll('input')).toHaveLength(2);
-      submitForm(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, ['foo', 'bar', 'baz'], true);
     });
@@ -2683,7 +2686,7 @@ describe('ArrayField', () => {
       return errors;
     }
 
-    it('should render nested error decorated input widgets with the expected ids', () => {
+    it('should render nested error decorated input widgets with the expected ids', async () => {
       const { node } = createFormComponent({
         schema: complexSchema,
         formData: {
@@ -2692,13 +2695,13 @@ describe('ArrayField', () => {
         customValidate,
       });
 
-      submitForm(node);
+      await submitForm(node, user);
 
       const inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputs[0]).toHaveAttribute('id', 'root_foo_0_bar');
       expect(inputs[1]).toHaveAttribute('id', 'root_foo_1_bar');
     });
-    it('must NOT render nested error decorated input widgets', () => {
+    it('must NOT render nested error decorated input widgets', async () => {
       const { node } = createFormComponent({
         schema: complexSchema,
         uiSchema: {
@@ -2710,7 +2713,7 @@ describe('ArrayField', () => {
         customValidate,
         showErrorList: false,
       });
-      submitForm(node);
+      await submitForm(node, user);
 
       const inputsNoError = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputsNoError).toHaveLength(0);
@@ -2831,7 +2834,10 @@ describe('ArrayField', () => {
         templates,
       });
 
-      submitForm(node);
+      // forceFireEvent=true: seeds errorSchema in form state via fireEvent.submit to avoid
+      // user.click(button) focusing the button, blurring a field, and firing onChange which
+      // would mutate formData before the submit runs.
+      await submitForm(node, user, true);
 
       const button = node.querySelector('[title="move-up"]');
 
@@ -2860,7 +2866,10 @@ describe('ArrayField', () => {
         templates,
       });
 
-      submitForm(node);
+      // forceFireEvent=true: seeds errorSchema in form state via fireEvent.submit to avoid
+      // user.click(button) focusing the button, blurring a field, and firing onChange which
+      // would mutate formData before the submit runs.
+      await submitForm(node, user, true);
 
       const button = node.querySelectorAll('[title="remove"]')[1];
 
@@ -2889,7 +2898,10 @@ describe('ArrayField', () => {
         templates,
       });
 
-      submitForm(node);
+      // forceFireEvent=true: seeds errorSchema in form state via fireEvent.submit to avoid
+      // user.click(button) focusing the button, blurring a field, and firing onChange which
+      // would mutate formData before the submit runs.
+      await submitForm(node, user, true);
 
       const button = node.querySelector('[title="remove"]');
 
@@ -2912,7 +2924,10 @@ describe('ArrayField', () => {
         templates,
       });
 
-      submitForm(node);
+      // forceFireEvent=true: seeds errorSchema in form state via fireEvent.submit to avoid
+      // user.click(button) focusing the button, blurring a field, and firing onChange which
+      // would mutate formData before the submit runs.
+      await submitForm(node, user, true);
 
       const button = node.querySelector('[title="insert"]');
 
@@ -2941,7 +2956,10 @@ describe('ArrayField', () => {
         templates,
       });
 
-      submitForm(node);
+      // forceFireEvent=true: seeds errorSchema in form state via fireEvent.submit to avoid
+      // user.click(button) focusing the button, blurring a field, and firing onChange which
+      // would mutate formData before the submit runs.
+      await submitForm(node, user, true);
 
       const button = node.querySelector('[title="insert"]');
 
@@ -2971,7 +2989,10 @@ describe('ArrayField', () => {
         templates,
       });
 
-      submitForm(node);
+      // forceFireEvent=true: seeds errorSchema in form state via fireEvent.submit to avoid
+      // user.click(button) focusing the button, blurring a field, and firing onChange which
+      // would mutate formData before the submit runs.
+      await submitForm(node, user, true);
 
       const button = node.querySelector('[title="copy"]');
 
@@ -3001,7 +3022,10 @@ describe('ArrayField', () => {
         templates,
       });
 
-      submitForm(node);
+      // forceFireEvent=true: seeds errorSchema in form state via fireEvent.submit to avoid
+      // user.click(button) focusing the button, blurring a field, and firing onChange which
+      // would mutate formData before the submit runs.
+      await submitForm(node, user, true);
 
       const button = node.querySelector('[title="copy"]');
 
@@ -3023,15 +3047,17 @@ describe('ArrayField', () => {
       );
     });
 
-    it('Check that when formData changes, the form should re-validate', () => {
+    it('Check that when formData changes, the form should re-validate', async () => {
       const { node, rerender } = createFormComponent({
         schema,
         formData: [{}],
         liveValidate: true,
       });
 
-      // trigger the errors by submitting the form since initial render no longer shows them
-      submitForm(node);
+      // trigger the errors by submitting the form since initial render no longer shows them.
+      // forceFireEvent=true: clicking the submit button focuses it, blurring any focused
+      // field and firing onChange, which can mutate formData before the submit runs.
+      await submitForm(node, user, true);
 
       const errorMessages = node.querySelectorAll('#root_0_text__error');
       expect(errorMessages).toHaveLength(1);
@@ -3627,7 +3653,7 @@ describe('ArrayField', () => {
 
       const ageInput = node.querySelector<HTMLInputElement>('#root_arrayList_0_age')!;
       await user.clear(ageInput);
-      submitForm(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, { arrayList: [{ name: 'John' }] }, true);
     });

--- a/packages/core/test/BooleanField.test.tsx
+++ b/packages/core/test/BooleanField.test.tsx
@@ -231,16 +231,16 @@ describe('BooleanField', () => {
     expect(node.querySelector('.rjsf-field input')).toHaveAttribute('checked', '');
   });
 
-  it('formData should default to undefined', () => {
+  it('formData should default to undefined', async () => {
     const { node, onSubmit } = createFormComponent({
       schema: { type: 'boolean' },
       noValidate: true,
     });
-    submitForm(node);
+    await submitForm(node, user);
     expectToHaveBeenCalledWithFormData(onSubmit, undefined, true);
   });
 
-  it('should focus on required radio missing data when focusOnFirstField and shows error', () => {
+  it('should focus on required radio missing data when focusOnFirstField and shows error', async () => {
     const { node, onError } = createFormComponent({
       schema: {
         type: 'object',
@@ -264,7 +264,8 @@ describe('BooleanField', () => {
     // a getter-only, making simple assignment throw in strict mode
     Object.defineProperty(inputs[0], 'focus', { value: focusSpys[0], writable: true, configurable: true });
     Object.defineProperty(inputs[1], 'focus', { value: focusSpys[1], writable: true, configurable: true });
-    submitForm(node);
+    // The focus overrides don't work unless fire event happens
+    await submitForm(node, user, true);
     expect(onError).toHaveBeenLastCalledWith([
       expect.objectContaining({ message: "must have required property 'bool'" }),
     ]);
@@ -274,7 +275,7 @@ describe('BooleanField', () => {
     expect(errorInputs).toHaveLength(2);
   });
 
-  it('should focus on required radio missing data when focusOnFirstField and hides error', () => {
+  it('should focus on required radio missing data when focusOnFirstField and hides error', async () => {
     const { node, onError } = createFormComponent({
       schema: {
         type: 'object',
@@ -298,7 +299,8 @@ describe('BooleanField', () => {
     // a getter-only, making simple assignment throw in strict mode
     Object.defineProperty(inputs[0], 'focus', { value: focusSpys[0], writable: true, configurable: true });
     Object.defineProperty(inputs[1], 'focus', { value: focusSpys[1], writable: true, configurable: true });
-    submitForm(node);
+    // The focus overrides don't work unless fire event happens
+    await submitForm(node, user, true);
     expect(onError).toHaveBeenLastCalledWith([
       expect.objectContaining({ message: "must have required property 'bool'" }),
     ]);

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -926,18 +926,18 @@ describeRepeated('Form common', (createFormComponent) => {
       },
     };
 
-    it('should propagate deeply nested defaults to submit handler', () => {
+    it('should propagate deeply nested defaults to submit handler', async () => {
       const { node, onSubmit } = createFormComponent({ schema });
 
       fireEvent.click(node.querySelector('.rjsf-array-item-add button')!);
-      fireEvent.submit(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, { object: { array: [{ bool: true }] } }, true);
     });
   });
 
   describe('Defaults additionalProperties propagation', () => {
-    it('should submit string string map defaults', () => {
+    it('should submit string string map defaults', async () => {
       const schema: RJSFSchema = {
         type: 'object',
         additionalProperties: {
@@ -949,12 +949,12 @@ describeRepeated('Form common', (createFormComponent) => {
       };
 
       const { node, onSubmit } = createFormComponent({ schema });
-      fireEvent.submit(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, { foo: 'bar' }, true);
     });
 
-    it('should submit a combination of properties and additional properties defaults', () => {
+    it('should submit a combination of properties and additional properties defaults', async () => {
       const schema: RJSFSchema = {
         type: 'object',
         properties: {
@@ -972,12 +972,12 @@ describeRepeated('Form common', (createFormComponent) => {
       };
 
       const { node, onSubmit } = createFormComponent({ schema });
-      fireEvent.submit(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, { x: 'x default value', y: 'y default value' }, true);
     });
 
-    it('should submit a properties and additional properties defaults when properties default is nested', () => {
+    it('should submit a properties and additional properties defaults when properties default is nested', async () => {
       const schema: RJSFSchema = {
         type: 'object',
         properties: {
@@ -995,7 +995,7 @@ describeRepeated('Form common', (createFormComponent) => {
       };
 
       const { node, onSubmit } = createFormComponent({ schema });
-      fireEvent.submit(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, { x: 'x default value', y: 'y default value' }, true);
     });
@@ -1028,9 +1028,7 @@ describeRepeated('Form common', (createFormComponent) => {
       };
 
       const { node, onSubmit } = createFormComponent({ schema });
-      await act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, { x: { y: { z: 'x.y.z default value' } } }, true);
     });
@@ -1054,14 +1052,12 @@ describeRepeated('Form common', (createFormComponent) => {
       };
 
       const { node, onSubmit } = createFormComponent({ schema });
-      await act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, { x: { y: 'x.y default value' } }, true);
     });
 
-    it('should submit defaults when additionalProperties is a boolean value', () => {
+    it('should submit defaults when additionalProperties is a boolean value', async () => {
       const schema: RJSFSchema = {
         type: 'object',
         additionalProperties: true,
@@ -1071,12 +1067,12 @@ describeRepeated('Form common', (createFormComponent) => {
       };
 
       const { node, onSubmit } = createFormComponent({ schema });
-      fireEvent.submit(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, { foo: 'bar' }, true);
     });
 
-    it('should NOT submit default values when additionalProperties is false', () => {
+    it('should NOT submit default values when additionalProperties is false', async () => {
       const schema: RJSFSchema = {
         type: 'object',
         properties: {
@@ -1092,7 +1088,7 @@ describeRepeated('Form common', (createFormComponent) => {
       };
 
       const { node, onSubmit } = createFormComponent({ schema });
-      fireEvent.submit(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, { foo: "I'm the only one" }, true);
     });
@@ -1109,16 +1105,13 @@ describeRepeated('Form common', (createFormComponent) => {
       const formData = {
         foo: 'bar',
       };
-      const event = { type: 'submit' };
       const { node, onSubmit } = createFormComponent({
         ref: createRef(),
         schema,
         formData,
       });
 
-      await act(() => {
-        fireEvent.submit(node, event);
-      });
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, formData, true);
     });
 
@@ -1141,9 +1134,7 @@ describeRepeated('Form common', (createFormComponent) => {
         formData,
       });
 
-      await act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       expect(onSubmit).not.toHaveBeenCalled();
       expect(onError).toHaveBeenCalled();
@@ -1831,7 +1822,7 @@ describeRepeated('Form common', (createFormComponent) => {
   });
 
   describe('Error handler', () => {
-    it('should call provided error handler on validation errors', () => {
+    it('should call provided error handler on validation errors', async () => {
       const schema: RJSFSchema = {
         type: 'object',
         properties: {
@@ -1846,7 +1837,7 @@ describeRepeated('Form common', (createFormComponent) => {
       };
       const { node, onError } = createFormComponent({ schema, formData });
 
-      fireEvent.submit(node);
+      await submitForm(node, user);
 
       expect(onError).toHaveBeenCalledTimes(1);
     });
@@ -1884,10 +1875,13 @@ describeRepeated('Form common', (createFormComponent) => {
       },
       required: ['shipping_address'],
     };
-    it('Errors when shipping address is not filled out, billing address is not needed', () => {
+    it('Errors when shipping address is not filled out, billing address is not needed', async () => {
       const { node, onChange, onError } = createFormComponent({ schema });
       expectToHaveBeenCalledWithFormData(onChange, { shipping_address: {} });
-      submitForm(node);
+      // forceFireEvent=true: clicking the submit button focuses it, blurring the
+      // currently focused field and firing onChange which may mutate formData before
+      // the submit handler runs. fireEvent.submit bypasses that side-effect chain.
+      await submitForm(node, user, true);
       expect(onError).toHaveBeenLastCalledWith([
         {
           message: "must have required property 'street_address'",
@@ -1918,7 +1912,7 @@ describeRepeated('Form common', (createFormComponent) => {
         },
       ]);
     });
-    it('Submits when shipping address is filled out, billing address is not needed', () => {
+    it('Submits when shipping address is filled out, billing address is not needed', async () => {
       const { node, onSubmit } = createFormComponent({
         schema,
         formData: {
@@ -1929,7 +1923,10 @@ describeRepeated('Form common', (createFormComponent) => {
           },
         },
       });
-      submitForm(node);
+      // forceFireEvent=true: clicking the submit button focuses it, blurring the
+      // currently focused field and firing onChange which may mutate formData before
+      // the submit handler runs. fireEvent.submit bypasses that side-effect chain.
+      await submitForm(node, user, true);
       expectToHaveBeenCalledWithFormData(
         onSubmit,
         {
@@ -1956,7 +1953,7 @@ describeRepeated('Form common', (createFormComponent) => {
         },
       },
     };
-    it('Errors when minItems is set, field is required, and minimum number of items are not present with IgnoreMinItemsUnlessRequired flag set', () => {
+    it('Errors when minItems is set, field is required, and minimum number of items are not present with IgnoreMinItemsUnlessRequired flag set', async () => {
       const { node, onError } = createFormComponent({
         schema: { ...schema, required: ['albums'] },
         formData: {
@@ -1964,7 +1961,7 @@ describeRepeated('Form common', (createFormComponent) => {
         },
         experimental_defaultFormStateBehavior: { arrayMinItems: { populate: 'requiredOnly' } },
       });
-      submitForm(node);
+      await submitForm(node, user);
       expect(onError).toHaveBeenLastCalledWith([
         {
           message: 'must NOT have fewer than 3 items',
@@ -1977,13 +1974,13 @@ describeRepeated('Form common', (createFormComponent) => {
         },
       ]);
     });
-    it('Submits when minItems is set, field is not required, and no items are present with IgnoreMinItemsUnlessRequired flag set', () => {
+    it('Submits when minItems is set, field is not required, and no items are present with IgnoreMinItemsUnlessRequired flag set', async () => {
       const { node, onSubmit } = createFormComponent({
         schema,
         formData: {},
         experimental_defaultFormStateBehavior: { arrayMinItems: { populate: 'requiredOnly' } },
       });
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, {}, true);
     });
   });
@@ -2145,7 +2142,7 @@ describeRepeated('Form common', (createFormComponent) => {
           onSubmit,
           formData: 'yo',
         });
-        await act(() => submitForm(node));
+        await submitForm(node, user);
         expectToHaveBeenCalledWithFormData(onSubmit, 'yo', true);
       });
 
@@ -2158,7 +2155,7 @@ describeRepeated('Form common', (createFormComponent) => {
           formData: 'yo',
           schema: { type: 'number' },
         });
-        await act(() => submitForm(node));
+        await submitForm(node, user);
         expect(onError).toHaveBeenLastCalledWith([
           {
             message: 'must be number',
@@ -2187,7 +2184,7 @@ describeRepeated('Form common', (createFormComponent) => {
           formData: { foo: 'yo' },
         });
 
-        await act(() => submitForm(node));
+        await submitForm(node, user);
         expectToHaveBeenCalledWithFormData(onSubmit, { foo: 'yo' }, true);
       });
     });
@@ -2208,7 +2205,7 @@ describeRepeated('Form common', (createFormComponent) => {
           formData: ['yo'],
         });
 
-        await act(() => submitForm(node));
+        await submitForm(node, user);
         expectToHaveBeenCalledWithFormData(onSubmit, ['yo'], true);
       });
     });
@@ -2365,7 +2362,7 @@ describeRepeated('Form common', (createFormComponent) => {
           expect(node.querySelectorAll('.rjsf-field-error')).toHaveLength(0);
         });
 
-        it("should clean contextualized errors up when they're fixed", () => {
+        it("should clean contextualized errors up when they're fixed", async () => {
           const altSchema: RJSFSchema = {
             type: 'object',
             properties: {
@@ -2381,13 +2378,13 @@ describeRepeated('Form common', (createFormComponent) => {
             },
           });
 
-          fireEvent.submit(node);
+          await submitForm(node, user);
 
           // Fix the first field
           fireEvent.change(node.querySelectorAll('input[type=text]')[0], {
             target: { value: 'fixed error' },
           });
-          fireEvent.submit(node);
+          await submitForm(node, user);
 
           expect(node.querySelectorAll('.rjsf-field-error')).toHaveLength(1);
 
@@ -2395,10 +2392,10 @@ describeRepeated('Form common', (createFormComponent) => {
           fireEvent.change(node.querySelectorAll('input[type=text]')[1], {
             target: { value: 'fixed error too' },
           });
-          fireEvent.submit(node);
+          await submitForm(node, user);
 
           // No error remaining, shouldn't throw.
-          fireEvent.submit(node);
+          await submitForm(node, user);
 
           expect(node.querySelectorAll('.rjsf-field-error')).toHaveLength(0);
         });
@@ -2459,7 +2456,7 @@ describeRepeated('Form common', (createFormComponent) => {
       });
 
       describe('Disable validation onSubmit event', () => {
-        it('should not update errorSchema when the formData changes', () => {
+        it('should not update errorSchema when the formData changes', async () => {
           const { node, onSubmit } = createFormComponent({
             schema,
             noValidate: true,
@@ -2468,7 +2465,7 @@ describeRepeated('Form common', (createFormComponent) => {
           fireEvent.change(node.querySelector<HTMLInputElement>('input[type=text]')!, {
             target: { value: 'short' },
           });
-          fireEvent.submit(node);
+          await submitForm(node, user);
 
           expect(onSubmit).toHaveBeenLastCalledWith(
             expect.objectContaining({ errorSchema: {} }),
@@ -2484,7 +2481,7 @@ describeRepeated('Form common', (createFormComponent) => {
         minLength: 8,
       };
 
-      it('should call the onError handler and focus on the error', () => {
+      it('should call the onError handler and focus on the error', async () => {
         const onError = jest.fn();
         const { node } = createFormComponent({
           schema,
@@ -2502,7 +2499,7 @@ describeRepeated('Form common', (createFormComponent) => {
         fireEvent.change(input, {
           target: { value: 'short' },
         });
-        fireEvent.submit(node);
+        await submitForm(node, user);
 
         expect(onError).toHaveBeenLastCalledWith(expect.any(Array));
         const callArg = jest.mocked(onError).mock.calls[0][0];
@@ -2511,7 +2508,7 @@ describeRepeated('Form common', (createFormComponent) => {
         expect(focusSpy).toHaveBeenCalledTimes(1);
       });
 
-      it('should call the onError handler and call the provided focusOnFirstError callback function', () => {
+      it('should call the onError handler and call the provided focusOnFirstError callback function', async () => {
         const onError = jest.fn();
 
         const focusCallback = () => {
@@ -2539,7 +2536,7 @@ describeRepeated('Form common', (createFormComponent) => {
         fireEvent.change(input, {
           target: { value: 'short' },
         });
-        fireEvent.submit(node);
+        await submitForm(node, user);
 
         expect(onError).toHaveBeenLastCalledWith(expect.any(Array));
         const callArg = jest.mocked(onError).mock.calls[0][0];
@@ -2550,7 +2547,7 @@ describeRepeated('Form common', (createFormComponent) => {
         expect(focusOnFirstError).toHaveBeenCalledTimes(1);
       });
 
-      it('should call the onError handler and call the provided focusOnFirstError callback function', () => {
+      it('should call the onError handler and call the provided focusOnFirstError callback function', async () => {
         const onError = jest.fn();
 
         const focusCallback = () => {
@@ -2580,7 +2577,7 @@ describeRepeated('Form common', (createFormComponent) => {
         fireEvent.change(input, {
           target: { value: 'valid string' },
         });
-        fireEvent.submit(node);
+        await submitForm(node, user);
 
         expect(onError).toHaveBeenLastCalledWith(expect.any(Array));
         const callArg = jest.mocked(onError).mock.calls[0][0];
@@ -2591,7 +2588,7 @@ describeRepeated('Form common', (createFormComponent) => {
         expect(focusOnFirstError).toHaveBeenCalledTimes(1);
       });
 
-      it('should reset errors and errorSchema state to initial state after correction and resubmission', () => {
+      it('should reset errors and errorSchema state to initial state after correction and resubmission', async () => {
         const { node, onError, onSubmit } = createFormComponent({
           schema,
         });
@@ -2599,7 +2596,7 @@ describeRepeated('Form common', (createFormComponent) => {
         fireEvent.change(node.querySelector<HTMLInputElement>('input[type=text]')!, {
           target: { value: 'short' },
         });
-        fireEvent.submit(node);
+        await submitForm(node, user);
 
         expect(onError).toHaveBeenLastCalledWith([
           {
@@ -2618,7 +2615,7 @@ describeRepeated('Form common', (createFormComponent) => {
         fireEvent.change(node.querySelector<HTMLInputElement>('input[type=text]')!, {
           target: { value: 'long enough' },
         });
-        fireEvent.submit(node);
+        await submitForm(node, user);
         expect(onError).not.toHaveBeenCalled();
         expect(onSubmit).toHaveBeenLastCalledWith(
           expect.objectContaining({
@@ -2629,7 +2626,7 @@ describeRepeated('Form common', (createFormComponent) => {
         );
       });
 
-      it('should reset errors from UI after correction and resubmission', () => {
+      it('should reset errors from UI after correction and resubmission', async () => {
         const { node } = createFormComponent({
           schema,
         });
@@ -2637,7 +2634,7 @@ describeRepeated('Form common', (createFormComponent) => {
         fireEvent.change(node.querySelector<HTMLInputElement>('input[type=text]')!, {
           target: { value: 'short' },
         });
-        fireEvent.submit(node);
+        await submitForm(node, user);
 
         const errorListHTML = '<li class="text-danger">must NOT have fewer than 8 characters</li>';
         const errors = node.querySelectorAll('.error-detail');
@@ -2648,7 +2645,7 @@ describeRepeated('Form common', (createFormComponent) => {
         fireEvent.change(node.querySelector<HTMLInputElement>('input[type=text]')!, {
           target: { value: 'long enough' },
         });
-        fireEvent.submit(node);
+        await submitForm(node, user);
         expect(node.querySelectorAll('.error-detail')).toHaveLength(0);
       });
     });
@@ -2663,9 +2660,9 @@ describeRepeated('Form common', (createFormComponent) => {
         formData: 'short',
       };
 
-      it('should reflect the contextualized error in state', () => {
+      it('should reflect the contextualized error in state', async () => {
         const { node, onError } = createFormComponent(formProps);
-        submitForm(node);
+        await submitForm(node, user);
         expect(onError).toHaveBeenLastCalledWith([
           {
             message: 'must NOT have fewer than 8 characters',
@@ -2709,9 +2706,9 @@ describeRepeated('Form common', (createFormComponent) => {
         formData: 'short',
       };
 
-      it('should reflect the contextualized error in state', () => {
+      it('should reflect the contextualized error in state', async () => {
         const { node, onError } = createFormComponent(formProps);
-        submitForm(node);
+        await submitForm(node, user);
         expect(onError).toHaveBeenLastCalledWith([
           {
             message: 'must NOT have fewer than 8 characters',
@@ -2778,10 +2775,10 @@ describeRepeated('Form common', (createFormComponent) => {
         },
       };
 
-      it('should reflect the contextualized error in state', () => {
+      it('should reflect the contextualized error in state', async () => {
         const { node, onError } = createFormComponent(formProps);
 
-        submitForm(node);
+        await submitForm(node, user);
         expect(onError).toHaveBeenLastCalledWith([
           {
             message: 'must NOT have fewer than 8 characters',
@@ -2827,10 +2824,10 @@ describeRepeated('Form common', (createFormComponent) => {
         formData: ['good', 'ba', 'good'],
       };
 
-      it('should contextualize the error for array indices', () => {
+      it('should contextualize the error for array indices', async () => {
         const { node, onError } = createFormComponent(formProps);
 
-        submitForm(node);
+        await submitForm(node, user);
         expect(onError).toHaveBeenLastCalledWith([
           {
             message: 'must NOT have fewer than 4 characters',
@@ -2889,14 +2886,14 @@ describeRepeated('Form common', (createFormComponent) => {
 
       const formProps: Omit<FormProps, 'validator'> = { schema, liveValidate: true };
 
-      it('should contextualize the error for nested array indices', () => {
+      it('should contextualize the error for nested array indices', async () => {
         const { node, onError } = createFormComponent({
           ...formProps,
           formData: {
             level1: ['good', 'bad', 'good', 'bad'],
           },
         });
-        submitForm(node);
+        await submitForm(node, user);
         expect(onError).toHaveBeenLastCalledWith([
           {
             message: 'must NOT have fewer than 4 characters',
@@ -2972,7 +2969,7 @@ describeRepeated('Form common', (createFormComponent) => {
 
       const formProps: Omit<FormProps, 'validator'> = { schema, formData, liveValidate: true };
 
-      it('should contextualize the error for nested array indices, focusing on first error', () => {
+      it('should contextualize the error for nested array indices, focusing on first error', async () => {
         const { node, onError } = createFormComponent({
           ...formProps,
           focusOnFirstError: true,
@@ -2986,7 +2983,7 @@ describeRepeated('Form common', (createFormComponent) => {
           value: focusSpy,
         });
 
-        submitForm(node);
+        await submitForm(node, user);
         expect(onError).toHaveBeenLastCalledWith([
           {
             message: 'must NOT have fewer than 4 characters',
@@ -3061,10 +3058,10 @@ describeRepeated('Form common', (createFormComponent) => {
         formData: [{ foo: 'good' }, { foo: 'ba' }, { foo: 'good' }],
       };
 
-      it('should contextualize the error for array nested items', () => {
+      it('should contextualize the error for array nested items', async () => {
         const { node, onError } = createFormComponent(formProps);
 
-        submitForm(node);
+        await submitForm(node, user);
         expect(onError).toHaveBeenLastCalledWith([
           {
             message: 'must NOT have fewer than 4 characters',
@@ -3527,7 +3524,7 @@ describeRepeated('Form common', (createFormComponent) => {
   });
 
   describe('Custom format updates, live validation', () => {
-    it('Should update custom formats when customFormats is changed', () => {
+    it('Should update custom formats when customFormats is changed', async () => {
       const formProps: Omit<FormProps, 'validator'> = {
         ref: createRef(),
         liveValidate: true,
@@ -3561,7 +3558,7 @@ describeRepeated('Form common', (createFormComponent) => {
 
       const { node, onError, rerender } = createFormComponent(formProps);
 
-      submitForm(node);
+      await submitForm(node, user);
       expect(onError).not.toHaveBeenCalled();
 
       rerender(
@@ -3572,7 +3569,7 @@ describeRepeated('Form common', (createFormComponent) => {
         customValidator,
       );
 
-      submitForm(node);
+      await submitForm(node, user);
       expect(onError).toHaveBeenLastCalledWith([
         {
           message: 'must match format "area-code"',
@@ -3590,7 +3587,7 @@ describeRepeated('Form common', (createFormComponent) => {
   });
 
   describe('Meta schema updates', () => {
-    it('Should update allowed meta schemas when additionalMetaSchemas is changed', () => {
+    it('Should update allowed meta schemas when additionalMetaSchemas is changed', async () => {
       const formProps: Omit<FormProps, 'validator'> = {
         ref: createRef(),
         schema: {
@@ -3604,7 +3601,7 @@ describeRepeated('Form common', (createFormComponent) => {
 
       const { node, onError, rerender } = createFormComponent(formProps);
 
-      submitForm(node);
+      await submitForm(node, user);
       expect(onError).toHaveBeenLastCalledWith([
         {
           stack: 'no schema with key or ref "http://json-schema.org/draft-06/schema#"',
@@ -3623,7 +3620,7 @@ describeRepeated('Form common', (createFormComponent) => {
         customValidator,
       );
 
-      submitForm(node);
+      await submitForm(node, user);
       expect(onError).toHaveBeenLastCalledWith([
         {
           message: 'must NOT have fewer than 8 characters',
@@ -3720,7 +3717,7 @@ describeRepeated('Form common', (createFormComponent) => {
   });
 
   describe('Dependencies', () => {
-    it('should not give a validation error by duplicating enum values in dependencies', () => {
+    it('should not give a validation error by duplicating enum values in dependencies', async () => {
       const schema: RJSFSchema = {
         title: 'A registration form',
         description: 'A simple form example.',
@@ -3754,7 +3751,7 @@ describeRepeated('Form common', (createFormComponent) => {
         type1: 'FOO',
       };
       const { node, onError } = createFormComponent({ schema, formData });
-      fireEvent.submit(node);
+      await submitForm(node, user);
       expect(onError).not.toHaveBeenCalled();
     });
     it('should show dependency defaults for uncontrolled components', () => {
@@ -4307,7 +4304,7 @@ describe('Form omitExtraData and liveOmit', () => {
     );
   });
 
-  it('should keep schema errors when extraErrors set after submit and liveValidate is false', () => {
+  it('should keep schema errors when extraErrors set after submit and liveValidate is false', async () => {
     const schema: RJSFSchema = {
       type: 'object',
       properties: {
@@ -4331,11 +4328,11 @@ describe('Form omitExtraData and liveOmit', () => {
       onSubmit,
       liveValidate: false,
     };
-    const event = { type: 'submit' };
     const { rerender, node } = createFormComponent(props);
-    act(() => {
-      fireEvent.submit(node, event);
-    });
+    // forceFireEvent=true: clicking the submit button focuses it, blurring the
+    // currently focused field and firing onChange which may mutate formData before
+    // the submit handler runs. fireEvent.submit bypasses that side-effect chain.
+    await submitForm(node, user, true);
     expect(node.querySelectorAll('.error-detail li')).toHaveLength(1);
 
     rerender({
@@ -4352,7 +4349,7 @@ describe('Form omitExtraData and liveOmit', () => {
 });
 
 describe('omitExtraData on submit', () => {
-  it('should call omitExtraData when the omitExtraData prop is true', () => {
+  it('should call omitExtraData when the omitExtraData prop is true', async () => {
     const schema: RJSFSchema = {
       type: 'object',
       properties: {
@@ -4375,12 +4372,12 @@ describe('omitExtraData on submit', () => {
 
     const theSpy = jest.spyOn(ref.current!, 'omitExtraData').mockReturnValue({ foo: '' });
 
-    fireEvent.submit(node);
+    await submitForm(node, user);
 
     expect(theSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('Should call validateFormWithFormData with the current formData if omitExtraData is false', () => {
+  it('Should call validateFormWithFormData with the current formData if omitExtraData is false', async () => {
     const omitExtraData = false;
     const schema: RJSFSchema = {
       type: 'object',
@@ -4398,11 +4395,11 @@ describe('omitExtraData on submit', () => {
     };
     const { node } = createFormComponent(props);
     const theSpy = jest.spyOn(formRef.current!, 'validateFormWithFormData').mockReturnValue(true);
-    fireEvent.submit(node);
+    await submitForm(node, user);
     expect(theSpy).toHaveBeenCalledWith(formData);
   });
 
-  it('Should call validateFormWithFormData with a new formData with only used fields if omitExtraData is true', () => {
+  it('Should call validateFormWithFormData with a new formData with only used fields if omitExtraData is true', async () => {
     const omitExtraData = true;
     const schema: RJSFSchema = {
       type: 'object',
@@ -4420,7 +4417,7 @@ describe('omitExtraData on submit', () => {
     };
     const { node } = createFormComponent(props);
     const theSpy = jest.spyOn(formRef.current!, 'validateFormWithFormData').mockReturnValue(true);
-    fireEvent.submit(node);
+    await submitForm(node, user);
     expect(theSpy).toHaveBeenCalledWith({ foo: 'bar' });
   });
 });
@@ -4441,21 +4438,19 @@ describe('omitExtraData prunes empty optional objects', () => {
     required: ['name'],
   };
 
-  it('prunes an empty optional object on submit when omitExtraData is true', () => {
+  it('prunes an empty optional object on submit when omitExtraData is true', async () => {
     const { node, onSubmit } = createFormComponent({
       schema,
       formData: { name: 'Alice', address: {} },
       omitExtraData: true,
     });
 
-    act(() => {
-      fireEvent.submit(node);
-    });
+    await submitForm(node, user);
 
     expectToHaveBeenCalledWithFormData(onSubmit, { name: 'Alice' }, true);
   });
 
-  it('does not prune a required object even when all its fields are empty', () => {
+  it('does not prune a required object even when all its fields are empty', async () => {
     const requiredAddressSchema: RJSFSchema = {
       type: 'object',
       properties: {
@@ -4476,23 +4471,19 @@ describe('omitExtraData prunes empty optional objects', () => {
       omitExtraData: true,
     });
 
-    act(() => {
-      fireEvent.submit(node);
-    });
+    await submitForm(node, user);
 
     expectToHaveBeenCalledWithFormData(onSubmit, { name: 'Alice', address: {} }, true);
   });
 
-  it('keeps an optional object when it has a non-empty field', () => {
+  it('keeps an optional object when it has a non-empty field', async () => {
     const { node, onSubmit } = createFormComponent({
       schema,
       formData: { name: 'Alice', address: { street: '123 Main St' } },
       omitExtraData: true,
     });
 
-    act(() => {
-      fireEvent.submit(node);
-    });
+    await submitForm(node, user);
 
     expectToHaveBeenCalledWithFormData(onSubmit, { name: 'Alice', address: { street: '123 Main St' } }, true);
   });
@@ -4563,7 +4554,7 @@ describe('Async errors', () => {
     expect(node.querySelectorAll('.error-detail li')).toHaveLength(2);
   });
 
-  it('should not block form submission', () => {
+  it('should not block form submission', async () => {
     const schema: RJSFSchema = {
       type: 'object',
       properties: {
@@ -4578,7 +4569,7 @@ describe('Async errors', () => {
     } as unknown as ErrorSchema;
 
     const { node, onSubmit } = createFormComponent({ schema, extraErrors });
-    fireEvent.submit(node);
+    await submitForm(node, user);
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
@@ -4651,7 +4642,7 @@ describe('Async errors', () => {
     expect(formRef.current!.state.errors).toEqual([]);
   });
 
-  it('should reset when schema changes', () => {
+  it('should reset when schema changes', async () => {
     const schema: RJSFSchema = {
       type: 'object',
       properties: {
@@ -4666,9 +4657,10 @@ describe('Async errors', () => {
       schema,
     });
 
-    act(() => {
-      fireEvent.submit(node);
-    });
+    // forceFireEvent=true: clicking the submit button focuses it, blurring the
+    // currently focused field and firing onChange which may mutate formData before
+    // the submit handler runs. fireEvent.submit bypasses that side-effect chain.
+    await submitForm(node, user, true);
 
     expect(formRef.current!.state.errorSchema).toEqual({ foo: { __errors: ["must have required property 'foo'"] } });
     expect(formRef.current!.state.errors).toEqual([
@@ -4759,9 +4751,7 @@ describe('Async errors', () => {
     });
 
     // Submit the form, then wait for async extraErrors to be set
-    await act(async () => {
-      fireEvent.submit(form);
-    });
+    await submitForm(form, user);
     await act(async () => {
       await new Promise((r) => setTimeout(r, 100));
     });
@@ -4855,7 +4845,7 @@ describe('Calling reset from ref object', () => {
     expect(node.querySelector<HTMLInputElement>('input')).toHaveAttribute('value', '');
   });
 
-  it('Clear errors', () => {
+  it('Clear errors', async () => {
     const schema: RJSFSchema = {
       title: 'Test form',
       type: 'number',
@@ -4870,9 +4860,7 @@ describe('Calling reset from ref object', () => {
     expect(node.querySelector<HTMLInputElement>('input')).toBeInTheDocument();
     fireEvent.change(node.querySelector<HTMLInputElement>('input')!, { target: { value: 'Some Value' } });
     expect(formRef.current!.state.errors).toHaveLength(0);
-    act(() => {
-      fireEvent.submit(node);
-    });
+    await submitForm(node, user);
     expect(formRef.current!.state.errors).toHaveLength(1);
     expect(node.querySelector('.errors')).toBeInTheDocument();
     act(() => {
@@ -6007,9 +5995,7 @@ describe('extraErrors set after submit (#4965)', () => {
     const { container } = render(<Wrapper />);
     const form = container.querySelector('form')!;
 
-    await act(async () => {
-      fireEvent.submit(form);
-    });
+    await submitForm(form, user);
 
     await act(async () => {
       await new Promise((r) => setTimeout(r, 100));
@@ -6049,9 +6035,10 @@ describe('extraErrors set after submit (#4965)', () => {
     const { container } = render(<Wrapper />);
     const form = container.querySelector('form')!;
 
-    await act(async () => {
-      fireEvent.submit(form);
-    });
+    // forceFireEvent=true: clicking the submit button focuses it, blurring the
+    // currently focused field and firing onChange which may mutate formData before
+    // the submit handler runs. fireEvent.submit bypasses that side-effect chain.
+    await submitForm(form, user, true);
 
     await act(async () => {
       await new Promise((r) => setTimeout(r, 200));
@@ -6090,9 +6077,7 @@ describe('extraErrors set after submit (#4965)', () => {
     const { container } = render(<Wrapper />);
     const form = container.querySelector('form')!;
 
-    await act(async () => {
-      fireEvent.submit(form);
-    });
+    await submitForm(form, user);
 
     await act(async () => {
       await new Promise((r) => setTimeout(r, 200));
@@ -6188,7 +6173,7 @@ describe('patternProperties with fixed properties (#4518)', () => {
       formData: { annotations: {} },
     });
 
-    submitForm(node);
+    await submitForm(node, user);
     expect(onError).not.toHaveBeenCalled();
     expect(onSubmit).toHaveBeenCalled();
     onSubmit.mockClear();
@@ -6199,7 +6184,7 @@ describe('patternProperties with fixed properties (#4518)', () => {
     await user.type(input!, 'hello');
     await user.clear(input!);
 
-    submitForm(node);
+    await submitForm(node, user);
     expect(onError).not.toHaveBeenCalled();
     expect(onSubmit).toHaveBeenCalled();
     const { formData } = onSubmit.mock.calls[onSubmit.mock.calls.length - 1][0];

--- a/packages/core/test/NullField.test.tsx
+++ b/packages/core/test/NullField.test.tsx
@@ -1,4 +1,8 @@
+import userEvent from '@testing-library/user-event';
+
 import { createFormComponent, expectToHaveBeenCalledWithFormData, submitForm } from './testUtils';
+
+const user = userEvent.setup();
 
 describe('NullField', () => {
   describe('No widget', () => {
@@ -34,7 +38,7 @@ describe('NullField', () => {
       expectToHaveBeenCalledWithFormData(onChange, null);
     });
 
-    it('should not overwrite existing data', () => {
+    it('should not overwrite existing data', async () => {
       const { node, onSubmit } = createFormComponent({
         schema: {
           type: 'null',
@@ -43,7 +47,7 @@ describe('NullField', () => {
         noValidate: true,
       });
 
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, 3, true);
     });
   });

--- a/packages/core/test/NumberField.test.tsx
+++ b/packages/core/test/NumberField.test.tsx
@@ -116,14 +116,14 @@ describe('NumberField', () => {
         expect(node.querySelector('.field-description')).toHaveTextContent('bar');
       });
 
-      it('formData should default to undefined', () => {
+      it('formData should default to undefined', async () => {
         const { node, onSubmit } = createFormComponent({
           schema: { type: 'number' },
           uiSchema,
           noValidate: true,
         });
 
-        submitForm(node);
+        await submitForm(node, user);
         expectToHaveBeenCalledWithFormData(onSubmit, undefined, true);
       });
 
@@ -484,7 +484,7 @@ describe('NumberField', () => {
       expectToHaveBeenCalledWithFormData(onChange, 2, 'root');
     });
 
-    it('should fill field with data', () => {
+    it('should fill field with data', async () => {
       const { node, onSubmit } = createFormComponent({
         schema: {
           type: 'number',
@@ -492,7 +492,7 @@ describe('NumberField', () => {
         },
         formData: 2,
       });
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, 2, true);
     });
 

--- a/packages/core/test/ObjectField.test.tsx
+++ b/packages/core/test/ObjectField.test.tsx
@@ -268,7 +268,7 @@ describe('ObjectField', () => {
       );
     });
 
-    it('should validate AJV $data reference ', () => {
+    it('should validate AJV $data reference ', async () => {
       const schema: RJSFSchema = {
         type: 'object',
         properties: {
@@ -297,7 +297,7 @@ describe('ObjectField', () => {
       });
 
       // trigger the errors by submitting the form since initial render no longer shows them
-      submitForm(node);
+      await submitForm(node, user);
 
       const errorMessages = node.querySelectorAll('#root_emailConfirm__error');
       expect(errorMessages).toHaveLength(1);
@@ -314,7 +314,7 @@ describe('ObjectField', () => {
       expect(node.querySelectorAll('#root_foo__error')).toHaveLength(0);
     });
 
-    it('Check that when formData changes, the form should re-validate', () => {
+    it('Check that when formData changes, the form should re-validate', async () => {
       const { node, rerender } = createFormComponent({
         schema,
         formData: {
@@ -323,8 +323,10 @@ describe('ObjectField', () => {
         liveValidate: true,
       });
 
-      // trigger the errors by submitting the form since initial render no longer shows them
-      submitForm(node);
+      // trigger the errors by submitting the form since initial render no longer shows them.
+      // forceFireEvent=true: clicking the submit button focuses it, blurring any focused
+      // field and firing onChange, which can mutate formData before the submit runs.
+      await submitForm(node, user, true);
 
       const errorMessages = node.querySelectorAll('#root_foo__error');
       expect(errorMessages).toHaveLength(1);
@@ -464,7 +466,7 @@ describe('ObjectField', () => {
       expect(errorMessages).toHaveLength(0);
     });
 
-    it('should not copy errors when name has dotted-path similar to real property', () => {
+    it('should not copy errors when name has dotted-path similar to real property', async () => {
       const schema: RJSFSchema = {
         type: 'object',
         properties: {
@@ -491,7 +493,7 @@ describe('ObjectField', () => {
       };
       const { node } = createFormComponent({ schema, formData });
       // click submit
-      submitForm(node);
+      await submitForm(node, user);
       const fooDotBarErrors = node.querySelectorAll('#root_Foo.Bar__error');
       expect(fooDotBarErrors).toHaveLength(0);
       const fooBarErrors = node.querySelectorAll('#root_Foo_Bar__error');
@@ -763,7 +765,7 @@ describe('ObjectField', () => {
       expect(objectTitle).toHaveTextContent('CustomName');
     });
 
-    it('should not throw validation errors if additionalProperties is undefined', () => {
+    it('should not throw validation errors if additionalProperties is undefined', async () => {
       const undefinedAPSchema: RJSFSchema = {
         ...schema,
         properties: { second: { type: 'string' } },
@@ -774,13 +776,13 @@ describe('ObjectField', () => {
         formData: { nonschema: 1 },
       });
 
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, { nonschema: 1 }, true);
 
       expect(onError).not.toHaveBeenCalled();
     });
 
-    it('should throw a validation error if additionalProperties is false', () => {
+    it('should throw a validation error if additionalProperties is false', async () => {
       const { node, onSubmit, onError } = createFormComponent({
         schema: {
           ...schema,
@@ -789,7 +791,7 @@ describe('ObjectField', () => {
         },
         formData: { nonschema: 1 },
       });
-      submitForm(node);
+      await submitForm(node, user);
       expect(onSubmit).not.toHaveBeenCalled();
       expect(onError).toHaveBeenLastCalledWith([
         {

--- a/packages/core/test/SchemaField.test.tsx
+++ b/packages/core/test/SchemaField.test.tsx
@@ -1,4 +1,3 @@
-import { fireEvent, act } from '@testing-library/react';
 import {
   DEFAULT_ID_PREFIX,
   DEFAULT_ID_SEPARATOR,
@@ -14,10 +13,13 @@ import {
   WidgetProps,
 } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
+import userEvent from '@testing-library/user-event';
 
 import { getDefaultRegistry } from '../src';
 import SchemaField from '../src/components/fields/SchemaField';
-import { createFormComponent } from './testUtils';
+import { createFormComponent, submitForm } from './testUtils';
+
+const user = userEvent.setup();
 
 describe('SchemaField', () => {
   describe('registry', () => {
@@ -505,39 +507,35 @@ describe('SchemaField', () => {
       return errors;
     }
 
-    it('should render its own errors', () => {
+    it('should render its own errors', async () => {
       const { node } = createFormComponent({
         schema,
         uiSchema,
         customValidate,
       });
 
-      act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       const matches = node.querySelectorAll('form > .form-group > div > .error-detail .text-danger');
       expect(matches).toHaveLength(1);
       expect(matches[0]).toHaveTextContent('container');
     });
 
-    it('should pass errors to child component', () => {
+    it('should pass errors to child component', async () => {
       const { node } = createFormComponent({
         schema,
         uiSchema,
         customValidate,
       });
 
-      act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       const matches = node.querySelectorAll('form .form-group .form-group .text-danger');
       expect(matches).toHaveLength(1);
       expect(matches[0]).toHaveTextContent('test');
     });
 
-    it('should ignore errors for top level anyOf/oneOf and show only one in child schema', () => {
+    it('should ignore errors for top level anyOf/oneOf and show only one in child schema', async () => {
       const testSchema: RJSFSchema = {
         type: 'object',
         properties: {
@@ -562,16 +560,14 @@ describe('SchemaField', () => {
         customValidate,
       });
 
-      act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       const matches = node.querySelectorAll('form .form-group .form-group .text-danger');
       expect(matches).toHaveLength(1);
       expect(matches[0]).toHaveTextContent('test');
     });
 
-    it('should show errors for top level anyOf/oneOf when schema is select control', () => {
+    it('should show errors for top level anyOf/oneOf when schema is select control', async () => {
       const testSchema: RJSFSchema = {
         type: 'object',
         properties: {
@@ -601,16 +597,14 @@ describe('SchemaField', () => {
         customValidate,
       });
 
-      act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       const matches = node.querySelectorAll('form .form-group .form-group .text-danger');
       expect(matches).toHaveLength(1);
       expect(matches[0]).toHaveTextContent('test');
     });
 
-    it('should pass errors to custom FieldErrorTemplate', () => {
+    it('should pass errors to custom FieldErrorTemplate', async () => {
       const customFieldError = (props: FieldErrorProps) => {
         return <div className='custom-field-error'>{props.errors}</div>;
       };
@@ -621,9 +615,7 @@ describe('SchemaField', () => {
         templates: { FieldErrorTemplate: customFieldError },
       });
 
-      act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       const matches = node.querySelectorAll('form .form-group .form-group .text-danger');
       expect(matches).toHaveLength(0);
@@ -632,7 +624,7 @@ describe('SchemaField', () => {
       expect(customMatches[0]).toHaveTextContent('test');
     });
 
-    it('should pass errors to custom FieldErrorTemplate, via uiSchema', () => {
+    it('should pass errors to custom FieldErrorTemplate, via uiSchema', async () => {
       const customFieldError = (props: FieldErrorProps) => {
         return <div className='custom-field-error'>{props.errors}</div>;
       };
@@ -649,9 +641,7 @@ describe('SchemaField', () => {
         customValidate,
       });
 
-      act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       const matches = node.querySelectorAll('form .form-group .form-group .text-danger');
       expect(matches).toHaveLength(0);
@@ -665,7 +655,7 @@ describe('SchemaField', () => {
         return <div className='custom-text-widget'>{props.rawErrors}</div>;
       };
 
-      it('should pass rawErrors down to custom widgets', () => {
+      it('should pass rawErrors down to custom widgets', async () => {
         const { node } = createFormComponent({
           schema,
           uiSchema,
@@ -673,9 +663,7 @@ describe('SchemaField', () => {
           templates: { BaseInputTemplate: customStringWidget },
         });
 
-        act(() => {
-          fireEvent.submit(node);
-        });
+        await submitForm(node, user);
 
         const matches = node.querySelectorAll('.custom-text-widget');
         expect(matches).toHaveLength(1);
@@ -689,31 +677,27 @@ describe('SchemaField', () => {
         ...uiSchema,
       };
 
-      it('should not render its own default errors', () => {
+      it('should not render its own default errors', async () => {
         const { node } = createFormComponent({
           schema,
           uiSchema: hideUiSchema,
           customValidate,
         });
 
-        act(() => {
-          fireEvent.submit(node);
-        });
+        await submitForm(node, user);
 
         const matches = node.querySelectorAll('form > .form-group > div > .error-detail .text-danger');
         expect(matches).toHaveLength(0);
       });
 
-      it('should not show default errors in child component', () => {
+      it('should not show default errors in child component', async () => {
         const { node } = createFormComponent({
           schema,
           uiSchema: hideUiSchema,
           customValidate,
         });
 
-        act(() => {
-          fireEvent.submit(node);
-        });
+        await submitForm(node, user);
 
         const matches = node.querySelectorAll('form .form-group .form-group .text-danger');
         expect(matches).toHaveLength(0);
@@ -724,7 +708,7 @@ describe('SchemaField', () => {
           return <div className='custom-text-widget'>{props.rawErrors}</div>;
         };
 
-        it('should pass rawErrors down to custom widgets and render them', () => {
+        it('should pass rawErrors down to custom widgets and render them', async () => {
           const { node } = createFormComponent({
             schema,
             uiSchema: hideUiSchema,
@@ -732,9 +716,7 @@ describe('SchemaField', () => {
             templates: { BaseInputTemplate: customStringWidget },
           });
 
-          act(() => {
-            fireEvent.submit(node);
-          });
+          await submitForm(node, user);
 
           const matches = node.querySelectorAll('.custom-text-widget');
           expect(matches).toHaveLength(1);
@@ -753,31 +735,27 @@ describe('SchemaField', () => {
         },
       };
 
-      it('should not render its own default errors', () => {
+      it('should not render its own default errors', async () => {
         const { node } = createFormComponent({
           schema,
           uiSchema: hideUiSchema,
           customValidate,
         });
 
-        act(() => {
-          fireEvent.submit(node);
-        });
+        await submitForm(node, user);
 
         const matches = node.querySelectorAll('form > .form-group > div > .error-detail .text-danger');
         expect(matches).toHaveLength(0);
       });
 
-      it('should show errors on child component', () => {
+      it('should show errors on child component', async () => {
         const { node } = createFormComponent({
           schema,
           uiSchema: hideUiSchema,
           customValidate,
         });
 
-        act(() => {
-          fireEvent.submit(node);
-        });
+        await submitForm(node, user);
 
         const matches = node.querySelectorAll('form .form-group .form-group .text-danger');
         expect(matches).toHaveLength(1);
@@ -797,22 +775,20 @@ describe('SchemaField', () => {
       foo: { 'ui:help': helpText },
     };
 
-    it('should render its own help', () => {
+    it('should render its own help', async () => {
       const { node } = createFormComponent({
         schema,
         uiSchema,
       });
 
-      act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       const matches = node.querySelectorAll('form .form-group .form-group .help-block');
       expect(matches).toHaveLength(1);
       expect(matches[0]).toHaveTextContent(helpText);
     });
 
-    it('should pass help to custom FieldHelpTemplate', () => {
+    it('should pass help to custom FieldHelpTemplate', async () => {
       const customFieldHelp = (props: FieldHelpProps) => {
         return <div className='custom-field-help'>{props.help}</div>;
       };
@@ -822,9 +798,7 @@ describe('SchemaField', () => {
         templates: { FieldHelpTemplate: customFieldHelp },
       });
 
-      act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       const matches = node.querySelectorAll('form .form-group .form-group .help-block');
       expect(matches).toHaveLength(0);
@@ -833,7 +807,7 @@ describe('SchemaField', () => {
       expect(customMatches[0]).toHaveTextContent(helpText);
     });
 
-    it('should pass errors to custom FieldErrorTemplate, via uiSchema', () => {
+    it('should pass errors to custom FieldErrorTemplate, via uiSchema', async () => {
       const customFieldHelp = (props: FieldHelpProps) => {
         return <div className='custom-field-help'>{props.help}</div>;
       };
@@ -846,9 +820,7 @@ describe('SchemaField', () => {
         uiSchema,
       });
 
-      act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       const matches = node.querySelectorAll('form .form-group .form-group .help-block');
       expect(matches).toHaveLength(0);

--- a/packages/core/test/StringField.test.tsx
+++ b/packages/core/test/StringField.test.tsx
@@ -181,12 +181,12 @@ describe('StringField', () => {
       expect(node.querySelector('.rjsf-field input')).toHaveAttribute('list', datalistId);
     });
 
-    it('should default submit value to undefined', () => {
+    it('should default submit value to undefined', async () => {
       const { node, onSubmit } = createFormComponent({
         schema: { type: 'string' },
         noValidate: true,
       });
-      submitForm(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, undefined, true);
     });
@@ -313,7 +313,7 @@ describe('StringField', () => {
       expect(node.querySelector('input')).toHaveAttribute('autocomplete', 'family-name');
     });
 
-    it('Check that when formData changes, the form should re-validate', () => {
+    it('Check that when formData changes, the form should re-validate', async () => {
       const { node, rerender } = createFormComponent({
         schema: { type: 'string' },
         formData: null,
@@ -321,7 +321,7 @@ describe('StringField', () => {
       });
 
       // trigger the errors by submitting the form since initial render no longer shows them
-      submitForm(node);
+      await submitForm(node, user);
 
       const errorMessages = node.querySelectorAll('#root__error');
       expect(errorMessages).toHaveLength(1);
@@ -482,7 +482,7 @@ describe('StringField', () => {
       expect(node.querySelectorAll('.rjsf-field option')[0]).toHaveTextContent('Test');
     });
 
-    it('should assign a default value', () => {
+    it('should assign a default value', async () => {
       const { node, onSubmit } = createFormComponent({
         schema: {
           type: 'string',
@@ -491,7 +491,7 @@ describe('StringField', () => {
         },
       });
 
-      submitForm(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, 'bar', true);
     });
@@ -553,7 +553,7 @@ describe('StringField', () => {
       expect(getSelectedOptionValue($select)).toEqual('');
     });
 
-    it('should fill field with data', () => {
+    it('should fill field with data', async () => {
       const { node, onSubmit } = createFormComponent({
         schema: {
           type: 'string',
@@ -561,7 +561,7 @@ describe('StringField', () => {
         },
         formData: 'bar',
       });
-      submitForm(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, 'bar', true);
     });
@@ -709,7 +709,7 @@ describe('StringField', () => {
       expect(node.querySelectorAll('.rjsf-field [type=datetime-local]')).toHaveLength(1);
     });
 
-    it('should assign a default value', () => {
+    it('should assign a default value', async () => {
       const datetime = new Date().toJSON();
       const { node, onSubmit } = createFormComponent({
         schema: {
@@ -718,7 +718,7 @@ describe('StringField', () => {
           default: datetime,
         },
       });
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, datetime, true);
     });
 
@@ -741,7 +741,7 @@ describe('StringField', () => {
       expect(dateNode).toHaveValue(newDatetime);
     });
 
-    it('should fill field with data', () => {
+    it('should fill field with data', async () => {
       const datetime = new Date().toJSON();
       const { node, onSubmit } = createFormComponent({
         schema: {
@@ -750,7 +750,7 @@ describe('StringField', () => {
         },
         formData: datetime,
       });
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, datetime, true);
     });
 
@@ -809,7 +809,7 @@ describe('StringField', () => {
       expect(node.querySelectorAll('.rjsf-field [type=date]')).toHaveLength(1);
     });
 
-    it('should assign a default value', () => {
+    it('should assign a default value', async () => {
       const datetime = new Date().toJSON();
       const { node, onSubmit } = createFormComponent({
         schema: {
@@ -820,7 +820,7 @@ describe('StringField', () => {
         uiSchema,
         noValidate: true,
       });
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, datetime, true);
     });
 
@@ -842,7 +842,7 @@ describe('StringField', () => {
       expect(input).toHaveValue(newDatetime.slice(0, 10));
     });
 
-    it('should fill field with data', () => {
+    it('should fill field with data', async () => {
       const datetime = new Date().toJSON();
       const { node, onSubmit } = createFormComponent({
         schema: {
@@ -852,7 +852,7 @@ describe('StringField', () => {
         formData: datetime,
         noValidate: true,
       });
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, datetime, true);
     });
 
@@ -928,7 +928,7 @@ describe('StringField', () => {
       expect(node.querySelectorAll('.rjsf-field [type=time]')).toHaveLength(1);
     });
 
-    it('should assign a default value', () => {
+    it('should assign a default value', async () => {
       const time = '01:10:00';
       const { node, onSubmit } = createFormComponent({
         schema: {
@@ -937,7 +937,7 @@ describe('StringField', () => {
           default: time,
         },
       });
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, time, true);
     });
 
@@ -957,7 +957,7 @@ describe('StringField', () => {
       expect(input).toHaveValue(`${newTime}:00`);
     });
 
-    it('should fill field with data', () => {
+    it('should fill field with data', async () => {
       const time = '13:10:00';
       const { node, onSubmit } = createFormComponent({
         schema: {
@@ -966,7 +966,7 @@ describe('StringField', () => {
         },
         formData: time,
       });
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, time, true);
     });
 
@@ -1038,7 +1038,7 @@ describe('StringField', () => {
       expect(node.querySelector('.rjsf-field label')).toHaveTextContent('foo');
     });
 
-    it('should assign a default value', () => {
+    it('should assign a default value', async () => {
       const current = new Date();
       current.setMilliseconds(0);
       const datetime = current.toJSON();
@@ -1050,7 +1050,7 @@ describe('StringField', () => {
         },
         uiSchema,
       });
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, datetime, true);
     });
 
@@ -1083,7 +1083,7 @@ describe('StringField', () => {
       expectToHaveBeenCalledWithFormData(onChange, '2012-10-02T01:02:03.000Z', 'root');
     });
 
-    it('should fill field with data', () => {
+    it('should fill field with data', async () => {
       const datetime = new Date().toJSON();
       const { node, onSubmit } = createFormComponent({
         schema: {
@@ -1092,7 +1092,7 @@ describe('StringField', () => {
         },
         formData: datetime,
       });
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, datetime, true);
     });
 
@@ -1395,7 +1395,7 @@ describe('StringField', () => {
       expect(node.querySelector('.rjsf-field label')).toHaveTextContent('foo');
     });
 
-    it('should assign a default value', () => {
+    it('should assign a default value', async () => {
       const datetime = '2012-12-12';
       const { node, onSubmit } = createFormComponent({
         schema: {
@@ -1405,7 +1405,7 @@ describe('StringField', () => {
         },
         uiSchema,
       });
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, datetime, true);
     });
 
@@ -1456,7 +1456,7 @@ describe('StringField', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
-    it('should fill field with data', () => {
+    it('should fill field with data', async () => {
       const datetime = '2012-12-12';
       const { node, onSubmit } = createFormComponent({
         schema: {
@@ -1466,7 +1466,7 @@ describe('StringField', () => {
         uiSchema,
         formData: datetime,
       });
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, datetime, true);
     });
 
@@ -1712,7 +1712,7 @@ describe('StringField', () => {
       expect(node.querySelector('.field-description')).toHaveTextContent('baz');
     });
 
-    it('should assign a default value', () => {
+    it('should assign a default value', async () => {
       const email = 'foo@bar.baz';
       const { node, onSubmit } = createFormComponent({
         schema: {
@@ -1722,7 +1722,7 @@ describe('StringField', () => {
         },
       });
 
-      submitForm(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, email, true);
     });
@@ -1741,7 +1741,7 @@ describe('StringField', () => {
       expect(node.querySelector('[type=email]')).toHaveValue(newDatetime);
     });
 
-    it('should fill field with data', () => {
+    it('should fill field with data', async () => {
       const email = 'foo@bar.baz';
       const { node, onSubmit } = createFormComponent({
         schema: {
@@ -1751,7 +1751,7 @@ describe('StringField', () => {
         formData: email,
       });
 
-      submitForm(node);
+      await submitForm(node, user);
       expectToHaveBeenCalledWithFormData(onSubmit, email, true);
     });
 
@@ -1847,7 +1847,7 @@ describe('StringField', () => {
       expect(node.querySelector('.field-description')).toHaveTextContent('baz');
     });
 
-    it('should assign a default value', () => {
+    it('should assign a default value', async () => {
       const url = 'http://foo.bar/baz';
       const { node, onSubmit } = createFormComponent({
         schema: {
@@ -1857,7 +1857,7 @@ describe('StringField', () => {
         },
       });
 
-      submitForm(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, url, true);
     });
@@ -1876,7 +1876,7 @@ describe('StringField', () => {
       expect(node.querySelector('[type=url]')).toHaveValue(newDatetime);
     });
 
-    it('should fill field with data', () => {
+    it('should fill field with data', async () => {
       const url = 'http://foo.bar/baz';
       const { node, onSubmit } = createFormComponent({
         schema: {
@@ -1886,7 +1886,7 @@ describe('StringField', () => {
         formData: url,
       });
 
-      submitForm(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, url, true);
     });
@@ -1963,7 +1963,7 @@ describe('StringField', () => {
       expect(node.querySelectorAll('.rjsf-field [type=color]')).toHaveLength(1);
     });
 
-    it('should assign a default value', () => {
+    it('should assign a default value', async () => {
       const { node, onSubmit } = createFormComponent({
         schema: {
           type: 'string',
@@ -1972,7 +1972,7 @@ describe('StringField', () => {
         },
         uiSchema,
       });
-      submitForm(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, color, true);
     });
@@ -1999,7 +1999,7 @@ describe('StringField', () => {
       expect(node.querySelector('[type=color]')).toHaveValue(newColor);
     });
 
-    it('should fill field with data', () => {
+    it('should fill field with data', async () => {
       const { node, onSubmit } = createFormComponent({
         schema: {
           type: 'string',
@@ -2007,7 +2007,7 @@ describe('StringField', () => {
         },
         formData: color,
       });
-      submitForm(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, color, true);
     });
@@ -2053,7 +2053,7 @@ describe('StringField', () => {
       expect(node.querySelectorAll('.rjsf-field [type=file]')).toHaveLength(1);
     });
 
-    it('should assign a default value', () => {
+    it('should assign a default value', async () => {
       const { node, onSubmit } = createFormComponent({
         schema: {
           type: 'string',
@@ -2061,7 +2061,7 @@ describe('StringField', () => {
           default: initialValue,
         },
       });
-      submitForm(node);
+      await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, initialValue, true);
     });

--- a/packages/core/test/anyOf.test.tsx
+++ b/packages/core/test/anyOf.test.tsx
@@ -1,9 +1,12 @@
 import { createRef } from 'react';
 import { fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { FormValidation, RJSFSchema, WidgetProps } from '@rjsf/utils';
 
-import { createFormComponent, getSelectedOptionValue } from './testUtils';
+import { createFormComponent, getSelectedOptionValue, submitForm } from './testUtils';
 import SelectWidget from '../src/components/widgets/SelectWidget';
+
+const user = userEvent.setup();
 
 describe('anyOf', () => {
   it('should not render a select element if the anyOf keyword is not present', () => {
@@ -1635,7 +1638,7 @@ describe('anyOf', () => {
       return errors;
     }
 
-    it('should show error on options with different types', () => {
+    it('should show error on options with different types', async () => {
       const { node } = createFormComponent({
         schema,
         customValidate,
@@ -1646,9 +1649,7 @@ describe('anyOf', () => {
           target: { value: 12345 },
         });
       });
-      act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       let inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=number]');
       expect(inputs[0]).toHaveAttribute('id', 'root_userId');
@@ -1666,15 +1667,13 @@ describe('anyOf', () => {
           target: { value: 'Lorem ipsum dolor sit amet' },
         });
       });
-      act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputs[0]).toHaveAttribute('id', 'root_userId');
     });
 
-    it('should NOT show error on options with different types when hideError: true', () => {
+    it('should NOT show error on options with different types when hideError: true', async () => {
       const { node } = createFormComponent({
         schema,
         uiSchema: {
@@ -1689,9 +1688,7 @@ describe('anyOf', () => {
         });
       });
 
-      act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       let inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=number]');
       expect(inputs).toHaveLength(0);
@@ -1709,9 +1706,7 @@ describe('anyOf', () => {
           target: { value: 'Lorem ipsum dolor sit amet' },
         });
       });
-      act(() => {
-        fireEvent.submit(node);
-      });
+      await submitForm(node, user);
 
       inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputs).toHaveLength(0);

--- a/packages/core/test/oneOf.test.tsx
+++ b/packages/core/test/oneOf.test.tsx
@@ -1,10 +1,13 @@
 import { createRef } from 'react';
 import { fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { FieldProps, FormValidation, GenericObjectType, RJSFSchema, WidgetProps } from '@rjsf/utils';
 
-import { createFormComponent, getSelectedOptionValue } from './testUtils';
+import { createFormComponent, getSelectedOptionValue, submitForm } from './testUtils';
 import SchemaField from '../src/components/fields/SchemaField';
 import SelectWidget from '../src/components/widgets/SelectWidget';
+
+const user = userEvent.setup();
 
 describe('oneOf', () => {
   it('should not render a select element if the oneOf keyword is not present', () => {
@@ -1711,7 +1714,7 @@ describe('oneOf', () => {
       return errors;
     }
 
-    it('should show error on options with different types', () => {
+    it('should show error on options with different types', async () => {
       const { node } = createFormComponent({
         schema,
         customValidate,
@@ -1722,7 +1725,7 @@ describe('oneOf', () => {
           target: { value: 12345 },
         });
       });
-      fireEvent.submit(node);
+      await submitForm(node, user);
 
       let inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=number]');
       expect(inputs[0]).toHaveAttribute('id', 'root_userId');
@@ -1740,12 +1743,12 @@ describe('oneOf', () => {
           target: { value: 'Lorem ipsum dolor sit amet' },
         });
       });
-      fireEvent.submit(node);
+      await submitForm(node, user);
 
       inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputs[0]).toHaveAttribute('id', 'root_userId');
     });
-    it('should NOT show error on options with different types when hideError: true', () => {
+    it('should NOT show error on options with different types when hideError: true', async () => {
       const { node } = createFormComponent({
         schema,
         uiSchema: {
@@ -1759,7 +1762,7 @@ describe('oneOf', () => {
           target: { value: 12345 },
         });
       });
-      fireEvent.submit(node);
+      await submitForm(node, user);
 
       let inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=number]');
       expect(inputs).toHaveLength(0);
@@ -1777,7 +1780,7 @@ describe('oneOf', () => {
           target: { value: 'Lorem ipsum dolor sit amet' },
         });
       });
-      fireEvent.submit(node);
+      await submitForm(node, user);
 
       inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputs).toHaveLength(0);

--- a/packages/core/test/testUtils.tsx
+++ b/packages/core/test/testUtils.tsx
@@ -67,9 +67,7 @@ export async function submitForm(node: Element, user: UserEvent, forceFireEvent 
     await user.click(submitButton);
   } else {
     // fallback if there isn't a submit button
-    act(() => {
-      fireEvent.submit(node);
-    });
+    fireEvent.submit(node);
   }
 }
 

--- a/packages/core/test/testUtils.tsx
+++ b/packages/core/test/testUtils.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType } from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { GenericObjectType, ValidatorType } from '@rjsf/utils';

--- a/packages/core/test/testUtils.tsx
+++ b/packages/core/test/testUtils.tsx
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
+import type { UserEvent } from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { GenericObjectType, ValidatorType } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
@@ -60,10 +61,16 @@ export function describeRepeated(title: string, fn: CreatorFn) {
   }
 }
 
-export function submitForm(node: Element) {
-  act(() => {
-    fireEvent.submit(node);
-  });
+export async function submitForm(node: Element, user: UserEvent, forceFireEvent = false) {
+  const submitButton = node.querySelector('[type="submit"]');
+  if (submitButton && !forceFireEvent) {
+    await user.click(submitButton);
+  } else {
+    // fallback if there isn't a submit button
+    act(() => {
+      fireEvent.submit(node);
+    });
+  }
 }
 
 export function getSelectedOptionValue(selectNode: HTMLSelectElement) {

--- a/packages/core/test/uiSchema.test.tsx
+++ b/packages/core/test/uiSchema.test.tsx
@@ -1057,7 +1057,7 @@ describe('uiSchema', () => {
         expect(node.querySelector('[type=hidden]')).toHaveValue('a');
       });
 
-      it('should map widget value to a typed event property', () => {
+      it('should map widget value to a typed event property', async () => {
         const { node, onSubmit } = createFormComponent({
           schema,
           uiSchema,
@@ -1066,7 +1066,7 @@ describe('uiSchema', () => {
           },
         });
 
-        submitForm(node);
+        await submitForm(node, user);
 
         expectToHaveBeenCalledWithFormData(onSubmit, { foo: 'a' }, true);
       });
@@ -1379,7 +1379,7 @@ describe('uiSchema', () => {
         expect(node.querySelector('[type=hidden]')).toHaveValue('42');
       });
 
-      it('should map widget value to a typed event property', () => {
+      it('should map widget value to a typed event property', async () => {
         const { node, onSubmit } = createFormComponent({
           schema,
           uiSchema,
@@ -1388,7 +1388,7 @@ describe('uiSchema', () => {
           },
         });
 
-        submitForm(node);
+        await submitForm(node, user);
 
         expectToHaveBeenCalledWithFormData(onSubmit, { foo: 42 }, true);
       });
@@ -1569,7 +1569,7 @@ describe('uiSchema', () => {
         expect(node.querySelector('[type=hidden]')).toHaveValue('42');
       });
 
-      it('should map widget value to a typed event property', () => {
+      it('should map widget value to a typed event property', async () => {
         const { node, onSubmit } = createFormComponent({
           schema,
           uiSchema,
@@ -1578,7 +1578,7 @@ describe('uiSchema', () => {
           },
         });
 
-        submitForm(node);
+        await submitForm(node, user);
 
         expectToHaveBeenCalledWithFormData(onSubmit, { foo: 42 }, true);
       });
@@ -1737,7 +1737,7 @@ describe('uiSchema', () => {
         expect(node.querySelector('[type=hidden]')).toHaveValue('true');
       });
 
-      it('should map widget value to a typed event property', () => {
+      it('should map widget value to a typed event property', async () => {
         const { node, onSubmit } = createFormComponent({
           schema,
           uiSchema,
@@ -1746,7 +1746,7 @@ describe('uiSchema', () => {
           },
         });
 
-        submitForm(node);
+        await submitForm(node, user);
 
         expectToHaveBeenCalledWithFormData(onSubmit, { foo: true }, true);
       });

--- a/packages/core/test/validate.test.tsx
+++ b/packages/core/test/validate.test.tsx
@@ -22,7 +22,7 @@ describe('Validation', () => {
 
         let onError: jest.Mock;
         let node: Element;
-        beforeEach(() => {
+        beforeEach(async () => {
           const compInfo = createFormComponent({
             schema,
             formData: {
@@ -31,7 +31,10 @@ describe('Validation', () => {
           });
           onError = compInfo.onError;
           node = compInfo.node;
-          submitForm(node);
+          // forceFireEvent=true: clicking the submit button focuses it, blurring the
+          // currently focused field and firing onChange which may mutate formData before
+          // the submit handler runs. fireEvent.submit bypasses that side-effect chain.
+          await submitForm(node, user, true);
         });
 
         it('should trigger onError call', () => {
@@ -69,7 +72,7 @@ describe('Validation', () => {
         let onError: jest.Mock;
         let node: Element;
 
-        beforeEach(() => {
+        beforeEach(async () => {
           const compInfo = createFormComponent({
             schema,
             formData: {
@@ -79,7 +82,7 @@ describe('Validation', () => {
           node = compInfo.node;
           onError = compInfo.onError;
 
-          submitForm(node);
+          await submitForm(node, user);
         });
 
         it('should render errors', () => {
@@ -104,7 +107,7 @@ describe('Validation', () => {
     });
 
     describe('Custom Form validation', () => {
-      it('should validate a simple string value', () => {
+      it('should validate a simple string value', async () => {
         const schema: RJSFSchema = { type: 'string' };
         const formData = 'a';
 
@@ -121,7 +124,7 @@ describe('Validation', () => {
           formData,
         });
 
-        submitForm(node);
+        await submitForm(node, user);
         expect(onError).toHaveBeenLastCalledWith([{ property: '.', message: 'Invalid', stack: '. Invalid' }]);
       });
 
@@ -157,7 +160,7 @@ describe('Validation', () => {
         );
       });
 
-      it('should submit form on valid data', () => {
+      it('should submit form on valid data', async () => {
         const schema: RJSFSchema = { type: 'string' };
         const formData = 'hello';
         const onSubmit = jest.fn();
@@ -176,12 +179,12 @@ describe('Validation', () => {
           onSubmit,
         });
 
-        submitForm(node);
+        await submitForm(node, user);
 
         expect(onSubmit).toHaveBeenCalled();
       });
 
-      it('should prevent form submission on invalid data', () => {
+      it('should prevent form submission on invalid data', async () => {
         const schema: RJSFSchema = { type: 'string' };
         const formData = 'a';
         const onSubmit = jest.fn();
@@ -202,13 +205,13 @@ describe('Validation', () => {
           onError,
         });
 
-        submitForm(node);
+        await submitForm(node, user);
 
         expect(onSubmit).not.toHaveBeenCalled();
         expect(onError).toHaveBeenCalled();
       });
 
-      it('should validate a simple object', () => {
+      it('should validate a simple object', async () => {
         const schema: RJSFSchema = {
           type: 'object',
           properties: {
@@ -232,7 +235,7 @@ describe('Validation', () => {
           customValidate,
           formData,
         });
-        submitForm(node);
+        await submitForm(node, user);
         expect(onError).toHaveBeenLastCalledWith([
           {
             message: 'must NOT have fewer than 3 characters',
@@ -251,7 +254,7 @@ describe('Validation', () => {
         ]);
       });
 
-      it('should validate an array of object', () => {
+      it('should validate an array of object', async () => {
         const schema: RJSFSchema = {
           type: 'array',
           items: {
@@ -284,7 +287,7 @@ describe('Validation', () => {
           formData,
         });
 
-        submitForm(node);
+        await submitForm(node, user);
         expect(onError).toHaveBeenLastCalledWith([
           {
             property: '.0.pass2',
@@ -294,7 +297,7 @@ describe('Validation', () => {
         ]);
       });
 
-      it('should validate a simple array', () => {
+      it('should validate a simple array', async () => {
         const schema: RJSFSchema = {
           type: 'array',
           items: {
@@ -316,7 +319,7 @@ describe('Validation', () => {
           customValidate,
           formData,
         });
-        submitForm(node);
+        await submitForm(node, user);
         expect(onError).toHaveBeenLastCalledWith([
           {
             property: '.',
@@ -340,7 +343,7 @@ describe('Validation', () => {
 
         let onError: jest.Mock;
         let node: Element;
-        beforeEach(() => {
+        beforeEach(async () => {
           const compInfo = createFormComponent({
             schema,
             formData: {
@@ -351,7 +354,10 @@ describe('Validation', () => {
           node = compInfo.node;
           onError = compInfo.onError;
 
-          submitForm(node);
+          // forceFireEvent=true: clicking the submit button focuses it, blurring the
+          // currently focused field and firing onChange which may mutate formData before
+          // the submit handler runs. fireEvent.submit bypasses that side-effect chain.
+          await submitForm(node, user, true);
         });
 
         it('should not render error list if showErrorList prop true', () => {
@@ -404,7 +410,7 @@ describe('Validation', () => {
         </div>
       );
 
-      it('should use CustomErrorList', () => {
+      it('should use CustomErrorList', async () => {
         const { node } = createFormComponent({
           schema,
           uiSchema,
@@ -415,7 +421,7 @@ describe('Validation', () => {
         });
 
         // trigger the errors by submitting the form since initial render no longer shows them
-        submitForm(node);
+        await submitForm(node, user);
         expect(node.querySelectorAll('.CustomErrorList')).toHaveLength(1);
         expect(node.querySelector('.CustomErrorList')).toHaveTextContent('1 custom');
         expect(node.querySelectorAll('.ErrorSchema')).toHaveLength(1);
@@ -451,7 +457,7 @@ describe('Validation', () => {
         },
       };
 
-      beforeEach(() => {
+      beforeEach(async () => {
         const validator = customizeV8Validator({
           additionalMetaSchemas: [require('ajv/lib/refs/json-schema-draft-06.json')],
         });
@@ -465,7 +471,7 @@ describe('Validation', () => {
         );
         node = withMetaSchema.node;
         onError = withMetaSchema.onError;
-        submitForm(node);
+        await submitForm(node, user);
       });
       it('should be used to validate schema', async () => {
         expect(node.querySelectorAll('.errors li')).toHaveLength(1);


### PR DESCRIPTION
### Reasons for making this change

Updated the `submitForm()` helper method to add two new params, `user: UserEvent` and `forceFireEvent=false` to better support actual user interactions
- Updated all tests that used `submitForm()` or `fireEvent.submit()` to use the new `submitForm()` signature, adding `forceFireEvent=true` as needed

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
