### PR TITLE
Fix issue where cleared fields would re-populate with default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `SchemaField` so that a schema with a primitive or array `type` alongside a non-select `oneOf`/`anyOf` no longer renders a spurious duplicate input above the option selector, fixing [#5119](https://github.com/rjsf-team/react-jsonschema-form/issues/5119)
 - Fixed `MultiSchemaField` to propagate the parent schema's `type` to option sub-schemas that don't define their own, so the correct widget (e.g. `StringField`) renders for the selected option instead of `FallbackField`, fixing [#5119](https://github.com/rjsf-team/react-jsonschema-form/issues/5119)
 - Fixed nested `constAsDefaults` values being skipped in matching conditional `allOf` schemas, fixing [#4963](https://github.com/rjsf-team/react-jsonschema-form/issues/4963)
+- Fixed `processPendingChange` so that clearing a string field that has a schema `default` value no longer re-applies the default, fixing [#5125](https://github.com/rjsf-team/react-jsonschema-form/issues/5125)
 
 ## @rjsf/daisyui
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -960,12 +960,18 @@ export default class Form<
     const inputForDefaults = hasOnlyUndefinedValues && wasPreviouslyNull ? undefined : formData;
 
     if (isObject(formData) || Array.isArray(formData)) {
+      // Tracks if the user cleared a plain (non-oneOf/anyOf) leaf field.
+      // The key is removed twice: once before getStateFromProps so inputForDefaults
+      // reflects an empty field for conditional schema resolution, and once after so
+      // the user's clear overrides any schema default getStateFromProps re-applied (#5125)
+      // and AJV never receives { key: undefined } for type:"string" fields (#4518).
+      let plainLeafWasCleared = false;
+
       if (newValue === ADDITIONAL_PROPERTY_KEY_REMOVE) {
-        // For additional properties, we were given the special remove this key value, so unset it
+        // For additional properties, this key was explicitly removed, so unset it
         _unset(formData, path);
       } else if (!isRootPath) {
-        // If the newValue is not on the root path, then set it into the form data
-        let unsetPath = false;
+        // Set the new value at its path in the form data.
         let valueForPath: T | null | undefined = newValue;
 
         if (newValue === undefined) {
@@ -977,17 +983,16 @@ export default class Form<
             const { field } = schemaUtils.findFieldInSchema(schema, path, oldFormData);
             const leaf = field as RJSFSchema | undefined;
             const isOneOfOrAnyOfLeaf = leaf && (ONE_OF_KEY in leaf || ANY_OF_KEY in leaf);
-            // Plain leaves: omit the key instead of `{ key: undefined }`, which breaks `type: "string"` validation in
-            // AJV after clearing a text input (https://github.com/rjsf-team/react-jsonschema-form/issues/4518).
-            // oneOf/anyOf leaves and unresolved leaves: keep `valueForPath === newValue` (already `undefined`) so
-            // mergeDefaults does not immediately re-apply a branch default when clearing those widgets.
+            // oneOf/anyOf and unresolved leaves keep `undefined` so mergeDefaults doesn't
+            // re-apply a branch default when the user clears the widget.
+            // Plain resolved leaves use plainLeafWasCleared instead (see below).
             if (!isOneOfOrAnyOfLeaf && leaf !== undefined) {
-              unsetPath = true;
+              plainLeafWasCleared = true;
             }
           }
         }
 
-        if (unsetPath) {
+        if (plainLeafWasCleared) {
           _unset(formData, path);
         } else {
           _set(formData, path, valueForPath);
@@ -995,7 +1000,7 @@ export default class Form<
       }
       const shouldSanitize =
         retrievedSchema && !isRootPath && !isObject(newValue) && !Array.isArray(newValue) && !disabled && !readonly;
-      // Pass true to skip live validation in `getStateFromProps()` since we will do it a bit later
+      // Skip live validation here; it runs later in this function.
       const newState = this.getStateFromProps(
         this.props,
         inputForDefaults,
@@ -1007,6 +1012,12 @@ export default class Form<
       );
       formData = newState.formData;
       retrievedSchema = newState.retrievedSchema;
+
+      // Re-unset after merging defaults so the user's clear is preserved (#5125) and
+      // the validator never sees { [key]: undefined } (#4518).
+      if (plainLeafWasCleared) {
+        _unset(formData, path);
+      }
     }
 
     const mustValidate = !noValidate && (liveValidate === true || liveValidate === 'onChange');

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -6112,6 +6112,38 @@ describe('patternProperties with fixed properties (#4518)', () => {
   });
 });
 
+describe('clearing a field with a schema default does not re-apply the default (#5125)', () => {
+  it('field stays empty after the user clears a string field that has a default value', async () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', default: 'Chuck' },
+      },
+    };
+
+    const { container, node, onSubmit, onError } = createFormComponent({ schema });
+
+    // Initial default is populated
+    const input = container.querySelector<HTMLInputElement>('#root_name');
+    expect(input).toBeInTheDocument();
+    expect(input!.value).toBe('Chuck');
+
+    // User clears the field
+    await user.clear(input!);
+    expect(input!.value).toBe('');
+
+    // After clearing, the field must NOT re-fill with the default
+    expect(input!.value).toBe('');
+
+    // Submitting should succeed and the cleared field must not carry the default
+    await submitForm(node, user);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalled();
+    const { formData } = onSubmit.mock.calls[onSubmit.mock.calls.length - 1][0];
+    expect(formData).not.toHaveProperty('name', 'Chuck');
+  });
+});
+
 describe('enum-based array values do not update when dependencies change (#1357 and #2492)', () => {
   it('should remove enum values in array when dependency switches', async () => {
     const schema: RJSFSchema = {


### PR DESCRIPTION
### Reasons for making this change

`processPendingChange` ensures cleared fields are not overwritten by defaults while still ensuring the key is unset before validation

Fixes #5125

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
