### PR TITLE
fix(utils): preserve boolean conditional branches in retrieveSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Fixed [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907) and [#4262](https://github.com/rjsf-team/react-jsonschema-form/issues/4262) as follows:
   - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
-  - Added `CyclicSchemaField` to the list of fields, that renders the `CyclicSchemaExpandTemplate` initially and, if expanded, will render the `SchemaField` with the `RJSF_REF_CYCLE_KEY` tag turned off  
+  - Added `CyclicSchemaField` to the list of fields, that renders the `CyclicSchemaExpandTemplate` initially and, if expanded, will render the `SchemaField` with the `RJSF_REF_CYCLE_KEY` tag turned off
   - Updated `SchemaForm` to render the `CyclicSchemaField` when the schema contains the `RJSF_REF_CYCLE_KEY` set to `true`
 
 ## @rjsf/daisyui
@@ -93,7 +93,6 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
-- Fixed `retrieveSchema()` to preserve boolean conditional branches while resolving schemas, fixing [#4476](https://github.com/rjsf-team/react-jsonschema-form/issues/4476)
 - Updated `sanitizeDataForNewSchema()` to preserve valid enum values while replacing or clearing stale values across enum, `oneOf`, and `anyOf` schema changes, fixing [#3838](https://github.com/rjsf-team/react-jsonschema-form/issues/3838)
 - Updated `sanitizeDataForNewSchema()` to filter out invalid enum values in arrays, fixing [#1357](https://github.com/rjsf-team/react-jsonschema-form/issues/1357) and [#2492](https://github.com/rjsf-team/react-jsonschema-form/issues/2492)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
+- Fixed `retrieveSchema()` to preserve boolean conditional branches while resolving schemas, fixing [#4476](https://github.com/rjsf-team/react-jsonschema-form/issues/4476) ([#5101](https://github.com/rjsf-team/react-jsonschema-form/pull/5101))
 - Updated `types.ts` to add `CyclicSchemaExpandProps` type and `CyclicSchemaExpandTemplate` in the `TemplatesType`
 - Updated `resolveAllReferences()` to add a new `markCycleOnDetection` prop which adds `RJSF_REF_CYCLE_KEY` marker (from `constants.ts`) to a schema that has been detected to have a cycle, partially fixing [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907)
 - Updated `hashForSchema()` to filter keys to remove `RJSF_REF_KEY` prefixed keys before hashing the schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,13 +70,13 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
-- Fixed `retrieveSchema()` to preserve boolean conditional branches while resolving schemas, fixing [#4476](https://github.com/rjsf-team/react-jsonschema-form/issues/4476) ([#5101](https://github.com/rjsf-team/react-jsonschema-form/pull/5101))
 - Updated `types.ts` to add `CyclicSchemaExpandProps` type and `CyclicSchemaExpandTemplate` in the `TemplatesType`
 - Updated `resolveAllReferences()` to add a new `markCycleOnDetection` prop which adds `RJSF_REF_CYCLE_KEY` marker (from `constants.ts`) to a schema that has been detected to have a cycle, partially fixing [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907)
 - Updated `hashForSchema()` to filter keys to remove `RJSF_REF_KEY` prefixed keys before hashing the schema
 - Updated `enums.ts` to add `ExpandButton` and `CycleDetected` keys
 - Updated `isFixedItems()` to treat empty tuple `items` arrays as fixed items so `additionalItems` schemas are handled consistently, fixing [#3791](https://github.com/rjsf-team/react-jsonschema-form/issues/3791)
 - Added `logUnsupportedDefaultForEnum()` helper for theme select widgets to warn when a schema default is not present in the enum options, fixing [#4494](https://github.com/rjsf-team/react-jsonschema-form/issues/4494)
+- Fixed `retrieveSchema()` to preserve boolean conditional branches while resolving schemas, fixing [#4476](https://github.com/rjsf-team/react-jsonschema-form/issues/4476) ([#5101](https://github.com/rjsf-team/react-jsonschema-form/pull/5101))
 
 ## Dev / docs / playground
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
+- Fixed `retrieveSchema()` to preserve boolean conditional branches while resolving schemas, fixing [#4476](https://github.com/rjsf-team/react-jsonschema-form/issues/4476)
 - Updated `sanitizeDataForNewSchema()` to preserve valid enum values while replacing or clearing stale values across enum, `oneOf`, and `anyOf` schema changes, fixing [#3838](https://github.com/rjsf-team/react-jsonschema-form/issues/3838)
 - Updated `sanitizeDataForNewSchema()` to filter out invalid enum values in arrays, fixing [#1357](https://github.com/rjsf-team/react-jsonschema-form/issues/1357) and [#2492](https://github.com/rjsf-team/react-jsonschema-form/issues/2492)
 

--- a/packages/core/test/validate.test.tsx
+++ b/packages/core/test/validate.test.tsx
@@ -30,8 +30,10 @@ describe('Validation', () => {
 
         expect(onSubmit).not.toHaveBeenCalled();
         expect(onError).toHaveBeenCalledOnce();
-        expect(node.querySelectorAll('.errors li')).toHaveLength(1);
-        expect(node.querySelector('.errors li')).toHaveTextContent('must NOT be valid');
+        expect(Array.from(node.querySelectorAll('.errors li')).map((error) => error.textContent)).toEqual([
+          'boolean schema is false',
+          'must match "then" schema',
+        ]);
       });
 
       describe('Required fields', () => {

--- a/packages/core/test/validate.test.tsx
+++ b/packages/core/test/validate.test.tsx
@@ -12,6 +12,28 @@ const user = userEvent.setup();
 describe('Validation', () => {
   describe('Form integration, v8 validator', () => {
     describe('JSONSchema validation', () => {
+      it('should block submit when a matched if/then branch resolves to false', async () => {
+        const schema: RJSFSchema = {
+          type: 'number',
+          if: {
+            const: 13,
+          },
+          then: false,
+        };
+
+        const { node, onError, onSubmit } = createFormComponent({
+          schema,
+          formData: 13,
+        });
+
+        await submitForm(node, user, true);
+
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledOnce();
+        expect(node.querySelectorAll('.errors li')).toHaveLength(1);
+        expect(node.querySelector('.errors li')).toHaveTextContent('must NOT be valid');
+      });
+
       describe('Required fields', () => {
         const schema: RJSFSchema = {
           type: 'object',

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -77,8 +77,16 @@ export default function retrieveSchema<
   )[0];
 }
 
+/** Converts boolean schemas to equivalent object schemas for APIs that operate on `StrictRJSFSchema` objects.
+ *
+ * @param schema - The schema or boolean schema to normalize
+ * @returns - The original schema or an equivalent object schema
+ */
 function normalizeBooleanSchema<S extends StrictRJSFSchema = RJSFSchema>(schema: S | boolean): S {
-  return (typeof schema === 'boolean' ? (schema ? {} : { not: {} }) : schema) as S;
+  if (typeof schema !== 'boolean') {
+    return schema;
+  }
+  return (schema ? {} : { not: {} }) as S;
 }
 
 /** Resolves a conditional block (if/else/then) by removing the condition and merging the appropriate conditional branch

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -77,6 +77,10 @@ export default function retrieveSchema<
   )[0];
 }
 
+function normalizeBooleanSchema<S extends StrictRJSFSchema = RJSFSchema>(schema: S | boolean): S {
+  return (typeof schema === 'boolean' ? (schema ? {} : { not: {} }) : schema) as S;
+}
+
 /** Resolves a conditional block (if/else/then) by removing the condition and merging the appropriate conditional branch
  * with the rest of the schema. If `expandAllBranches` is true, then the `retrieveSchemaInteral()` results for both
  * conditions will be returned.
@@ -101,13 +105,6 @@ export function resolveCondition<T = any, S extends StrictRJSFSchema = RJSFSchem
   experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>,
 ): S[] {
   const { if: expression, then, else: otherwise, ...resolvedSchemaLessConditional } = schema;
-
-  const convertBooleanSchema = (branch: S | boolean | undefined): S | undefined => {
-    if (branch === undefined) {
-      return undefined;
-    }
-    return (typeof branch === 'boolean' ? (branch ? {} : { not: {} }) : branch) as S;
-  };
 
   const conditionValue = validator.isValid(expression as S, formData || ({} as T), rootSchema);
   let resolvedSchemas = [resolvedSchemaLessConditional as S];
@@ -142,8 +139,9 @@ export function resolveCondition<T = any, S extends StrictRJSFSchema = RJSFSchem
       );
     }
   } else {
-    const conditionalSchema = convertBooleanSchema((conditionValue ? then : otherwise) as S | boolean | undefined);
-    if (conditionalSchema) {
+    const conditionalBranch = (conditionValue ? then : otherwise) as S | boolean | undefined;
+    if (conditionalBranch !== undefined) {
+      const conditionalSchema = normalizeBooleanSchema<S>(conditionalBranch);
       schemas = schemas.concat(
         retrieveSchemaInternal<T, S, F>(
           validator,
@@ -764,7 +762,7 @@ export function relaxOptionsForScoring<S extends StrictRJSFSchema = RJSFSchema>(
 ): S[] {
   return options.map((d) => {
     if (!isObject(d)) {
-      return (d ? {} : { not: {} }) as S;
+      return normalizeBooleanSchema<S>(d);
     }
     const schema = resolveRefs && rootSchema ? resolveAllReferences<S>(d, rootSchema, []) : d;
     return schema.additionalProperties === false ? { ...schema, additionalProperties: true } : schema;

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -102,15 +102,23 @@ export function resolveCondition<T = any, S extends StrictRJSFSchema = RJSFSchem
 ): S[] {
   const { if: expression, then, else: otherwise, ...resolvedSchemaLessConditional } = schema;
 
+  const convertBooleanSchema = (branch: S | boolean | undefined): S | undefined => {
+    if (branch === undefined) {
+      return undefined;
+    }
+    return (typeof branch === 'boolean' ? (branch ? {} : { not: {} }) : branch) as S;
+  };
+
   const conditionValue = validator.isValid(expression as S, formData || ({} as T), rootSchema);
   let resolvedSchemas = [resolvedSchemaLessConditional as S];
   let schemas: S[] = [];
   if (expandAllBranches) {
     if (then && typeof then !== 'boolean') {
+      const thenSchema = then as unknown as S;
       schemas = schemas.concat(
         retrieveSchemaInternal<T, S, F>(
           validator,
-          then as S,
+          thenSchema,
           rootSchema,
           formData,
           expandAllBranches,
@@ -120,10 +128,11 @@ export function resolveCondition<T = any, S extends StrictRJSFSchema = RJSFSchem
       );
     }
     if (otherwise && typeof otherwise !== 'boolean') {
+      const otherwiseSchema = otherwise as unknown as S;
       schemas = schemas.concat(
         retrieveSchemaInternal<T, S, F>(
           validator,
-          otherwise as S,
+          otherwiseSchema,
           rootSchema,
           formData,
           expandAllBranches,
@@ -133,12 +142,12 @@ export function resolveCondition<T = any, S extends StrictRJSFSchema = RJSFSchem
       );
     }
   } else {
-    const conditionalSchema = conditionValue ? then : otherwise;
-    if (conditionalSchema && typeof conditionalSchema !== 'boolean') {
+    const conditionalSchema = convertBooleanSchema((conditionValue ? then : otherwise) as S | boolean | undefined);
+    if (conditionalSchema) {
       schemas = schemas.concat(
         retrieveSchemaInternal<T, S, F>(
           validator,
-          conditionalSchema as S,
+          conditionalSchema,
           rootSchema,
           formData,
           expandAllBranches,

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -516,7 +516,7 @@ export function stubExistingAdditionalProperties<
             validator,
             { [REF_KEY]: get(schema.additionalProperties, [REF_KEY]) } as S,
             rootSchema,
-            formData as T,
+            get(formData, [key]) as T,
             experimental_customMergeAllOf,
           );
         } else if ('type' in schema.additionalProperties!) {

--- a/packages/utils/test/getTestIds.test.ts
+++ b/packages/utils/test/getTestIds.test.ts
@@ -14,12 +14,16 @@ const uniqueIdMock = vi.mocked(uniqueIdFn);
 
 describe('getTestIds', () => {
   describe('process.env.NODE_ENV === "test"', () => {
+    let oldNodeEnv: string | undefined;
     let testIds: TestIdShape;
     let fooTestId: string;
     beforeAll(() => {
+      oldNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'test';
       testIds = getTestIds();
     });
     afterAll(() => {
+      process.env.NODE_ENV = oldNodeEnv;
       uniqueIdMock.mockClear();
     });
     it('does not return an empty object', () => {

--- a/packages/utils/test/schema/retrieveSchemaTest.ts
+++ b/packages/utils/test/schema/retrieveSchemaTest.ts
@@ -1098,6 +1098,23 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
           },
         });
       });
+      it('should preserve a matched boolean false branch as an impossible schema', () => {
+        testValidator.setReturnValues({
+          isValid: [true],
+        });
+        const schema: RJSFSchema = {
+          type: 'number',
+          if: {
+            const: 13,
+          },
+          then: false,
+        };
+
+        expect(retrieveSchema(testValidator, schema, schema, 13)).toEqual({
+          type: 'number',
+          not: {},
+        });
+      });
       it('should resolve multiple conditions', () => {
         // Mock errors so that resolveCondition works as expected
         testValidator.setReturnValues({

--- a/packages/utils/test/schema/retrieveSchemaTest.ts
+++ b/packages/utils/test/schema/retrieveSchemaTest.ts
@@ -160,6 +160,72 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
         },
       });
     });
+    it('should resolve conditions in additionalProperties $ref using the additional property value', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        additionalProperties: {
+          $ref: '#/definitions/property',
+        },
+      };
+
+      const property: RJSFSchema = {
+        type: 'object',
+        properties: {
+          type: {
+            type: 'string',
+            enum: ['string', 'object'],
+          },
+        },
+        if: {
+          required: ['type'],
+          properties: {
+            type: {
+              const: 'object',
+            },
+          },
+        },
+        then: {
+          properties: {
+            properties: {
+              type: 'object',
+              additionalProperties: {
+                $ref: '#/definitions/property',
+              },
+            },
+          },
+        },
+      };
+
+      const rootSchema: RJSFSchema = { definitions: { property } };
+      const formData = {
+        newKey: {
+          type: 'object',
+        },
+      };
+
+      expect(retrieveSchema(testValidator, schema, rootSchema, formData)).toEqual({
+        ...schema,
+        properties: {
+          newKey: {
+            type: 'object',
+            properties: {
+              type: {
+                type: 'string',
+                enum: ['string', 'object'],
+              },
+              properties: {
+                type: 'object',
+                additionalProperties: {
+                  $ref: '#/definitions/property',
+                },
+              },
+            },
+            __rjsf_ref: '#/definitions/property',
+            [ADDITIONAL_PROPERTY_FLAG]: true,
+          },
+        },
+      });
+    });
     it('should `resolve` and stub out a schema which contains an `additionalProperties` with a type and definition', () => {
       const schema: RJSFSchema = {
         type: 'string',

--- a/packages/utils/test/schema/retrieveSchemaTest.ts
+++ b/packages/utils/test/schema/retrieveSchemaTest.ts
@@ -220,7 +220,7 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
                 },
               },
             },
-            __rjsf_ref: '#/definitions/property',
+            [RJSF_REF_KEY]: '#/definitions/property',
             [ADDITIONAL_PROPERTY_FLAG]: true,
           },
         },

--- a/packages/utils/test/schema/retrieveSchemaTest.ts
+++ b/packages/utils/test/schema/retrieveSchemaTest.ts
@@ -1115,6 +1115,22 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
           not: {},
         });
       });
+      it('should preserve a matched boolean true branch as an empty schema', () => {
+        testValidator.setReturnValues({
+          isValid: [true],
+        });
+        const schema: RJSFSchema = {
+          type: 'number',
+          if: {
+            const: 13,
+          },
+          then: true,
+        };
+
+        expect(retrieveSchema(testValidator, schema, schema, 13)).toEqual({
+          type: 'number',
+        });
+      });
       it('should resolve multiple conditions', () => {
         // Mock errors so that resolveCondition works as expected
         testValidator.setReturnValues({


### PR DESCRIPTION
## Summary
- convert matched boolean `if`/`then`/`else` branches to their schema equivalents during `retrieveSchema()` resolution
- add a utils regression covering `then: false`
- add a core regression proving submit is blocked when the matched branch resolves to an impossible schema

## Test plan
- `cd packages/utils && npm run build`
- `cd packages/utils && npx vitest run -c vitest.config.ts test/schema.test.ts --reporter=dot --coverage.enabled=false`
- `cd packages/validator-ajv8 && npm run build`
- `cd packages/core && npx vitest run -c vitest.config.ts test/validate.test.tsx --reporter=dot`

Closes #4528
