### PR TITLE
Fix clearing optional object with required fields

### DIFF
--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -45,6 +45,7 @@ import {
   NameGeneratorFunction,
   getUsedFormData,
   getFieldNames,
+  isValueEmpty,
   ANY_OF_KEY,
   ONE_OF_KEY,
 } from '@rjsf/utils';
@@ -885,6 +886,69 @@ export default class Form<
     return schemaUtils.omitExtraData(schema, formData);
   };
 
+  /** Removes optional object branches that became empty after their child fields were cleared. This keeps validation
+   * aligned with untouched optional objects without enabling full `omitExtraData` filtering.
+   */
+  pruneOptionalEmptyObjects = (formData?: T): T | undefined => {
+    const { schema, schemaUtils } = this.state;
+
+    const prune = (currentSchema: S, value: unknown): unknown => {
+      const resolvedSchema = schemaUtils.retrieveSchema(currentSchema, value as T);
+
+      if (Array.isArray(value)) {
+        const { items } = resolvedSchema;
+        if (!items) {
+          return value;
+        }
+        return value.map((item, index) => {
+          const itemSchema = Array.isArray(items) ? (items[index] as S) : (items as S);
+          return itemSchema ? prune(itemSchema, item) : item;
+        });
+      }
+
+      if (!isObject(value) || !isObject(resolvedSchema.properties)) {
+        return value;
+      }
+
+      const data = value as Record<string, unknown>;
+      const result: Record<string, unknown> = {};
+      const requiredFields = new Set((resolvedSchema.required ?? []) as string[]);
+
+      Object.keys(data).forEach((key) => {
+        const propertySchema = resolvedSchema.properties![key] as S | undefined;
+        const propertyValue = data[key];
+
+        if (!propertySchema || (!isObject(propertyValue) && !Array.isArray(propertyValue))) {
+          result[key] = propertyValue;
+          return;
+        }
+
+        const prunedValue = prune(propertySchema, propertyValue);
+        const effectivePropertySchema = schemaUtils.retrieveSchema(propertySchema, propertyValue as T);
+        const isFixedObject =
+          isObject(propertyValue) &&
+          isObject(effectivePropertySchema.properties) &&
+          effectivePropertySchema.additionalProperties === undefined &&
+          effectivePropertySchema.patternProperties === undefined;
+        const onlySchemaDefinedKeys =
+          isFixedObject &&
+          Object.keys(propertyValue as Record<string, unknown>).every(
+            (propertyKey) => effectivePropertySchema.properties![propertyKey],
+          );
+
+        if (!requiredFields.has(key) && isFixedObject && onlySchemaDefinedKeys && isValueEmpty(prunedValue)) {
+          return;
+        }
+
+        result[key] = prunedValue;
+      });
+
+      return result;
+    };
+
+    return prune(schema, formData) as T | undefined;
+  };
+
   /** Allows a user to set a value for the provided `fieldPath`, which must be either a dotted path to the field OR a
    * `FieldPathList`. To set the root element, used either `''` or `[]` for the path. Passing undefined will clear the
    * value in the field.
@@ -1200,9 +1264,8 @@ export default class Form<
     const { omitExtraData, extraErrors, noValidate, onSubmit } = this.props;
     let { formData: newFormData } = this.state;
 
-    if (omitExtraData === true) {
-      newFormData = this.omitExtraData(newFormData);
-    }
+    newFormData =
+      omitExtraData === true ? this.omitExtraData(newFormData) : this.pruneOptionalEmptyObjects(newFormData);
 
     if (noValidate || this.validateFormWithFormData(newFormData)) {
       // There are no errors generated through schema validation.
@@ -1389,9 +1452,8 @@ export default class Form<
   validateForm() {
     const { omitExtraData } = this.props;
     let { formData: newFormData } = this.state;
-    if (omitExtraData === true) {
-      newFormData = this.omitExtraData(newFormData);
-    }
+    newFormData =
+      omitExtraData === true ? this.omitExtraData(newFormData) : this.pruneOptionalEmptyObjects(newFormData);
     return this.validateFormWithFormData(newFormData);
   }
 

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -4472,6 +4472,40 @@ describe('omitExtraData prunes empty optional objects', () => {
   });
 });
 
+describe('optional object with required children after clearing inputs', () => {
+  const schema: RJSFSchema = {
+    type: 'object',
+    properties: {
+      test: {
+        type: 'object',
+        properties: {
+          field1: { type: 'string' },
+          field2: { type: 'string' },
+        },
+        required: ['field1', 'field2'],
+      },
+    },
+  };
+
+  it('submits without errors after the user clears all fields in an optional object', async () => {
+    const { node, onSubmit, onError } = createFormComponent({
+      schema,
+      formData: {},
+      noHtml5Validate: true,
+    });
+
+    await user.type(node.querySelector('#root_test_field1')!, 'value');
+    await user.type(node.querySelector('#root_test_field2')!, 'value');
+    await user.clear(node.querySelector('#root_test_field1')!);
+    await user.clear(node.querySelector('#root_test_field2')!);
+
+    await submitForm(node, user);
+
+    expect(onError).not.toHaveBeenCalled();
+    expectToHaveBeenCalledWithFormData(onSubmit, {}, true);
+  });
+});
+
 describe('Async errors', () => {
   it('should render the async errors', () => {
     const schema: RJSFSchema = {


### PR DESCRIPTION
## Summary
- prune optional object branches that become empty after users clear their child fields
- preserve `omitExtraData` behavior when it is explicitly enabled
- add a regression test for clearing all fields in an optional object with required children

Fixes #4483.

## Validation
Commands rerun locally from `packages/core`:
- `npm test -- Form.test.tsx`
  - Result: 1 file passed, 675 tests passed. Reran after commit hook formatting.
- `npm run cs-check`
  - Result: passed; all matched files use the correct format.
- `npm run lint`
  - Result: exited 0 with existing `typescript(no-var-requires)` warnings in `test/validate.test.tsx` and `test/Form.test.tsx`.
- `npm run build`
  - Result: exited 0; Rollup emitted existing external/global/export warnings while producing the UMD bundle.

## PR branch update
- Rebasing follow-up: updated `nkgotcode:codex/fix-optional-object-clearing` onto `rjsf-team/react-jsonschema-form@bd1a1aa` from a separate clean worktree to avoid unrelated OSS-35/39 local changes.
- Current PR head: `b88569f132406dcfe5f4188757abfc4fd9a4b645`.

Additional commands rerun for this update:
- `npm install` from the clean worktree root
  - Result: exited 0; emitted `EBADENGINE` warning for `lint-staged@17.0.5` requiring Node `>=22.22.1` while runtime was `v22.22.0`, plus npm audit output.
- `npm test -- Form.test.tsx` from `packages/core` before dependency workspace builds
  - Result: failed before tests because fresh workspace packages such as `@rjsf/utils` were not built.
- `npm run build -w @rjsf/utils -w @rjsf/validator-ajv8` from the clean worktree root
  - Result: exited 0; Rollup emitted external/global/export warnings while building workspace dependencies.
- `npm test -- Form.test.tsx` from `packages/core` after dependency workspace builds
  - Result: 1 file passed, 675 tests passed.