### PR TITLE
Warn when enum default is outside options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
+- Added a warning when a `select` widget schema default is not present in the enum options, fixing [#4494](https://github.com/rjsf-team/react-jsonschema-form/issues/4494)
 - Fixed [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907) and [#4262](https://github.com/rjsf-team/react-jsonschema-form/issues/4262) as follows:
   - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
   - Added `CyclicSchemaField` to the list of fields, that renders the `CyclicSchemaExpandTemplate` initially and, if expanded, will render the `SchemaField` with the `RJSF_REF_CYCLE_KEY` tag turned off  
@@ -68,6 +69,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
+- Added `logUnsupportedDefaultForEnum()` helper for theme select widgets to warn when a schema default is not present in the enum options, fixing [#4494](https://github.com/rjsf-team/react-jsonschema-form/issues/4494)
 - Updated `types.ts` to add `CyclicSchemaExpandProps` type and `CyclicSchemaExpandTemplate` in the `TemplatesType`
 - Updated `resolveAllReferences()` to add a new `markCycleOnDetection` prop which adds `RJSF_REF_CYCLE_KEY` marker (from `constants.ts`) to a schema that has been detected to have a cycle, partially fixing [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907)
 - Updated `hashForSchema()` to filter keys to remove `RJSF_REF_KEY` prefixed keys before hashing the schema
@@ -75,6 +77,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## Dev / docs / playground
 
+- Updated `utility-functions.md` to document `logUnsupportedDefaultForEnum()`
 - Updated `@rjsf/snapshots` to add a test case to `formTests` that verifies the new Cycle detection UI
 - Updated the `custom-templates.md` and `custom-widgets-fields.md` for the new feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
+- Added `logUnsupportedDefaultForEnum()` helper for theme select widgets to warn when a schema default is not present in the enum options, fixing [#4494](https://github.com/rjsf-team/react-jsonschema-form/issues/4494)
 - Updated `sanitizeDataForNewSchema()` to preserve valid enum values while replacing or clearing stale values across enum, `oneOf`, and `anyOf` schema changes, fixing [#3838](https://github.com/rjsf-team/react-jsonschema-form/issues/3838)
 - Updated `sanitizeDataForNewSchema()` to filter out invalid enum values in arrays, fixing [#1357](https://github.com/rjsf-team/react-jsonschema-form/issues/1357) and [#2492](https://github.com/rjsf-team/react-jsonschema-form/issues/2492)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Added a warning when a `select` widget schema default is not present in the enum options, fixing [#4494](https://github.com/rjsf-team/react-jsonschema-form/issues/4494)
 - Fixed [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907) and [#4262](https://github.com/rjsf-team/react-jsonschema-form/issues/4262) as follows:
   - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
-  - Added `CyclicSchemaField` to the list of fields, that renders the `CyclicSchemaExpandTemplate` initially and, if expanded, will render the `SchemaField` with the `RJSF_REF_CYCLE_KEY` tag turned off  
+  - Added `CyclicSchemaField` to the list of fields, that renders the `CyclicSchemaExpandTemplate` initially and, if expanded, will render the `SchemaField` with the `RJSF_REF_CYCLE_KEY` tag turned off
   - Updated `SchemaForm` to render the `CyclicSchemaField` when the schema contains the `RJSF_REF_CYCLE_KEY` set to `true`
 
 ## @rjsf/daisyui
@@ -95,7 +95,6 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
-- Added `logUnsupportedDefaultForEnum()` helper for theme select widgets to warn when a schema default is not present in the enum options, fixing [#4494](https://github.com/rjsf-team/react-jsonschema-form/issues/4494)
 - Updated `sanitizeDataForNewSchema()` to preserve valid enum values while replacing or clearing stale values across enum, `oneOf`, and `anyOf` schema changes, fixing [#3838](https://github.com/rjsf-team/react-jsonschema-form/issues/3838)
 - Updated `sanitizeDataForNewSchema()` to filter out invalid enum values in arrays, fixing [#1357](https://github.com/rjsf-team/react-jsonschema-form/issues/1357) and [#2492](https://github.com/rjsf-team/react-jsonschema-form/issues/2492)
 

--- a/packages/antd/src/widgets/SelectWidget/index.tsx
+++ b/packages/antd/src/widgets/SelectWidget/index.tsx
@@ -6,6 +6,7 @@ import {
   enumOptionValueDecoder,
   enumOptionValueEncoder,
   getOptionValueFormat,
+  logUnsupportedDefaultForEnum,
 } from '@rjsf/utils';
 import type { SelectProps } from 'antd';
 import { Select } from 'antd';
@@ -74,6 +75,7 @@ export default function SelectWidget<
   };
 
   const showPlaceholderOption = !multiple && schema.default === undefined;
+  logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, multiple);
 
   const selectOptions: DefaultOptionType[] | undefined = useMemo(() => {
     if (Array.isArray(enumOptions)) {

--- a/packages/chakra-ui/src/NativeSelectWidget/NativeSelectWidget.tsx
+++ b/packages/chakra-ui/src/NativeSelectWidget/NativeSelectWidget.tsx
@@ -2,7 +2,13 @@ import type { ChangeEvent, FocusEvent } from 'react';
 import { useMemo } from 'react';
 import { createListCollection, NativeSelect } from '@chakra-ui/react';
 import type { EnumOptionsType, FormContextType, RJSFSchema, StrictRJSFSchema, WidgetProps } from '@rjsf/utils';
-import { ariaDescribedByIds, enumOptionsIndexForValue, enumOptionsValueForIndex, labelValue } from '@rjsf/utils';
+import {
+  ariaDescribedByIds,
+  enumOptionsIndexForValue,
+  enumOptionsValueForIndex,
+  labelValue,
+  logUnsupportedDefaultForEnum,
+} from '@rjsf/utils';
 import type { OptionsOrGroups } from 'chakra-react-select';
 
 import { Field } from '../components/ui/field';
@@ -54,6 +60,7 @@ export default function NativeSelectWidget<
     onFocus(id, enumOptionsValueForIndex<S>(target?.value, enumOptions, emptyValue));
 
   const showPlaceholderOption = !multiple && schema.default === undefined;
+  logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, multiple);
   const { valueLabelMap, displayEnumOptions } = useMemo((): {
     valueLabelMap: Record<string | number, string>;
     displayEnumOptions: OptionsOrGroups<any, any>;

--- a/packages/chakra-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/chakra-ui/src/SelectWidget/SelectWidget.tsx
@@ -10,6 +10,7 @@ import {
   enumOptionValueEncoder,
   getOptionValueFormat,
   labelValue,
+  logUnsupportedDefaultForEnum,
 } from '@rjsf/utils';
 import type { OptionsOrGroups } from 'chakra-react-select';
 
@@ -58,6 +59,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
     onFocus(id, enumOptionValueDecoder<S>(target?.value, enumOptions, optionValueFormat, emptyValue));
 
   const showPlaceholderOption = !multiple && schema.default === undefined;
+  logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, multiple);
   const displayEnumOptions = useMemo((): OptionsOrGroups<any, any> => {
     let computedOptions: OptionsOrGroups<any, any> = [];
     if (Array.isArray(enumOptions)) {

--- a/packages/core/src/components/widgets/SelectWidget.tsx
+++ b/packages/core/src/components/widgets/SelectWidget.tsx
@@ -3,11 +3,11 @@ import { useCallback } from 'react';
 import type { FormContextType, RJSFSchema, StrictRJSFSchema, WidgetProps } from '@rjsf/utils';
 import {
   ariaDescribedByIds,
-  enumOptionsIndexForValue,
   enumOptionSelectedValue,
   enumOptionValueDecoder,
   enumOptionValueEncoder,
   getOptionValueFormat,
+  logUnsupportedDefaultForEnum,
 } from '@rjsf/utils';
 
 function getValue(event: SyntheticEvent<HTMLSelectElement>, multiple: boolean) {
@@ -71,16 +71,7 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
 
   const selectValue = enumOptionSelectedValue<S>(value, enumOptions, multiple, optionValueFormat, emptyValue);
   const showPlaceholderOption = !multiple && schema.default === undefined;
-  if (
-    !multiple &&
-    Array.isArray(enumOptions) &&
-    schema.default !== undefined &&
-    enumOptionsIndexForValue<S>(schema.default, enumOptions, multiple) === undefined
-  ) {
-    console.error(
-      `The schema default value "${schema.default}" is not one of the values in the enum options for "${id}"`,
-    );
-  }
+  logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, multiple);
 
   return (
     // oxlint-disable-next-line jsx-a11y/no-autofocus

--- a/packages/core/src/components/widgets/SelectWidget.tsx
+++ b/packages/core/src/components/widgets/SelectWidget.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import type { FormContextType, RJSFSchema, StrictRJSFSchema, WidgetProps } from '@rjsf/utils';
 import {
   ariaDescribedByIds,
+  enumOptionsIndexForValue,
   enumOptionSelectedValue,
   enumOptionValueDecoder,
   enumOptionValueEncoder,
@@ -70,6 +71,16 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
 
   const selectValue = enumOptionSelectedValue<S>(value, enumOptions, multiple, optionValueFormat, emptyValue);
   const showPlaceholderOption = !multiple && schema.default === undefined;
+  if (
+    !multiple &&
+    Array.isArray(enumOptions) &&
+    schema.default !== undefined &&
+    enumOptionsIndexForValue<S>(schema.default, enumOptions, multiple) === undefined
+  ) {
+    console.error(
+      `The schema default value "${schema.default}" is not one of the values in the enum options for "${id}"`,
+    );
+  }
 
   return (
     // oxlint-disable-next-line jsx-a11y/no-autofocus

--- a/packages/core/test/StringField.test.tsx
+++ b/packages/core/test/StringField.test.tsx
@@ -13,7 +13,7 @@ import {
   expectToHaveBeenCalledWithFormData,
 } from './testUtils';
 
-setupConsoleErrorSuppression();
+const consoleErrorSuppression = setupConsoleErrorSuppression();
 
 const mockFileReader = {
   // oxlint-disable-next-line no-unused-vars
@@ -488,6 +488,20 @@ describe('StringField', () => {
       await submitForm(node, user);
 
       expectToHaveBeenCalledWithFormData(onSubmit, 'bar', true);
+    });
+
+    it('should warn when the default value is not in the enum options', () => {
+      createFormComponent({
+        schema: {
+          type: 'string',
+          enum: ['foo', 'bar'],
+          default: 'baz',
+        },
+      });
+
+      expect(consoleErrorSuppression.consoleSpy).toHaveBeenCalledWith(
+        'The schema default value "baz" is not one of the values in the enum options for "root"',
+      );
     });
 
     it('should reflect the change in the change event', async () => {

--- a/packages/daisyui/src/widgets/SelectWidget/SelectWidget.tsx
+++ b/packages/daisyui/src/widgets/SelectWidget/SelectWidget.tsx
@@ -6,6 +6,7 @@ import {
   enumOptionValueDecoder,
   enumOptionValueEncoder,
   getOptionValueFormat,
+  logUnsupportedDefaultForEnum,
 } from '@rjsf/utils';
 
 /** The `SelectWidget` component renders a select input with DaisyUI styling
@@ -116,6 +117,7 @@ export default function SelectWidget<
   const optionsList =
     enumOptions ||
     (Array.isArray(schema.examples) ? schema.examples.map((example) => ({ value: example, label: example })) : []);
+  logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, isMultiple);
 
   return (
     <div className='form-control w-full'>

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -341,6 +341,18 @@ When `format` is `'indexed'` (the default), returns the index as a string.
 
 - string: The string to use as the DOM value attribute
 
+### logUnsupportedDefaultForEnum&lt;S extends StrictRJSFSchema = RJSFSchema>()
+
+Logs a warning when a single-select enum widget has a schema default that is not one of its enum options.
+Multi-select widgets are ignored because they do not use the same single-value default handling.
+
+#### Parameters
+
+- id: string - The field id used in the warning message
+- schema: S - The schema whose default value is checked
+- [enumOptions]: EnumOptionsType&lt;S>[] - The enum options available to the widget
+- [multiple=false]: boolean - Whether the widget allows multiple selections
+
 ### errorId()
 
 Return a consistent `id` for the field error element.

--- a/packages/fluentui-rc/src/SelectWidget/SelectWidget.tsx
+++ b/packages/fluentui-rc/src/SelectWidget/SelectWidget.tsx
@@ -8,6 +8,7 @@ import {
   enumOptionsIndexForValue,
   getOptionValueFormat,
   labelValue,
+  logUnsupportedDefaultForEnum,
 } from '@rjsf/utils';
 
 function getValue(data: OptionOnSelectData, multiple: boolean) {
@@ -64,6 +65,7 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
     return onChange(enumOptionValueDecoder<S>(newValue, enumOptions, optionValueFormat, optEmptyVal));
   };
   const showPlaceholderOption = !multiple && schema.default === undefined;
+  logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, multiple);
 
   return (
     <Field

--- a/packages/mantine/src/widgets/SelectWidget.tsx
+++ b/packages/mantine/src/widgets/SelectWidget.tsx
@@ -9,6 +9,7 @@ import {
   enumOptionValueEncoder,
   getOptionValueFormat,
   labelValue,
+  logUnsupportedDefaultForEnum,
 } from '@rjsf/utils';
 
 import { cleanupOptions } from '../utils';
@@ -34,6 +35,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
     hideLabel,
     multiple,
     rawErrors,
+    schema,
     options,
     onChange,
     onBlur,
@@ -43,6 +45,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
   const { enumOptions, enumDisabled, emptyValue } = options;
   const optionValueFormat = getOptionValueFormat(options);
   const themeProps = cleanupOptions(options);
+  logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, multiple);
 
   const handleChange = useCallback(
     (nextValue: any) => {

--- a/packages/mui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/mui/src/SelectWidget/SelectWidget.tsx
@@ -12,6 +12,7 @@ import {
   enumOptionValueEncoder,
   getOptionValueFormat,
   labelValue,
+  logUnsupportedDefaultForEnum,
 } from '@rjsf/utils';
 
 import { getMuiProps } from '../util';
@@ -79,6 +80,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
 
   const { InputLabelProps, SelectProps, autocomplete, ...textFieldRemainingProps } = textFieldProps;
   const showPlaceholderOption = !isMultiple && schema.default === undefined;
+  logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, isMultiple);
 
   return (
     <TextField

--- a/packages/primereact/src/SelectWidget/SelectWidget.tsx
+++ b/packages/primereact/src/SelectWidget/SelectWidget.tsx
@@ -6,6 +6,7 @@ import {
   enumOptionValueDecoder,
   enumOptionValueEncoder,
   getOptionValueFormat,
+  logUnsupportedDefaultForEnum,
 } from '@rjsf/utils';
 import { Dropdown } from 'primereact/dropdown';
 import { MultiSelect } from 'primereact/multiselect';
@@ -55,6 +56,7 @@ function SingleSelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F 
   const isMultiple = typeof multiple === 'undefined' ? false : multiple;
 
   const emptyValue = isMultiple ? [] : '';
+  logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, isMultiple);
 
   const handleChange = (e: { value: any }) =>
     onChange(enumOptionValueDecoder<S>(e.value, enumOptions, optionValueFormat, optEmptyVal));

--- a/packages/react-bootstrap/src/SelectWidget/SelectWidget.tsx
+++ b/packages/react-bootstrap/src/SelectWidget/SelectWidget.tsx
@@ -6,6 +6,7 @@ import {
   enumOptionValueDecoder,
   enumOptionValueEncoder,
   getOptionValueFormat,
+  logUnsupportedDefaultForEnum,
 } from '@rjsf/utils';
 import FormSelect from 'react-bootstrap/FormSelect';
 
@@ -46,6 +47,7 @@ export default function SelectWidget<
   }
   const selectValue = enumOptionSelectedValue<S>(value, enumOptions, !!multiple, optionValueFormat, emptyValue);
   const showPlaceholderOption = !multiple && schema.default === undefined;
+  logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, multiple);
 
   return (
     <FormSelect

--- a/packages/semantic-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/semantic-ui/src/SelectWidget/SelectWidget.tsx
@@ -15,6 +15,7 @@ import {
   enumOptionValueEncoder,
   getOptionValueFormat,
   labelValue,
+  logUnsupportedDefaultForEnum,
 } from '@rjsf/utils';
 import map from 'lodash/map';
 import type { DropdownProps, DropdownItemProps } from 'semantic-ui-react';
@@ -95,6 +96,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
   const emptyValue = multiple ? [] : '';
   const optionValueFormat = getOptionValueFormat(options);
   const showPlaceholderOption = !multiple && schema.default === undefined;
+  logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, multiple);
   const dropdownOptions = createDefaultValueOptionsForDropDown<S>(
     enumOptions,
     enumDisabled,

--- a/packages/shadcn/src/SelectWidget/SelectWidget.tsx
+++ b/packages/shadcn/src/SelectWidget/SelectWidget.tsx
@@ -5,6 +5,7 @@ import {
   enumOptionValueDecoder,
   enumOptionValueEncoder,
   getOptionValueFormat,
+  logUnsupportedDefaultForEnum,
 } from '@rjsf/utils';
 
 import { FancyMultiSelect } from '../components/ui/fancy-multi-select';
@@ -27,6 +28,7 @@ export default function SelectWidget<
   disabled,
   readonly,
   value,
+  schema,
   multiple,
   autofocus,
   onChange,
@@ -38,6 +40,7 @@ export default function SelectWidget<
 }: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled, emptyValue: optEmptyValue } = options;
   const optionValueFormat = getOptionValueFormat(options);
+  logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, multiple);
 
   const handleFancyFocus = () => {
     onFocus(id, enumOptionValueDecoder<S>(value, enumOptions, optionValueFormat, optEmptyValue));

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -52,6 +52,7 @@ import isObject from './isObject';
 import isRootSchema from './isRootSchema';
 import labelValue from './labelValue';
 import localToUTC from './localToUTC';
+import logUnsupportedDefaultForEnum from './logUnsupportedDefaultForEnum';
 import lookupFromFormContext from './lookupFromFormContext';
 import mergeDefaultsWithFormData from './mergeDefaultsWithFormData';
 import mergeObjects from './mergeObjects';
@@ -154,6 +155,7 @@ export {
   isRootSchema,
   labelValue,
   localToUTC,
+  logUnsupportedDefaultForEnum,
   lookupFromFormContext,
   mergeDefaultsWithFormData,
   mergeObjects,

--- a/packages/utils/src/logUnsupportedDefaultForEnum.ts
+++ b/packages/utils/src/logUnsupportedDefaultForEnum.ts
@@ -1,0 +1,21 @@
+import enumOptionsIndexForValue from './enumOptionsIndexForValue';
+import type { EnumOptionsType, RJSFSchema, StrictRJSFSchema } from './types';
+
+export default function logUnsupportedDefaultForEnum<S extends StrictRJSFSchema = RJSFSchema>(
+  id: string,
+  schema: S,
+  enumOptions?: EnumOptionsType<S>[],
+  multiple = false,
+) {
+  if (
+    !multiple &&
+    Array.isArray(enumOptions) &&
+    schema.default !== undefined &&
+    enumOptionsIndexForValue<S>(schema.default, enumOptions, multiple) === undefined
+  ) {
+    // oxlint-disable-next-line no-console
+    console.error(
+      `The schema default value "${schema.default}" is not one of the values in the enum options for "${id}"`,
+    );
+  }
+}

--- a/packages/utils/src/logUnsupportedDefaultForEnum.ts
+++ b/packages/utils/src/logUnsupportedDefaultForEnum.ts
@@ -1,6 +1,13 @@
 import enumOptionsIndexForValue from './enumOptionsIndexForValue';
 import type { EnumOptionsType, RJSFSchema, StrictRJSFSchema } from './types';
 
+/** Logs a warning when a single-select enum widget has a schema default that is not one of its enum options.
+ *
+ * @param id - The field id used in the warning message
+ * @param schema - The schema whose default value is checked
+ * @param enumOptions - The enum options available to the widget
+ * @param multiple - Whether the widget allows multiple selections
+ */
 export default function logUnsupportedDefaultForEnum<S extends StrictRJSFSchema = RJSFSchema>(
   id: string,
   schema: S,

--- a/packages/utils/test/logUnsupportedDefaultForEnum.test.ts
+++ b/packages/utils/test/logUnsupportedDefaultForEnum.test.ts
@@ -1,0 +1,39 @@
+import logUnsupportedDefaultForEnum from '../src/logUnsupportedDefaultForEnum';
+
+describe('logUnsupportedDefaultForEnum()', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // oxlint-disable-next-line no-empty-function
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('logs when a single-select schema default is not in enum options', () => {
+    logUnsupportedDefaultForEnum('root_color', { type: 'string', default: 'blue' }, [{ label: 'Red', value: 'red' }]);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'The schema default value "blue" is not one of the values in the enum options for "root_color"',
+    );
+  });
+
+  it('does not log when a single-select schema default is in enum options', () => {
+    logUnsupportedDefaultForEnum('root_color', { type: 'string', default: 'red' }, [{ label: 'Red', value: 'red' }]);
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not log for multiple-select widgets', () => {
+    logUnsupportedDefaultForEnum(
+      'root_color',
+      { type: 'array', default: ['blue'] },
+      [{ label: 'Red', value: 'red' }],
+      true,
+    );
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/utils/test/logUnsupportedDefaultForEnum.test.ts
+++ b/packages/utils/test/logUnsupportedDefaultForEnum.test.ts
@@ -1,11 +1,14 @@
+import noop from 'lodash';
+import type { MockInstance } from 'vitest';
+
 import logUnsupportedDefaultForEnum from '../src/logUnsupportedDefaultForEnum';
 
 describe('logUnsupportedDefaultForEnum()', () => {
-  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: MockInstance;
 
   beforeEach(() => {
     // oxlint-disable-next-line no-empty-function
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
   });
 
   afterEach(() => {


### PR DESCRIPTION
#### Reasons for making this change

Fixes #4494.

This adds a warning in the single-select widget when a schema default value is not present in the generated enum options. The change is warning-only: it logs the mismatch and does not mutate `value`, `selectValue`, options, or submitted form data. Placeholder behavior also remains unchanged because `showPlaceholderOption` still depends on `schema.default === undefined`.

#### Checklist

- [x] `git diff --check`
- [x] `npm --workspace @rjsf/core test -- StringField.test.tsx`
- [x] `npx oxlint packages/core/src/components/widgets/SelectWidget.tsx packages/core/test/StringField.test.tsx`
- [x] `npx oxfmt --check packages/core/src/components/widgets/SelectWidget.tsx packages/core/test/StringField.test.tsx`