### PR TITLE
fix(antd): fix DateWidget/DateTimeWidget popup positioning in playground

### DIFF
--- a/packages/antd/src/widgets/DateTimeWidget/index.tsx
+++ b/packages/antd/src/widgets/DateTimeWidget/index.tsx
@@ -1,14 +1,9 @@
-import type { FormContextType, GenericObjectType, RJSFSchema, StrictRJSFSchema, WidgetProps } from '@rjsf/utils';
-import { ariaDescribedByIds } from '@rjsf/utils';
-import { DatePicker } from 'antd';
-import dayjs from 'dayjs';
+import type { FormContextType, RJSFSchema, StrictRJSFSchema, WidgetProps } from '@rjsf/utils';
 
-const DATE_PICKER_STYLE = {
-  width: '100%',
-};
+import DateWidget from '../DateWidget';
 
-/** The `DateTimeWidget` component uses the `BaseInputTemplate` changing the type to `datetime-local` and transforms
- * the value to/from utc using the appropriate utility functions.
+/** The `DateTimeWidget` component uses the `DateWidget` with `showTime` enabled, transforming
+ * the value to/from ISO string format.
  *
  * @param props - The `WidgetProps` for this component
  */
@@ -17,32 +12,5 @@ export default function DateTimeWidget<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: WidgetProps<T, S, F>) {
-  const { disabled, registry, id, onBlur, onChange, onFocus, placeholder, readonly, value } = props;
-  const { formContext } = registry;
-  const { readonlyAsDisabled = true } = formContext as GenericObjectType;
-
-  const handleChange = (nextValue: any) => onChange(nextValue && nextValue.toISOString());
-
-  const handleBlur = () => onBlur(id, value);
-
-  const handleFocus = () => onFocus(id, value);
-
-  const getPopupContainer = (node: any) => node.parentNode;
-
-  return (
-    <DatePicker
-      disabled={disabled || (readonlyAsDisabled && readonly)}
-      getPopupContainer={getPopupContainer}
-      id={id}
-      name={id}
-      onBlur={!readonly ? handleBlur : undefined}
-      onChange={!readonly ? handleChange : undefined}
-      onFocus={!readonly ? handleFocus : undefined}
-      placeholder={placeholder}
-      showTime
-      style={DATE_PICKER_STYLE}
-      value={value && dayjs(value)}
-      aria-describedby={ariaDescribedByIds(id)}
-    />
-  );
+  return <DateWidget showTime {...props} />;
 }

--- a/packages/antd/src/widgets/DateWidget/index.tsx
+++ b/packages/antd/src/widgets/DateWidget/index.tsx
@@ -7,25 +7,38 @@ const DATE_PICKER_STYLE = {
   width: '100%',
 };
 
+type DateWidgetProps<T, S extends StrictRJSFSchema, F extends FormContextType> = WidgetProps<T, S, F> & {
+  showTime?: boolean;
+};
+
 /** The `DateWidget` component uses the `BaseInputTemplate` changing the type to `date` and transforms
  * the value to undefined when it is falsy during the `onChange` handling.
  *
  * @param props - The `WidgetProps` for this component
  */
