### PR TITLE
Fix MUI null field title rendering

### DIFF
--- a/packages/mui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/mui/src/FieldTemplate/FieldTemplate.tsx
@@ -1,4 +1,5 @@
 import FormControl, { FormControlProps } from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import {
   FieldTemplateProps,
@@ -68,6 +69,7 @@ export default function FieldTemplate<
   }
 
   const isCheckbox = uiOptions.widget === 'checkbox';
+  const isNullField = schema.type === 'null';
 
   const { rjsfSlotProps: muiSlotProps, ...otherMuiProps } = getMuiProps<T, S, F, FieldTemplateMuiProps>(uiOptions);
 
@@ -97,6 +99,11 @@ export default function FieldTemplate<
         sx={otherMuiProps.sx}
         className={otherMuiProps.className}
       >
+        {displayLabel && !isCheckbox && isNullField && label ? (
+          <FormLabel id={`${id}__title`} required={required}>
+            {label}
+          </FormLabel>
+        ) : null}
         {children}
         {displayLabel && !isCheckbox && rawDescription ? (
           <Typography variant='caption' color='textSecondary' {...muiSlotProps?.fieldTypography}>

--- a/packages/mui/test/MuiProps.test.tsx
+++ b/packages/mui/test/MuiProps.test.tsx
@@ -1,7 +1,7 @@
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
 import '@testing-library/jest-dom';
 import validator from '@rjsf/validator-ajv8';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import Form from '../src';
 
@@ -97,5 +97,18 @@ describe('MUI Theme-Specific Props', () => {
 
     const select = container.querySelector('.MuiFilledInput-root');
     expect(select).toBeInTheDocument();
+  });
+
+  it('should render a title for null fields without losing the description', () => {
+    const schema: RJSFSchema = {
+      type: 'null',
+      title: 'My title extra info',
+      description: 'My extra info description',
+    };
+
+    render(<Form schema={schema} validator={validator} />);
+
+    expect(screen.getByText('My title extra info')).toBeInTheDocument();
+    expect(screen.getByText('My extra info description')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- render the title for MUI null fields using `FormLabel` so title text is not dropped
- keep the existing description rendering below the field content
- add MUI regression coverage for a null schema with both title and description

Fixes #4110.

## Validation
Clean packaging branch/worktree: `/tmp/rjsf-oss57-clean` from `rjsf-team/react-jsonschema-form@bd1a1aa8e78185cffb6222a7c06e051eb3c096ce`.

Diff check before commit:
- `git diff --name-only`
  - Result: exactly `packages/mui/src/FieldTemplate/FieldTemplate.tsx` and `packages/mui/test/MuiProps.test.tsx`.

Commands rerun locally:
- `npm install`
  - Result: exited 0; emitted `EBADENGINE` warning for `lint-staged@17.0.5` requiring Node `>=22.22.1` while runtime was `v22.22.0`, plus npm audit output.
- `npm --workspace @rjsf/mui test -- MuiProps.test.tsx` before dependency workspace builds
  - Result: failed before tests because fresh workspace packages such as `@rjsf/validator-ajv8` were not built.
- `npm --workspace @rjsf/mui run lint`
  - Result: exited 0.
- `npm run build -w @rjsf/utils -w @rjsf/core -w @rjsf/validator-ajv8`
  - Result: exited 0; Rollup emitted external/global/export warnings while building workspace dependencies.
- `npm --workspace @rjsf/mui test -- MuiProps.test.tsx` after dependency workspace builds
  - Result: 1 file passed, 5 tests passed.
- Post-commit `npm --workspace @rjsf/mui test -- MuiProps.test.tsx`
  - Result: 1 file passed, 5 tests passed.
- Post-commit `npm --workspace @rjsf/mui run lint`
  - Result: exited 0.