### PR TITLE
[codex] Fix dependentRequired title-aware errors

### DIFF
--- a/packages/validator-ajv8/src/processRawValidationErrors.ts
+++ b/packages/validator-ajv8/src/processRawValidationErrors.ts
@@ -24,6 +24,22 @@ import get from 'lodash/get';
 
 import type { SuppressDuplicateFilteringType } from './types';
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function replacePropertyName(message: string, propertyName: string, title: string) {
+  const quotedProperty = `'${propertyName}'`;
+  if (message.includes(quotedProperty)) {
+    return message.replace(quotedProperty, `'${title}'`);
+  }
+
+  return message.replace(
+    new RegExp(`(^|[^\\w'])${escapeRegExp(propertyName)}(?=$|[^\\w'])`),
+    (_, prefix) => `${prefix}${title}`,
+  );
+}
+
 export interface RawValidationErrorsType<Result = any> {
   errors?: Result[];
   validationError?: Error;
@@ -111,12 +127,12 @@ export function transformRJSFValidationErrors<
           uiSchemaTitle = getUiOptions(get(uiSchema, uiSchemaPath)).title;
         }
         if (uiSchemaTitle) {
-          message = message.replace(`'${currentProperty}'`, `'${uiSchemaTitle}'`);
+          message = replacePropertyName(message, currentProperty, uiSchemaTitle);
           uiTitle = uiSchemaTitle;
         } else {
           const parentSchemaTitle = get(parentSchema, [PROPERTIES_KEY, currentProperty, 'title']);
           if (parentSchemaTitle) {
-            message = message.replace(`'${currentProperty}'`, `'${parentSchemaTitle}'`);
+            message = replacePropertyName(message, currentProperty, parentSchemaTitle);
             uiTitle = parentSchemaTitle;
           }
         }

--- a/packages/validator-ajv8/test/validator.test.ts
+++ b/packages/validator-ajv8/test/validator.test.ts
@@ -2376,6 +2376,73 @@ describe('AJV8Validator', () => {
         });
       });
     });
+    describe('validating dependencies without localizer', () => {
+      beforeAll(() => {
+        validator = new AJV8Validator({ AjvClass: Ajv2019 });
+      });
+      it('should return an error with title when a dependent is missing', () => {
+        schema = {
+          type: 'object',
+          properties: {
+            creditCard: {
+              type: 'number',
+              title: 'Credit card',
+            },
+            billingAddress: {
+              type: 'string',
+              title: 'Billing address',
+            },
+          },
+          dependentRequired: {
+            creditCard: ['billingAddress'],
+          },
+        };
+        const errors = validator.validateFormData({ creditCard: 1234567890 }, schema);
+        const errMessage = 'must have property Billing address when property Credit card is present';
+        expect(errors.errors[0].message).toEqual(errMessage);
+        expect(errors.errors[0].stack).toEqual(errMessage);
+        expect(errors.errorSchema).toEqual({
+          billingAddress: {
+            __errors: [errMessage],
+          },
+        });
+        expect(errors.errors[0].params.deps).toEqual('billingAddress');
+      });
+      it('should return an error with uiSchema title when a dependent is missing', () => {
+        schema = {
+          type: 'object',
+          properties: {
+            creditCard: {
+              type: 'number',
+            },
+            billingAddress: {
+              type: 'string',
+            },
+          },
+          dependentRequired: {
+            creditCard: ['billingAddress'],
+          },
+        };
+        const uiSchema: UiSchema = {
+          creditCard: {
+            'ui:title': 'uiSchema Credit card',
+          },
+          billingAddress: {
+            'ui:title': 'uiSchema Billing address',
+          },
+        };
+        const errors = validator.validateFormData({ creditCard: 1234567890 }, schema, undefined, undefined, uiSchema);
+        const errMessage = 'must have property uiSchema Billing address when property uiSchema Credit card is present';
+        expect(errors.errors[0].message).toEqual(errMessage);
+        expect(errors.errors[0].stack).toEqual(errMessage);
+        expect(errors.errorSchema).toEqual({
+          billingAddress: {
+            __errors: [errMessage],
+          },
+        });
+        expect(errors.errors[0].params.deps).toEqual('billingAddress');
+      });
+    });
     describe('validating dependencies', () => {
       beforeAll(() => {
         validator = new AJV8Validator({ AjvClass: Ajv2019 }, localize.en as Localizer);


### PR DESCRIPTION
## Summary

Fixes title-aware error message replacement for Ajv2019 `dependentRequired` validation errors when no localizer is configured.

The raw Ajv message for `dependentRequired` can include unquoted property names, so the existing quoted-only replacement updated neither the missing dependent property nor the triggering property in that path. This adds a property-name replacement helper that handles both quoted and unquoted forms while preserving the raw error schema keys and Ajv params.

## Tests

- `npm run build:ts --workspace @rjsf/utils`
- `npm run cs-check --workspace @rjsf/validator-ajv8`
- `npm run lint --workspace @rjsf/validator-ajv8`
- `npm test --workspace @rjsf/validator-ajv8` (10 files / 2516 tests)