-export default function DateWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
-  props: WidgetProps<T, S, F>,
-) {
-  const { disabled, registry, id, onBlur, onChange, onFocus, placeholder, readonly, value } = props;
+export default function DateWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>({
+  disabled,
+  registry,
+  id,
+  onBlur,
+  onChange,
+  onFocus,
+  placeholder,
+  readonly,
+  value,
+  showTime = false,
+}: DateWidgetProps<T, S, F>) {
   const { formContext } = registry;
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 
-  const handleChange = (nextValue: any) => onChange(nextValue && nextValue.format('YYYY-MM-DD'));
+  const handleChange = (nextValue: any) =>
+    onChange(nextValue && (showTime ? nextValue.toISOString() : nextValue.format('YYYY-MM-DD')));
 
   const handleBlur = () => onBlur(id, value);
 
   const handleFocus = () => onFocus(id, value);
 
-  const getPopupContainer = (node: any) => node.parentNode;
+  const getPopupContainer = DateWidget.getPopupContainerCallback();
 
   return (
     <DatePicker
@@ -37,10 +50,16 @@ export default function DateWidget<T = any, S extends StrictRJSFSchema = RJSFSch
       onChange={!readonly ? handleChange : undefined}
       onFocus={!readonly ? handleFocus : undefined}
       placeholder={placeholder}
-      showTime={false}
+      showTime={showTime}
       style={DATE_PICKER_STYLE}
       value={value && dayjs(value)}
       aria-describedby={ariaDescribedByIds(id)}
     />
   );
 }
+
+/** Give the playground a place to hook into the `getPopupContainer` callback generation function so that it can be
+ * disabled while in the playground. Since the callback is a simple function, it can be returned by this static
+ * "generator" function.
+ */
+DateWidget.getPopupContainerCallback = () => (node: any) => node.parentNode;

--- a/packages/playground/src/components/DemoFrame.tsx
+++ b/packages/playground/src/components/DemoFrame.tsx
@@ -87,6 +87,14 @@ function AntdPopupPatcher({ frameDoc }: { frameDoc: Document }) {
 
       const trigger = frameDoc.querySelector(triggerSelector) as HTMLElement | null;
       if (!trigger) {
+        // The popup is still visible but the trigger's open class is already gone — it's in the
+        // process of closing. Restore our last known position so it doesn't flash to (0, 0)
+        // during the close animation while antd resets its own inset before hiding the element.
+        const lastInset = ourInsets.get(popup);
+        if (lastInset !== undefined && popup.style.inset !== lastInset) {
+          popup.style.position = 'absolute';
+          popup.style.inset = lastInset;
+        }
         return;
       }
 

--- a/packages/playground/src/components/DemoFrame.tsx
+++ b/packages/playground/src/components/DemoFrame.tsx
@@ -17,14 +17,17 @@ import Frame, { FrameContextConsumer } from 'react-frame-component';
 
 const DEMO_FRAME_JSS = 'demo-frame-jss';
 
-const { SelectWidget } = Widgets;
+const { SelectWidget, DateWidget } = Widgets;
 
-// Override the static function on the antd `SelectWidget` so that we can "disable" the getPopupContainer callback
+// Override the static functions on the antd widgets so that we can "disable" the getPopupContainer callback
 // function because, when it is active, the `SelectPatcher` code below along with the `ConfigProvider` for the antd
-// theme conditional branch won't take effect as the antd `Select` `getPopupContainer()` supercedes it, so we make it
+// theme conditional branch won't take effect as the antd component `getPopupContainer()` supercedes it, so we make it
 // return undefined to disable it.
 // @ts-expect-error TS2339 because the Widget interface doesn't have the static function on it
 SelectWidget.getPopupContainerCallback = () => undefined;
+// @ts-expect-error TS2339 because the Widget interface doesn't have the static function on it
+// DateWidget also covers DateTimeWidget since it delegates to DateWidget internally
+DateWidget.getPopupContainerCallback = () => undefined;
 
 /*
 Adapted from https://github.com/mui-org/material-ui/blob/master/docs/src/modules/components/DemoSandboxed.js
@@ -52,88 +55,99 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-/** This is a hack to fix the antd `SelectWidget` so that the popup works properly within the iframe of the playground.
- * It basically observes when the `antd-select-dropdown` is created and attaches a dropdown positioning callback that is
- * tracking the scrolling of the iFrome document and fixing up the dropdown's `inset` style attribute so that it is
- * positioned properly.
+/** This is a hack to fix antd popups (Select dropdown, DatePicker panel) so they work properly within the iframe of
+ * the playground. The root issue is that antd's positioning code runs two passes: first it places the popup at
+ * `-1000vh` to measure it, then calculates a final position. We need to override BOTH passes — not just the first —
+ * because antd's final calculation uses `window.scrollY` from the parent window context (since react-frame-component
+ * runs JS in the parent window), while `getBoundingClientRect()` returns iframe-relative coordinates. This mismatch
+ * puts the popup in the wrong place when the iframe is scrolled.
+ *
+ * Strategy: observe every style change on popup elements and always reapply the correct position using the iframe's
+ * own scroll offsets. A WeakMap tracks the inset value we last set so we can skip our own changes and avoid infinite
+ * observer loops.
  *
  * @param frameDoc - The iFrame document of the playground
  */
-function AntdSelectPatcher({ frameDoc }: { frameDoc: Document }) {
+function AntdPopupPatcher({ frameDoc }: { frameDoc: Document }) {
   useEffect(() => {
     if (!frameDoc) {
       return;
     }
 
-    const handleDropdownPositioning = (dropdown: HTMLElement) => {
-      const { style } = dropdown;
+    // Maps each popup element to the inset string we last wrote, so we can skip our own style changes.
+    const ourInsets = new WeakMap<HTMLElement, string>();
 
-      // Check if dropdown needs repositioning
-      const isHidden = style.inset && style.inset.includes('-1000vh');
-      if (isHidden) {
-        const trigger = frameDoc.querySelector('.ant-select-focused, .ant-select-open');
+    const correctPosition = (popup: HTMLElement, triggerSelector: string) => {
+      if (
+        popup.classList.contains('ant-select-dropdown-hidden') ||
+        popup.classList.contains('ant-picker-dropdown-hidden')
+      ) {
+        return;
+      }
 
-        if (trigger) {
-          const rect = trigger.getBoundingClientRect();
-          // Get scroll offsets
-          const scrollTop = frameDoc.documentElement.scrollTop || frameDoc.body.scrollTop;
-          const scrollLeft = frameDoc.documentElement.scrollLeft || frameDoc.body.scrollLeft;
+      const trigger = frameDoc.querySelector(triggerSelector) as HTMLElement | null;
+      if (!trigger) {
+        return;
+      }
 
-          // Calculate absolute position accounting for scroll
-          const top = rect.bottom + scrollTop + 4;
-          const left = rect.left + scrollLeft;
+      const rect = trigger.getBoundingClientRect();
+      const scrollTop = frameDoc.documentElement.scrollTop || frameDoc.body.scrollTop;
+      const scrollLeft = frameDoc.documentElement.scrollLeft || frameDoc.body.scrollLeft;
 
-          // Position the dropdown BELOW the select
-          dropdown.style.inset = `${top}px auto auto ${left}px`;
-          dropdown.style.position = 'absolute';
-        }
+      const inset = `${rect.bottom + scrollTop + 4}px auto auto ${rect.left + scrollLeft}px`;
+      ourInsets.set(popup, inset);
+      popup.style.position = 'absolute';
+      popup.style.inset = inset;
+      popup.style.minWidth = `${rect.right - rect.left}px`;
+    };
+
+    const handleElement = (el: HTMLElement) => {
+      // Skip changes that we ourselves made (prevents infinite observer loop).
+      if (ourInsets.has(el) && el.style.inset === ourInsets.get(el)) {
+        return;
+      }
+      if (el.classList.contains('ant-select-dropdown')) {
+        correctPosition(el, '.ant-select-focused, .ant-select-open');
+      } else if (el.classList.contains('ant-picker-dropdown')) {
+        correctPosition(el, '.ant-picker-focused, .ant-picker-open');
       }
     };
 
-    const createObserver = () =>
-      new MutationObserver((mutations) => {
-        mutations.forEach((mutation) => {
-          if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
-            const dropdown = mutation.target as HTMLElement;
-
-            if (dropdown.classList.contains('ant-select-dropdown')) {
-              handleDropdownPositioning(dropdown);
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+          handleElement(mutation.target as HTMLElement);
+        }
+        if (mutation.type === 'childList') {
+          mutation.addedNodes.forEach((node) => {
+            if (node.nodeType === 1) {
+              handleElement(node as HTMLElement);
             }
-          }
-
-          // Also check for newly added dropdowns
-          if (mutation.type === 'childList') {
-            mutation.addedNodes.forEach((node) => {
-              if (node.nodeType === 1) {
-                const element = node as HTMLElement;
-                if (element.classList.contains('ant-select-dropdown')) {
-                  handleDropdownPositioning(element);
-                }
-              }
-            });
-          }
-        });
+          });
+        }
       });
+    });
 
-    // Observe iframe document
-    const iframeObserver = createObserver();
-    iframeObserver.observe(frameDoc.body, {
+    observer.observe(frameDoc.body, {
       childList: true,
       subtree: true,
       attributes: true,
       attributeFilter: ['style', 'class'],
     });
 
-    // Also reposition on scroll
+    // Reposition visible popups on scroll so they track the trigger element.
     const handleScroll = () => {
-      const dropdowns = frameDoc.querySelectorAll('.ant-select-dropdown:not(.ant-select-dropdown-hidden)');
-      dropdowns.forEach((dropdown) => {
-        handleDropdownPositioning(dropdown as HTMLElement);
-      });
+      frameDoc
+        .querySelectorAll<HTMLElement>('.ant-select-dropdown:not(.ant-select-dropdown-hidden)')
+        .forEach((el) => correctPosition(el, '.ant-select-focused, .ant-select-open'));
+      frameDoc
+        .querySelectorAll<HTMLElement>('.ant-picker-dropdown:not(.ant-picker-dropdown-hidden)')
+        .forEach((el) => correctPosition(el, '.ant-picker-focused, .ant-picker-open'));
     };
     frameDoc.addEventListener('scroll', handleScroll, true);
+
     return () => {
-      iframeObserver.disconnect();
+      observer.disconnect();
       frameDoc.removeEventListener('scroll', handleScroll, true);
     };
   }, [frameDoc]);
@@ -196,7 +210,7 @@ export default function DemoFrame(props: DemoFrameProps) {
             frameDoc?.getElementById(DEMO_FRAME_JSS) || instanceRef.current.contentWindow[DEMO_FRAME_JSS];
           return (
             <>
-              <AntdSelectPatcher frameDoc={frameDoc || instanceRef.current.contentDocument} />
+              <AntdPopupPatcher frameDoc={frameDoc || instanceRef.current.contentDocument} />
               <AntdStyleProvider container={jssContainer}>
                 <ConfigProvider getPopupContainer={() => jssContainer.parentElement}>{children}</ConfigProvider>
               </AntdStyleProvider>


### PR DESCRIPTION
### Reasons for making this change
Fixes #4305 by expanding and improving the playground fix for antd's `SelectWidget` to the `DateWidget` as well

- Refactor `DateWidget` to use the same static `getPopupContainerCallback` pattern as `SelectWidget`, accepting an optional `showTime` prop that controls both the picker mode and the value format (ISO string vs YYYY-MM-DD)
- Simplify `DateTimeWidget` to a thin wrapper over `DateWidget` with `showTime={true}`, mirroring the AltDateTimeWidget → AltDateWidget pattern
- Override `DateWidget.getPopupContainerCallback` in the playground's `DemoFrame` so the `ConfigProvider` popup container takes effect (same treatment already applied to `SelectWidget`)
- Rename `AntdSelectPatcher` → `AntdPopupPatcher` and fix its core positioning bug: the patcher previously only corrected the initial `-1000vh` hidden pass, letting antd's second (final) positioning pass win with wrong coordinates. Now every style change on a popup element is corrected; a `WeakMap` tracks values we wrote so the observer skips our own changes and avoids infinite loops. Extends coverage to `ant-picker-dropdown` for DatePicker/DateTimeWidget.


### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature


https://github.com/user-attachments/assets/c7fb4acf-904b-41f7-8c91-4e017aa0a670


