### PR TITLE
Fix additionalItems add for empty tuple arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
+- Fixed array fields with empty tuple `items` and schema-valued `additionalItems` so clicking add renders the additional item field, fixing [#3791](https://github.com/rjsf-team/react-jsonschema-form/issues/3791)
 - Fixed [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907) and [#4262](https://github.com/rjsf-team/react-jsonschema-form/issues/4262) as follows:
   - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
-  - Added `CyclicSchemaField` to the list of fields, that renders the `CyclicSchemaExpandTemplate` initially and, if expanded, will render the `SchemaField` with the `RJSF_REF_CYCLE_KEY` tag turned off  
+  - Added `CyclicSchemaField` to the list of fields, that renders the `CyclicSchemaExpandTemplate` initially and, if expanded, will render the `SchemaField` with the `RJSF_REF_CYCLE_KEY` tag turned off
   - Updated `SchemaForm` to render the `CyclicSchemaField` when the schema contains the `RJSF_REF_CYCLE_KEY` set to `true`
 
 ## @rjsf/daisyui
@@ -68,6 +69,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
+- Updated `isFixedItems()` to treat empty tuple `items` arrays as fixed items so `additionalItems` schemas are handled consistently, fixing [#3791](https://github.com/rjsf-team/react-jsonschema-form/issues/3791)
 - Updated `types.ts` to add `CyclicSchemaExpandProps` type and `CyclicSchemaExpandTemplate` in the `TemplatesType`
 - Updated `resolveAllReferences()` to add a new `markCycleOnDetection` prop which adds `RJSF_REF_CYCLE_KEY` marker (from `constants.ts`) to a schema that has been detected to have a cycle, partially fixing [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907)
 - Updated `hashForSchema()` to filter keys to remove `RJSF_REF_KEY` prefixed keys before hashing the schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,6 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
-- Fixed array fields with empty tuple `items` and schema-valued `additionalItems` so clicking add renders the additional item field, fixing [#3791](https://github.com/rjsf-team/react-jsonschema-form/issues/3791)
 - Fixed schema-change handling so dependent enum updates sanitize invalid scalar field data without over-sanitizing root, object, array, readonly, or disabled field changes, fixing [#3838](https://github.com/rjsf-team/react-jsonschema-form/issues/3838)
 - Updated `Form` tests to verify fix for [#1357](https://github.com/rjsf-team/react-jsonschema-form/issues/1357) and [#2492](https://github.com/rjsf-team/react-jsonschema-form/issues/2492)
   - Also added `console` message suppression support to the tests to reduce noise
@@ -95,7 +94,6 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
-- Updated `isFixedItems()` to treat empty tuple `items` arrays as fixed items so `additionalItems` schemas are handled consistently, fixing [#3791](https://github.com/rjsf-team/react-jsonschema-form/issues/3791)
 - Updated `sanitizeDataForNewSchema()` to preserve valid enum values while replacing or clearing stale values across enum, `oneOf`, and `anyOf` schema changes, fixing [#3838](https://github.com/rjsf-team/react-jsonschema-form/issues/3838)
 - Updated `sanitizeDataForNewSchema()` to filter out invalid enum values in arrays, fixing [#1357](https://github.com/rjsf-team/react-jsonschema-form/issues/1357) and [#2492](https://github.com/rjsf-team/react-jsonschema-form/issues/2492)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
+- Fixed array fields with empty tuple `items` and schema-valued `additionalItems` so clicking add renders the additional item field, fixing [#3791](https://github.com/rjsf-team/react-jsonschema-form/issues/3791)
 - Fixed schema-change handling so dependent enum updates sanitize invalid scalar field data without over-sanitizing root, object, array, readonly, or disabled field changes, fixing [#3838](https://github.com/rjsf-team/react-jsonschema-form/issues/3838)
 - Updated `Form` tests to verify fix for [#1357](https://github.com/rjsf-team/react-jsonschema-form/issues/1357) and [#2492](https://github.com/rjsf-team/react-jsonschema-form/issues/2492)
   - Also added `console` message suppression support to the tests to reduce noise
@@ -92,6 +93,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
+- Updated `isFixedItems()` to treat empty tuple `items` arrays as fixed items so `additionalItems` schemas are handled consistently, fixing [#3791](https://github.com/rjsf-team/react-jsonschema-form/issues/3791)
 - Updated `sanitizeDataForNewSchema()` to preserve valid enum values while replacing or clearing stale values across enum, `oneOf`, and `anyOf` schema changes, fixing [#3838](https://github.com/rjsf-team/react-jsonschema-form/issues/3838)
 - Updated `sanitizeDataForNewSchema()` to filter out invalid enum values in arrays, fixing [#1357](https://github.com/rjsf-team/react-jsonschema-form/issues/1357) and [#2492](https://github.com/rjsf-team/react-jsonschema-form/issues/2492)
 

--- a/packages/core/test/ArrayField.test.tsx
+++ b/packages/core/test/ArrayField.test.tsx
@@ -1940,6 +1940,38 @@ describe('ArrayField', () => {
     });
 
     describe('operations for additional items', () => {
+      it('should add a field when clicking add button for empty fixed items', async () => {
+        const schema: RJSFSchema = {
+          type: 'array',
+          title: 'List of additional items',
+          items: [],
+          additionalItems: {
+            type: 'string',
+            title: 'Additional item',
+          },
+        };
+        const templates = {
+          ArrayFieldTemplate: ExposedArrayKeyTemplate,
+          ArrayFieldItemTemplate: ExposedArrayKeyItemTemplate,
+        };
+        const { node, onChange, rerender } = createFormComponent({
+          schema,
+          templates,
+        });
+
+        const addBtn = node.querySelector('.rjsf-array-item-add button');
+
+        expect(addBtn).not.toBeNull();
+
+        await user.click(addBtn!);
+
+        expectToHaveBeenCalledWithFormData(onChange, [undefined], 'root');
+
+        rerender({ schema, formData: [undefined], templates });
+
+        expect(node.querySelectorAll('.rjsf-field-string')).toHaveLength(1);
+      });
+
       it('should add a field when clicking add button', async () => {
         const { node, onChange } = createFormComponent({
           schema: schemaAdditional,

--- a/packages/utils/src/isFixedItems.ts
+++ b/packages/utils/src/isFixedItems.ts
@@ -1,12 +1,12 @@
 import isObject from './isObject';
 import type { RJSFSchema, StrictRJSFSchema } from './types';
 
-/** Detects whether the given `schema` contains fixed items. This is the case when `schema.items` is a non-empty array
- * that only contains objects.
+/** Detects whether the given `schema` contains fixed items. This is the case when `schema.items` is an array that only
+ * contains objects.
  *
  * @param schema - The schema in which to check for fixed items
  * @returns - True if there are fixed items in the schema, false otherwise
  */
 export default function isFixedItems<S extends StrictRJSFSchema = RJSFSchema>(schema: S) {
-  return Array.isArray(schema.items) && schema.items.length > 0 && schema.items.every((item) => isObject(item));
+  return Array.isArray(schema.items) && schema.items.every((item) => isObject(item));
 }

--- a/packages/utils/test/isFixedItems.test.ts
+++ b/packages/utils/test/isFixedItems.test.ts
@@ -4,8 +4,8 @@ describe('isFixedItems()', () => {
   it('returns false when schema.items is not an array', () => {
     expect(isFixedItems({})).toBe(false);
   });
-  it('returns false when schema.items is an empty array', () => {
-    expect(isFixedItems({ items: [] })).toBe(false);
+  it('returns true when schema.items is an empty array', () => {
+    expect(isFixedItems({ items: [] })).toBe(true);
   });
   it('returns false when schema.items do not contain objects', () => {
     expect(isFixedItems({ items: [{}, true] })).toBe(false);


### PR DESCRIPTION
## Summary
- Treat tuple-array schemas with object `additionalItems` as fixed/additional arrays even when `items` is empty
- Use `schema.additionalItems` when adding the first row for an empty tuple schema
- Add regression coverage for clicking Add on `items: []` plus string `additionalItems` and rerendering the added field

Fixes #3791.

## Testing
- `git diff --check origin/main...HEAD`
- `npx oxfmt --check packages/core/src/components/fields/ArrayField.tsx packages/core/test/ArrayField.test.tsx`
- `npx oxlint packages/core/src/components/fields/ArrayField.tsx packages/core/test/ArrayField.test.tsx`
