### PR TITLE
Fix 1357 and 2492 by filtering out enums in arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,14 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
-- Fixed schema-change handling so dependent enum updates sanitize invalid scalar field data without over-sanitizing root, object, array, readonly, or disabled field changes ([#5067](https://github.com/rjsf-team/react-jsonschema-form/pull/5067))
+- Fixed schema-change handling so dependent enum updates sanitize invalid scalar field data without over-sanitizing root, object, array, readonly, or disabled field changes, fixing [#3838](https://github.com/rjsf-team/react-jsonschema-form/issues/3838)
+- Updated `Form` tests to verify fix for [#1357](https://github.com/rjsf-team/react-jsonschema-form/issues/1357) and [#2492](https://github.com/rjsf-team/react-jsonschema-form/issues/2492)
+  - Also added `console` message suppression support to the tests to reduce noise
 
 ## @rjsf/utils
 
-- Updated `sanitizeDataForNewSchema()` to preserve valid enum values while replacing or clearing stale values across enum, `oneOf`, and `anyOf` schema changes ([#5067](https://github.com/rjsf-team/react-jsonschema-form/pull/5067))
+- Updated `sanitizeDataForNewSchema()` to preserve valid enum values while replacing or clearing stale values across enum, `oneOf`, and `anyOf` schema changes, fixing [#3838](https://github.com/rjsf-team/react-jsonschema-form/issues/3838)
+- Updated `sanitizeDataForNewSchema()` to filter out invalid enum values in arrays, fixing [#1357](https://github.com/rjsf-team/react-jsonschema-form/issues/1357) and [#2492](https://github.com/rjsf-team/react-jsonschema-form/issues/2492)
 
 ## Dev / docs / playground
 

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -34,6 +34,7 @@ import {
   NoValFormProps,
   renderNode,
   RerenderType,
+  setupConsoleErrorSuppression,
   submitForm,
 } from './testUtils';
 import widgetsSchema from './widgets_schema.json';
@@ -46,17 +47,17 @@ const TWO_BUTTONS = (
 );
 const user = userEvent.setup();
 
+const renderErrorSuppression = setupConsoleErrorSuppression();
+
 describeRepeated('Form common', (createFormComponent) => {
   describe('Empty schema', () => {
     it('Should throw error when Form is missing validator', () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
       expect(() =>
         createComponent(Form, { ref: createRef(), schema: {}, validator: undefined as unknown as ValidatorType }),
       ).toThrow('A validator is required for Form functionality to work');
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(renderErrorSuppression.consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining('The above error occurred in the <Form> component'),
       );
-      consoleErrorSpy.mockRestore();
     });
 
     it('should render a form tag', () => {
@@ -659,7 +660,6 @@ describeRepeated('Form common', (createFormComponent) => {
     });
 
     it('should raise for non-existent definitions referenced', () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
       const schema: RJSFSchema = {
         type: 'object',
         properties: {
@@ -668,10 +668,9 @@ describeRepeated('Form common', (createFormComponent) => {
       };
 
       expect(() => createFormComponent({ schema })).toThrow(/#\/definitions\/nonexistent/);
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(renderErrorSuppression.consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining('The above error occurred in the <Form> component'),
       );
-      consoleErrorSpy.mockRestore();
     });
 
     it('should propagate referenced definition defaults', () => {
@@ -3629,19 +3628,17 @@ describeRepeated('Form common', (createFormComponent) => {
     });
 
     it('should render the component using a ComponentType', () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
       const Component = (props: any) => <div {...props} id='test' />;
       const { node } = createFormComponent({ schema: {}, tagName: Component });
       expect(node.id).toEqual('test');
       // React deduplicates this warning per component name — only fires on the first test iteration
-      if (consoleErrorSpy.mock.calls.length > 0) {
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
+      if (renderErrorSuppression.consoleSpy.mock.calls.length > 0) {
+        expect(renderErrorSuppression.consoleSpy).toHaveBeenCalledWith(
           expect.stringContaining('Function components cannot be given refs'),
           expect.any(String),
           expect.any(String),
         );
       }
-      consoleErrorSpy.mockRestore();
     });
   });
 

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -19,6 +19,7 @@ import {
 import validator, { customizeValidator } from '@rjsf/validator-ajv8';
 import { act, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { noop } from 'lodash';
 import { Portal } from 'react-portal';
 import type { Mock } from 'vitest';
 
@@ -48,9 +49,14 @@ const user = userEvent.setup();
 describeRepeated('Form common', (createFormComponent) => {
   describe('Empty schema', () => {
     it('Should throw error when Form is missing validator', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
       expect(() =>
         createComponent(Form, { ref: createRef(), schema: {}, validator: undefined as unknown as ValidatorType }),
       ).toThrow('A validator is required for Form functionality to work');
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('The above error occurred in the <Form> component'),
+      );
+      consoleErrorSpy.mockRestore();
     });
 
     it('should render a form tag', () => {
@@ -653,6 +659,7 @@ describeRepeated('Form common', (createFormComponent) => {
     });
 
     it('should raise for non-existent definitions referenced', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
       const schema: RJSFSchema = {
         type: 'object',
         properties: {
@@ -661,6 +668,10 @@ describeRepeated('Form common', (createFormComponent) => {
       };
 
       expect(() => createFormComponent({ schema })).toThrow(/#\/definitions\/nonexistent/);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('The above error occurred in the <Form> component'),
+      );
+      consoleErrorSpy.mockRestore();
     });
 
     it('should propagate referenced definition defaults', () => {
@@ -2450,6 +2461,7 @@ describeRepeated('Form common', (createFormComponent) => {
       });
 
       it('should call the onError handler and call the provided focusOnFirstError callback function', async () => {
+        const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(noop);
         const onError = vi.fn();
 
         const focusCallback = () => {
@@ -2481,9 +2493,12 @@ describeRepeated('Form common', (createFormComponent) => {
 
         expect(focusSpy).not.toHaveBeenCalled();
         expect(focusOnFirstError).toHaveBeenCalledTimes(1);
+        expect(consoleLogSpy).toHaveBeenCalledWith('focusCallback called');
+        consoleLogSpy.mockRestore();
       });
 
       it('should call the onError handler and call the provided focusOnFirstError callback function', async () => {
+        const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(noop);
         const onError = vi.fn();
 
         const focusCallback = () => {
@@ -2520,6 +2535,8 @@ describeRepeated('Form common', (createFormComponent) => {
 
         expect(focusSpy).not.toHaveBeenCalled();
         expect(focusOnFirstError).toHaveBeenCalledTimes(1);
+        expect(consoleLogSpy).toHaveBeenCalledWith('focusCallback called');
+        consoleLogSpy.mockRestore();
       });
 
       it('should reset errors and errorSchema state to initial state after correction and resubmission', async () => {
@@ -3088,6 +3105,7 @@ describeRepeated('Form common', (createFormComponent) => {
       });
 
       it('should not show any errors when branch is empty', async () => {
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(noop);
         const { node, onChange } = createFormComponent({
           ref: createRef(),
           schema,
@@ -3103,6 +3121,10 @@ describeRepeated('Form common', (createFormComponent) => {
           }),
           'root_branch',
         );
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          "ignoring oneOf in dependencies because there isn't exactly one subschema that is valid",
+        );
+        consoleWarnSpy.mockRestore();
       });
 
       it('should sanitize stale enum data and persist the retrieved dependency schema', async () => {
@@ -3477,6 +3499,7 @@ describeRepeated('Form common', (createFormComponent) => {
 
   describe('Custom format updates, live validation', () => {
     it('Should update custom formats when customFormats is changed', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(noop);
       const formProps: Omit<FormProps, 'validator'> = {
         ref: createRef(),
         liveValidate: true,
@@ -3533,6 +3556,10 @@ describeRepeated('Form common', (createFormComponent) => {
           title: '',
         },
       ]);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('unknown format "area-code" ignored in schema at path "#/properties/areaCode"'),
+      );
+      consoleWarnSpy.mockRestore();
     });
   });
 
@@ -3602,9 +3629,19 @@ describeRepeated('Form common', (createFormComponent) => {
     });
 
     it('should render the component using a ComponentType', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
       const Component = (props: any) => <div {...props} id='test' />;
       const { node } = createFormComponent({ schema: {}, tagName: Component });
       expect(node.id).toEqual('test');
+      // React deduplicates this warning per component name — only fires on the first test iteration
+      if (consoleErrorSpy.mock.calls.length > 0) {
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Function components cannot be given refs'),
+          expect.any(String),
+          expect.any(String),
+        );
+      }
+      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -6077,5 +6114,149 @@ describe('patternProperties with fixed properties (#4518)', () => {
     expect(onSubmit).toHaveBeenCalled();
     const { formData } = onSubmit.mock.calls[onSubmit.mock.calls.length - 1][0];
     expect(formData).toEqual({ annotations: {} });
+  });
+});
+
+describe('enum-based array values do not update when dependencies change (#1357 and #2492)', () => {
+  it('should remove enum values in array when dependency switches', async () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        opt: {
+          type: 'boolean',
+        },
+      },
+      dependencies: {
+        opt: {
+          oneOf: [
+            {
+              properties: {
+                opt: {
+                  const: true,
+                },
+                arr: {
+                  type: 'array',
+                  uniqueItems: true,
+                  items: {
+                    type: 'string',
+                    enum: ['a', 'b'],
+                  },
+                },
+              },
+            },
+            {
+              properties: {
+                opt: {
+                  const: false,
+                },
+                arr: {
+                  type: 'array',
+                  uniqueItems: true,
+                  items: {
+                    type: 'string',
+                    enum: ['c', 'd'],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const uiSchema: UiSchema = {
+      arr: {
+        'ui:widget': 'checkboxes',
+      },
+    };
+
+    const { node, onChange } = createFormComponent({
+      schema,
+      uiSchema,
+      formData: { opt: false },
+    });
+
+    const checkboxC = node.querySelector('#root_arr-0');
+    expect(checkboxC).not.toBeChecked();
+    await user.click(checkboxC!);
+    expect(checkboxC).toBeChecked();
+
+    expectToHaveBeenCalledWithFormData(onChange, { opt: false, arr: ['c'] }, 'root_arr');
+
+    const checkboxOpt = node.querySelector('#root_opt');
+    expect(checkboxOpt).not.toBeChecked();
+    await user.click(checkboxOpt!);
+    expect(checkboxOpt).toBeChecked();
+
+    expectToHaveBeenCalledWithFormData(onChange, { opt: true, arr: [] }, 'root_opt');
+  });
+  it('array item defaults based on enums are switched when dependencies switch and arrayMinItems.mergeExtraDefaults is true', async () => {
+    const schema: RJSFSchema = {
+      title: 'Dependencies & Default',
+      type: 'object',
+      properties: {
+        select_item: {
+          type: 'string',
+          enum: ['item1', 'item2'],
+        },
+      },
+      dependencies: {
+        select_item: {
+          oneOf: [
+            {
+              properties: {
+                select_item: {
+                  const: 'item1',
+                },
+                item_detail: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                    enum: ['item_detail1', 'item_detail2'],
+                  },
+                  default: ['item_detail1', 'item_detail2'],
+                },
+              },
+            },
+            {
+              properties: {
+                select_item: {
+                  const: 'item2',
+                },
+                item_detail: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                    enum: ['item_detail3', 'item_detail4'],
+                  },
+                  default: ['item_detail3', 'item_detail4'],
+                },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const { node, onChange } = createFormComponent({
+      schema,
+      formData: { select_item: 'item1' },
+      experimental_defaultFormStateBehavior: { arrayMinItems: { mergeExtraDefaults: true } },
+    });
+
+    expectToHaveBeenCalledWithFormData(onChange, {
+      select_item: 'item1',
+      item_detail: ['item_detail1', 'item_detail2'],
+    });
+
+    const selectItem = node.querySelector('#root_select_item');
+    await user.selectOptions(selectItem!, 'item2');
+
+    expectToHaveBeenCalledWithFormData(
+      onChange,
+      {
+        select_item: 'item2',
+        item_detail: ['item_detail3', 'item_detail4'],
+      },
+      'root_select_item',
+    );
   });
 });

--- a/packages/core/test/LayoutMultiSchemaField.test.tsx
+++ b/packages/core/test/LayoutMultiSchemaField.test.tsx
@@ -21,8 +21,6 @@ import {
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { get } from 'lodash';
-import noop from 'lodash/noop';
-import type { MockInstance } from 'vitest';
 
 import LayoutMultiSchemaField, {
   computeEnumOptions,
@@ -32,6 +30,7 @@ import RadioWidget from '../src/components/widgets/RadioWidget';
 import SelectWidget from '../src/components/widgets/SelectWidget';
 import getTestRegistry from '../src/getTestRegistry';
 import { SIMPLE_ONEOF, SIMPLE_ONEOF_OPTIONS } from './testData/layoutData';
+import { setupConsoleErrorSuppression } from './testUtils';
 
 vi.mock('@rjsf/utils', async (importOriginal) => ({
   ...(await importOriginal()),
@@ -221,17 +220,7 @@ describe('LayoutMultiSchemaField', () => {
       onFocus: vi.fn(),
     };
   }
-  let consoleErrorSpy: MockInstance;
-  beforeAll(() => {
-    // silence the error reporting
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
-  });
-  afterEach(() => {
-    consoleErrorSpy.mockClear();
-  });
-  afterAll(() => {
-    consoleErrorSpy.mockRestore();
-  });
+  setupConsoleErrorSuppression();
   test('throws when no selectorField is provided', () => {
     const expectedError = 'No selector field provided for the LayoutMultiSchemaField';
     const schema: RJSFSchema = {

--- a/packages/core/test/StringField.test.tsx
+++ b/packages/core/test/StringField.test.tsx
@@ -12,16 +12,18 @@ import {
 } from '@rjsf/utils';
 import { fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import noop from 'lodash/noop';
 
 import StringField from '../src/components/fields/StringField';
 import TextWidget from '../src/components/widgets/TextWidget';
 import {
   createFormComponent,
   getSelectedOptionValue,
+  setupConsoleErrorSuppression,
   submitForm,
   expectToHaveBeenCalledWithFormData,
 } from './testUtils';
+
+setupConsoleErrorSuppression();
 
 const mockFileReader = {
   // eslint-disable-next-line no-unused-vars
@@ -1551,7 +1553,6 @@ describe('StringField', () => {
     });
 
     it('should throw on invalid date', () => {
-      const mockError = vi.spyOn(console, 'error').mockImplementation(noop);
       expect(() =>
         createFormComponent({
           schema: {
@@ -1563,7 +1564,6 @@ describe('StringField', () => {
           formData: '2012-1212',
         }),
       ).toThrow('Unable to parse date 2012-1212');
-      mockError.mockRestore();
     });
 
     describe('AltDateWidget with format option', () => {

--- a/packages/core/test/allOf.test.tsx
+++ b/packages/core/test/allOf.test.tsx
@@ -1,7 +1,9 @@
 import { RJSFSchema, FieldProps, GenericObjectType } from '@rjsf/utils';
 
 import SchemaField from '../src/components/fields/SchemaField';
-import { createFormComponent } from './testUtils';
+import { createFormComponent, setupConsoleWarnSuppression } from './testUtils';
+
+setupConsoleWarnSuppression();
 
 describe('allOf', () => {
   it('should render a regular input element with a single type, when multiple types specified', () => {

--- a/packages/core/test/testUtils.tsx
+++ b/packages/core/test/testUtils.tsx
@@ -4,6 +4,8 @@ import validator from '@rjsf/validator-ajv8';
 import '@testing-library/jest-dom';
 import { act, render, fireEvent } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
+import noop from 'lodash/noop';
+import type { MockInstance } from 'vitest';
 
 import Form, { FormProps } from '../src';
 
@@ -101,4 +103,71 @@ export async function delayPromise(delay = 100) {
 
 export function actWrappedDelayPromise(delay = 100) {
   return act(async () => delayPromise(delay));
+}
+
+// React's invokeGuardedCallback (dev mode) re-throws render errors by dispatching a synthetic
+// DOM event on a fake node. jsdom catches that throw and calls reportException(), which fires
+// an ErrorEvent on window and — if unhandled — forwards it to the virtualConsole, producing
+// "Error: ..." lines in vitest's stderr. Calling event.preventDefault() marks the error as
+// handled, stopping both the virtualConsole output and any uncaughtException emission.
+//
+// We also keep a file-level console.error spy so individual tests can assert on React's
+// "The above error occurred in the <Component> component" messages without creating per-test
+// spies that call mockRestore() — which would silently kill the file-level spy for every
+// subsequent test in the file.
+//
+// Call this once at the top of a test file or describe block (not inside a test).
+// The returned object's `consoleSpy` getter is safe to access inside test bodies.
+export function setupConsoleErrorSuppression() {
+  let spy: MockInstance;
+
+  function handleWindowError(event: ErrorEvent): void {
+    if (event.error instanceof Error) {
+      event.preventDefault();
+    }
+  }
+
+  beforeAll(() => {
+    spy = vi.spyOn(console, 'error').mockImplementation(noop);
+    window.addEventListener('error', handleWindowError);
+  });
+  beforeEach(() => {
+    spy.mockClear();
+  });
+  afterAll(() => {
+    window.removeEventListener('error', handleWindowError);
+    spy.mockRestore();
+  });
+
+  return {
+    get consoleSpy() {
+      return spy;
+    },
+  };
+}
+
+// Companion to setupConsoleErrorSuppression for tests that produce expected console.warn
+// output. console.warn calls go directly through the spy (no jsdom/window involvement),
+// so no window event listener is needed here.
+//
+// Call this once at the top of a test file or describe block (not inside a test).
+// The returned object's `consoleSpy` getter is safe to access inside test bodies.
+export function setupConsoleWarnSuppression() {
+  let spy: MockInstance;
+
+  beforeAll(() => {
+    spy = vi.spyOn(console, 'warn').mockImplementation(noop);
+  });
+  beforeEach(() => {
+    spy.mockClear();
+  });
+  afterAll(() => {
+    spy.mockRestore();
+  });
+
+  return {
+    get consoleSpy() {
+      return spy;
+    },
+  };
 }

--- a/packages/core/test/validate.test.tsx
+++ b/packages/core/test/validate.test.tsx
@@ -274,7 +274,6 @@ describe('Validation', () => {
 
         function customValidate(formData: FormProps['formData'], errors: FormValidation) {
           formData.forEach(({ pass1, pass2 }: GenericObjectType, i: number) => {
-            console.log(pass1, pass2, errors);
             if (pass1 !== pass2) {
               (errors as GenericObjectType)[i].pass2.addError("Passwords don't match");
             }

--- a/packages/utils/src/schema/sanitizeDataForNewSchema.ts
+++ b/packages/utils/src/schema/sanitizeDataForNewSchema.ts
@@ -265,7 +265,12 @@ export default function sanitizeDataForNewSchema<
             return newValue;
           }, []);
         } else {
-          newFormData = maxItems > 0 && data.length > maxItems ? data.slice(0, maxItems) : data;
+          // Filter out items that are no longer valid in the new items schema (e.g., enum values that changed)
+          const newItemEnumValues = enumValuesForSchema(newSchemaItems as S);
+          const filteredData = newItemEnumValues
+            ? data.filter((item: any) => newItemEnumValues.some((v: any) => deepEquals(v, item)))
+            : data;
+          newFormData = maxItems > 0 && filteredData.length > maxItems ? filteredData.slice(0, maxItems) : filteredData;
         }
       }
     } else if (

--- a/packages/utils/test/schema/sanitizeDataForNewSchemaTest.ts
+++ b/packages/utils/test/schema/sanitizeDataForNewSchemaTest.ts
@@ -530,6 +530,39 @@ export default function sanitizeDataForNewSchemaTest(testValidator: TestValidato
       };
       expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, ['1', '2'])).toEqual(['1']);
     });
+    it('filters out items not in the new items enum', () => {
+      const oldSchema: RJSFSchema = {
+        type: 'array',
+        items: { type: 'string', enum: ['c', 'd'] },
+      };
+      const newSchema: RJSFSchema = {
+        type: 'array',
+        items: { type: 'string', enum: ['a', 'b'] },
+      };
+      expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, ['c', 'd'])).toEqual([]);
+    });
+    it('keeps items that remain valid in the new items enum', () => {
+      const oldSchema: RJSFSchema = {
+        type: 'array',
+        items: { type: 'string', enum: ['a', 'b', 'c'] },
+      };
+      const newSchema: RJSFSchema = {
+        type: 'array',
+        items: { type: 'string', enum: ['a', 'b'] },
+      };
+      expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, ['a', 'c'])).toEqual(['a']);
+    });
+    it('returns all items when the new items schema has no enum constraint', () => {
+      const oldSchema: RJSFSchema = {
+        type: 'array',
+        items: { type: 'string', enum: ['a', 'b'] },
+      };
+      const newSchema: RJSFSchema = {
+        type: 'array',
+        items: { type: 'string' },
+      };
+      expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, ['a', 'b'])).toEqual(['a', 'b']);
+    });
     it('returns whole array when the new schema does not have maxItems for simple type', () => {
       const rootSchema: RJSFSchema = {
         definitions: {


### PR DESCRIPTION
### Reasons for making this change

Fixed #1357 and #2492 by filtering out invalid enum values in arrays during sanitization
- Updated `sanitizeDataForNewSchema()` to filter out invalid enum values in arrays during sanitization
  - Updated unit tests accordingly
- Update `Form` tests to add use cases to verify the fix for 1357 and 2492
  - Updated validate tests to either remove `console` message
- Add `setupConsoleErrorSuppression()` to testUtils: sets up a file-level
  console.error spy and a window 'error' listener that calls preventDefault()
  to stop jsdom forwarding React's invokeGuardedCallback re-throws to vitest's
  stderr. Returning the spy via a getter avoids the mockRestore()-kills-file-spy
  problem that per-test spies cause across describeRepeated blocks.
- Add `setupConsoleWarnSuppression()` to testUtils: simpler companion for
  expected console.warn output (no window listener needed).
- Update Form.test.tsx, StringField.test.tsx, LayoutMultiSchemaField.test.tsx
  to use setupConsoleErrorSuppression(), removing per-test spy/mockRestore pairs.
- Update allOf.test.tsx to use setupConsoleWarnSuppression() for the expected
  'could not merge subschemas in allOf' warnings from incompatible-type tests.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
