### PR TITLE
Fix selected oneOf option descriptions

### DIFF
--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -17,12 +17,14 @@ import {
   ADDITIONAL_PROPERTY_FLAG,
   ANY_OF_KEY,
   descriptionId,
+  enumOptionsIndexForValue,
   getSchemaType,
   getTemplate,
   getUiOptions,
   ID_KEY,
   isFormDataAvailable,
   ONE_OF_KEY,
+  optionsList,
   resolveUiSchema,
   shouldRender,
   shouldRenderOptionalField,
@@ -84,6 +86,24 @@ function getFieldComponent<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   }
 
   return componentName in fields ? fields[componentName] : fields['FallbackField'];
+}
+
+function getSelectedOptionDescription<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+>(schema: S, uiSchema: FieldProps<T, S, F>['uiSchema'], formData: T | undefined) {
+  if (!schema.oneOf && !schema.anyOf) {
+    return undefined;
+  }
+
+  const enumOptions = optionsList<T, S, F>(schema, uiSchema);
+  const selectedIndex = enumOptionsIndexForValue<S>(formData, enumOptions);
+  if (typeof selectedIndex !== 'string') {
+    return undefined;
+  }
+
+  return enumOptions?.[Number(selectedIndex)]?.schema?.description;
 }
 
 /** The `SchemaFieldRender` component is the work-horse of react-jsonschema-form, determining what kind of real field to
@@ -226,8 +246,13 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
     label = registry.translateString(TranslatableString.DeprecatedLabel, [label]);
   }
 
-  const description = uiOptions.description || props.schema.description || schema.description || '';
-  const { help } = uiOptions;
+  const selectedOptionDescription =
+    schemaUtils.isSelect(schema) && !XxxOfField
+      ? getSelectedOptionDescription<T, S, F>(schema, uiSchema, formData)
+      : '';
+  const description =
+    uiOptions.description || props.schema.description || schema.description || selectedOptionDescription || '';
+  const help = uiOptions.help;
   const hidden = uiOptions.widget === 'hidden' || deprecatedHandling === 'hide';
 
   const classNames = ['rjsf-field', `rjsf-field-${getSchemaType(schema)}`];

--- a/packages/core/test/oneOf.test.tsx
+++ b/packages/core/test/oneOf.test.tsx
@@ -89,6 +89,44 @@ describe('oneOf', () => {
     expect(node.querySelectorAll('span.required')).toHaveLength(2);
   });
 
+  it('should render the selected oneOf const option description for select fields', async () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        dessert: {
+          type: 'string',
+          oneOf: [
+            {
+              const: 'vanilla',
+              title: 'Vanilla',
+              description: 'Classic vanilla bean description should render for vanilla',
+            },
+            {
+              const: 'chocolate',
+              title: 'Chocolate',
+              description: 'Dark chocolate description should render for chocolate',
+            },
+          ],
+        },
+      },
+    };
+
+    const { node } = createFormComponent({
+      schema,
+      formData: { dessert: 'vanilla' },
+    });
+    const select = node.querySelector('#root_dessert') as HTMLSelectElement;
+
+    expect([...select.options].map((option) => option.textContent)).toEqual(['', 'Vanilla', 'Chocolate']);
+    expect(node).toHaveTextContent('Classic vanilla bean description should render for vanilla');
+    expect(node).not.toHaveTextContent('Dark chocolate description should render for chocolate');
+
+    await user.selectOptions(select, '1');
+
+    expect(node).not.toHaveTextContent('Classic vanilla bean description should render for vanilla');
+    expect(node).toHaveTextContent('Dark chocolate description should render for chocolate');
+  });
+
   it('should assign a default value and set defaults on option change', async () => {
     const { node, onChange } = createFormComponent({
       schema: {


### PR DESCRIPTION
## Summary

- render the selected `oneOf`/`anyOf` option description for select-backed schemas when there is no explicit field or parent description
- reuse existing option metadata from `optionsList` and the current selected enum index
- add a regression test for selected `oneOf` const option descriptions, including selection changes

Fixes #4214.

## Validation

- `npm --workspace @rjsf/core test -- oneOf.test.tsx` -> 1 test file passed, 48 tests passed
- Prior independent validation from OSS-100: `npm --workspace @rjsf/core run cs-check` passed
- Prior independent validation from OSS-100: `npm --workspace @rjsf/core run lint` passed with existing `typescript(no-var-requires)` warnings in `test/validate.test.tsx:462:35` and `test/Form.test.tsx:3588:33`
