### PR TITLE
Fix 5134: resolve property title when required is inside allOf/if-then-else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,14 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `Experimental_DefaultFormStateBehavior` to add a new `nestedDefaultsPrecedence` option
 - Updated `getDefaultFormState()` to use the new `nestedDefaultsPrecedence` option to control how defaults defined on multiple levels are merged together, fixing [#5089](https://github.com/rjsf-team/react-jsonschema-form/issues/5089)
 
+## @rjsf/validator-ajv8
+
+- Updated `transformRJSFValidationErrors()` to detect field name for `allOf` and `if-then-else` by falling back to the root schema to find the title, fixing [#5134](https://github.com/rjsf-team/react-jsonschema-form/issues/5134)
+
+## @rjsf/validator-ata
+
+- Updated `transformRJSFValidationErrors()` to detect field name for `allOf` and `if-then-else` by falling back to the root schema to find the title, fixing [#5134](https://github.com/rjsf-team/react-jsonschema-form/issues/5134)
+
 ## Dev / docs / playground
 
 - Updated `@rjsf/snapshots` to add a test case to `formTests` that verifies the new Cycle detection UI

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -414,7 +414,7 @@ export function resolveAllReferences<S extends StrictRJSFSchema = RJSFSchema>(
           value as S,
           rootSchema,
           childList,
-          baseURI,
+          currentBaseURI,
           resolveAnyOfOrOneOfRefs,
           !resolveAnyOfOrOneOfRefs,
         );

--- a/packages/validator-ajv8/src/processRawValidationErrors.ts
+++ b/packages/validator-ajv8/src/processRawValidationErrors.ts
@@ -74,6 +74,7 @@ export function filterDuplicateErrors(
  * @param errors - The list of AJV errors to convert to `RJSFValidationErrors`
  * @param [uiSchema] - An optional uiSchema that is passed to `transformErrors` and `customValidate`
  * @param [suppressDuplicateFiltering] - Controls which duplicate filtering is suppressed; see `filterDuplicateErrors`
+ * @param [schema] - The schema for the validation
  */
 export function transformRJSFValidationErrors<
   T = any,
@@ -83,6 +84,7 @@ export function transformRJSFValidationErrors<
   errors: ErrorObject[] = [],
   uiSchema?: UiSchema<T, S, F>,
   suppressDuplicateFiltering?: SuppressDuplicateFilteringType,
+  schema?: S,
 ): RJSFValidationError[] {
   const errorList = errors.map((e: ErrorObject) => {
     const { instancePath, keyword, params, schemaPath, parentSchema, ...rest } = e;
@@ -110,6 +112,13 @@ export function transformRJSFValidationErrors<
             .concat([currentProperty]);
           uiSchemaTitle = getUiOptions(get(uiSchema, uiSchemaPath)).title;
         }
+        if (uiSchemaTitle === undefined) {
+          // schemaPath may include non-property segments (e.g. allOf/if/then) that do
+          // not exist in the uiSchema; fall back to the instance path, the same way the
+          // root-schema title fallback does below.
+          const propParts = property.replace(/^\./, '').split('.').filter(Boolean);
+          uiSchemaTitle = get(uiSchema, [...propParts, currentProperty, 'title']) as string | undefined;
+        }
         if (uiSchemaTitle) {
           message = message.replace(`'${currentProperty}'`, `'${uiSchemaTitle}'`);
           uiTitle = uiSchemaTitle;
@@ -118,6 +127,20 @@ export function transformRJSFValidationErrors<
           if (parentSchemaTitle) {
             message = message.replace(`'${currentProperty}'`, `'${parentSchemaTitle}'`);
             uiTitle = parentSchemaTitle;
+          } else if (schema) {
+            // parentSchema may be an allOf/anyOf/oneOf entry that lacks `properties`;
+            // fall back to looking up the title from the root schema.
+            const propParts = property.replace(/^\./, '').split('.').filter(Boolean);
+            const aSchemaPath: (string | number)[] = [];
+            for (const part of propParts) {
+              aSchemaPath.push(PROPERTIES_KEY, part);
+            }
+            aSchemaPath.push(PROPERTIES_KEY, currentProperty, 'title');
+            const rootSchemaTitle = get(schema, aSchemaPath) as string | undefined;
+            if (rootSchemaTitle) {
+              message = message.replace(`'${currentProperty}'`, `'${rootSchemaTitle}'`);
+              uiTitle = rootSchemaTitle;
+            }
           }
         }
       });
@@ -187,7 +210,7 @@ export default function processRawValidationErrors<
   suppressDuplicateFiltering?: SuppressDuplicateFilteringType,
 ) {
   const { validationError: invalidSchemaError } = rawErrors;
-  let errors = transformRJSFValidationErrors<T, S, F>(rawErrors.errors, uiSchema, suppressDuplicateFiltering);
+  let errors = transformRJSFValidationErrors<T, S, F>(rawErrors.errors, uiSchema, suppressDuplicateFiltering, schema);
 
   if (invalidSchemaError) {
     errors = [...errors, { stack: invalidSchemaError.message }];

--- a/packages/validator-ajv8/test/validator.test.ts
+++ b/packages/validator-ajv8/test/validator.test.ts
@@ -1327,6 +1327,158 @@ describe('AJV8Validator', () => {
             expect(errorSchema.numberOfChildren!.__errors![0]).toEqual('must match pattern "\\d+"');
           });
         });
+        describe('title is in validation messages at the top level, with an allOf', () => {
+          beforeAll(() => {
+            const schema: RJSFSchema = {
+              type: 'object',
+              properties: {
+                animal: {
+                  title: 'My animal',
+                  enum: ['Cat', 'Fish'],
+                },
+              },
+              allOf: [
+                {
+                  required: ['animal'],
+                },
+              ],
+            };
+
+            const formData = {};
+            const result = validator.validateFormData(formData, schema);
+            errors = result.errors;
+            errorSchema = result.errorSchema;
+          });
+          it('should return an error list', () => {
+            expect(errors).toHaveLength(1);
+
+            const stack = errors.map((e) => e.stack);
+
+            expect(stack).toEqual(["must have required property 'My animal'"]);
+          });
+          it('should return an errorSchema', () => {
+            expect(errorSchema.animal!.__errors).toHaveLength(1);
+            expect(errorSchema.animal!.__errors![0]).toEqual("must have required property 'My animal'");
+          });
+        });
+        describe('title is in validation messages at the top level, with if-then-else', () => {
+          beforeAll(() => {
+            const schema: RJSFSchema = {
+              type: 'object',
+              properties: {
+                hasPet: { type: 'boolean' },
+                animal: {
+                  title: 'My animal',
+                  enum: ['Cat', 'Fish'],
+                },
+              },
+              if: {
+                properties: { hasPet: { const: true } },
+                required: ['hasPet'],
+              },
+              then: {
+                required: ['animal'],
+              },
+            };
+
+            const formData = { hasPet: true };
+            const result = validator.validateFormData(formData, schema);
+            errors = result.errors;
+            errorSchema = result.errorSchema;
+          });
+          it('should return an error list', () => {
+            expect(errors).toHaveLength(2);
+
+            const stack = errors.map((e) => e.stack);
+
+            expect(stack).toEqual(["must have required property 'My animal'", 'must match "then" schema']);
+          });
+          it('should return an errorSchema', () => {
+            expect(errorSchema.animal!.__errors).toHaveLength(1);
+            expect(errorSchema.animal!.__errors![0]).toEqual("must have required property 'My animal'");
+          });
+        });
+        describe('title is in validation messages at the top level, with an allOf, uiSchema title', () => {
+          beforeAll(() => {
+            const schema: RJSFSchema = {
+              type: 'object',
+              properties: {
+                animal: {
+                  title: 'My animal',
+                  enum: ['Cat', 'Fish'],
+                },
+              },
+              allOf: [
+                {
+                  required: ['animal'],
+                },
+              ],
+            };
+            const uiSchema: UiSchema = {
+              animal: {
+                title: 'My animal uiSchema',
+              },
+            };
+
+            const formData = {};
+            const result = validator.validateFormData(formData, schema, undefined, undefined, uiSchema);
+            errors = result.errors;
+            errorSchema = result.errorSchema;
+          });
+          it('should return an error list', () => {
+            expect(errors).toHaveLength(1);
+
+            const stack = errors.map((e) => e.stack);
+
+            expect(stack).toEqual(["must have required property 'My animal uiSchema'"]);
+          });
+          it('should return an errorSchema', () => {
+            expect(errorSchema.animal!.__errors).toHaveLength(1);
+            expect(errorSchema.animal!.__errors![0]).toEqual("must have required property 'My animal uiSchema'");
+          });
+        });
+        describe('title is in validation messages at the top level, with if-then-else', () => {
+          beforeAll(() => {
+            const schema: RJSFSchema = {
+              type: 'object',
+              properties: {
+                hasPet: { type: 'boolean' },
+                animal: {
+                  title: 'My animal',
+                  enum: ['Cat', 'Fish'],
+                },
+              },
+              if: {
+                properties: { hasPet: { const: true } },
+                required: ['hasPet'],
+              },
+              then: {
+                required: ['animal'],
+              },
+            };
+            const uiSchema: UiSchema = {
+              animal: {
+                title: 'My animal uiSchema',
+              },
+            };
+
+            const formData = { hasPet: true };
+            const result = validator.validateFormData(formData, schema, undefined, undefined, uiSchema);
+            errors = result.errors;
+            errorSchema = result.errorSchema;
+          });
+          it('should return an error list', () => {
+            expect(errors).toHaveLength(2);
+
+            const stack = errors.map((e) => e.stack);
+
+            expect(stack).toEqual(["must have required property 'My animal uiSchema'", 'must match "then" schema']);
+          });
+          it('should return an errorSchema', () => {
+            expect(errorSchema.animal!.__errors).toHaveLength(1);
+            expect(errorSchema.animal!.__errors![0]).toEqual("must have required property 'My animal uiSchema'");
+          });
+        });
         describe('title is in validation message with a nested child', () => {
           beforeAll(() => {
             const schema: RJSFSchema = {

--- a/packages/validator-ata/src/processRawValidationErrors.ts
+++ b/packages/validator-ata/src/processRawValidationErrors.ts
@@ -75,6 +75,7 @@ export function transformRJSFValidationErrors<
   errors: ValidationError[] = [],
   uiSchema?: UiSchema<T, S, F>,
   suppressDuplicateFiltering?: SuppressDuplicateFilteringType,
+  schema?: S,
 ): RJSFValidationError[] {
   const errorList = errors.map((e: ValidationError) => {
     const { instancePath, keyword, params, schemaPath, parentSchema } = e;
@@ -102,6 +103,13 @@ export function transformRJSFValidationErrors<
             .concat([currentProperty]);
           uiSchemaTitle = getUiOptions(get(uiSchema, uiSchemaPath)).title;
         }
+        if (uiSchemaTitle === undefined) {
+          // schemaPath may include non-property segments (e.g. allOf/if/then) that do
+          // not exist in the uiSchema; fall back to the instance path, the same way the
+          // root-schema title fallback does below.
+          const propParts = property.replace(/^\./, '').split('.').filter(Boolean);
+          uiSchemaTitle = get(uiSchema, [...propParts, currentProperty, 'title']) as string | undefined;
+        }
         if (uiSchemaTitle) {
           message = message.replace(`'${currentProperty}'`, `'${uiSchemaTitle}'`);
           uiTitle = uiSchemaTitle;
@@ -110,6 +118,20 @@ export function transformRJSFValidationErrors<
           if (parentSchemaTitle) {
             message = message.replace(`'${currentProperty}'`, `'${parentSchemaTitle}'`);
             uiTitle = parentSchemaTitle;
+          } else if (schema) {
+            // parentSchema may be an allOf/anyOf/oneOf entry that lacks `properties`;
+            // fall back to looking up the title from the root schema.
+            const propParts = property.replace(/^\./, '').split('.').filter(Boolean);
+            const aSchemaPath: (string | number)[] = [];
+            for (const part of propParts) {
+              aSchemaPath.push(PROPERTIES_KEY, part);
+            }
+            aSchemaPath.push(PROPERTIES_KEY, currentProperty, 'title');
+            const rootSchemaTitle = get(schema, aSchemaPath) as string | undefined;
+            if (rootSchemaTitle) {
+              message = message.replace(`'${currentProperty}'`, `'${rootSchemaTitle}'`);
+              uiTitle = rootSchemaTitle;
+            }
           }
         }
       });
@@ -167,7 +189,7 @@ export default function processRawValidationErrors<
   suppressDuplicateFiltering?: SuppressDuplicateFilteringType,
 ) {
   const { validationError: invalidSchemaError } = rawErrors;
-  let errors = transformRJSFValidationErrors<T, S, F>(rawErrors.errors, uiSchema, suppressDuplicateFiltering);
+  let errors = transformRJSFValidationErrors<T, S, F>(rawErrors.errors, uiSchema, suppressDuplicateFiltering, schema);
 
   if (invalidSchemaError) {
     errors = [...errors, { stack: invalidSchemaError.message }];

--- a/packages/validator-ata/test/processRawValidationErrors.test.ts
+++ b/packages/validator-ata/test/processRawValidationErrors.test.ts
@@ -138,6 +138,42 @@ describe('transformRJSFValidationErrors()', () => {
     expect(out[0].message).toContain('Schema Title');
   });
 
+  it('falls back to uiSchema title via instance path when schemaPath contains non-property segments (e.g. allOf)', () => {
+    const errors: ValidationError[] = [
+      ataError({
+        instancePath: '',
+        schemaPath: '#/allOf/0/required',
+        params: { missingProperty: 'animal' },
+        message: "must have required property 'animal'",
+        parentSchema: { required: ['animal'] },
+      }),
+    ];
+    const uiSchema: UiSchema = { animal: { title: 'My animal uiSchema' } };
+    const out = transformRJSFValidationErrors(errors, uiSchema);
+    expect(out[0].title).toBe('My animal uiSchema');
+    expect(out[0].message).toContain('My animal uiSchema');
+  });
+
+  it('falls back to root schema title when parentSchema lacks properties (e.g. allOf)', () => {
+    const errors: ValidationError[] = [
+      ataError({
+        instancePath: '',
+        schemaPath: '#/allOf/0/required',
+        params: { missingProperty: 'animal' },
+        message: "must have required property 'animal'",
+        parentSchema: { required: ['animal'] },
+      }),
+    ];
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: { animal: { title: 'My animal', enum: ['Cat', 'Fish'] } },
+      allOf: [{ required: ['animal'] }],
+    };
+    const out = transformRJSFValidationErrors(errors, undefined, undefined, schema);
+    expect(out[0].title).toBe('My animal');
+    expect(out[0].message).toContain('My animal');
+  });
+
   it('uses uiSchema title at the property level when params has no property names', () => {
     const errors: ValidationError[] = [
       {

--- a/packages/validator-ata/test/validator.test.ts
+++ b/packages/validator-ata/test/validator.test.ts
@@ -130,6 +130,68 @@ describe('ATAValidator', () => {
       expect(customValidate).toHaveBeenCalled();
       expect(errorSchema.x?.__errors).toContain('custom error');
     });
+
+    it('uses the uiSchema title when required is inside allOf', () => {
+      const v = customizeValidator();
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: { animal: { title: 'My animal', enum: ['Cat', 'Fish'] } },
+        allOf: [{ required: ['animal'] }],
+      };
+      const uiSchema = { animal: { title: 'My animal uiSchema' } };
+      const { errors, errorSchema } = v.validateFormData({}, schema, undefined, undefined, uiSchema);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].stack).toBe("must have required property 'My animal uiSchema'");
+      expect(errorSchema.animal?.__errors).toEqual(["must have required property 'My animal uiSchema'"]);
+    });
+
+    it('uses the uiSchema title when required is inside if-then-else', () => {
+      const v = customizeValidator();
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          hasPet: { type: 'boolean' },
+          animal: { title: 'My animal', enum: ['Cat', 'Fish'] },
+        },
+        if: { properties: { hasPet: { const: true } }, required: ['hasPet'] },
+        then: { required: ['animal'] },
+      };
+      const uiSchema = { animal: { title: 'My animal uiSchema' } };
+      const { errors, errorSchema } = v.validateFormData({ hasPet: true }, schema, undefined, undefined, uiSchema);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].stack).toBe("must have required property 'My animal uiSchema'");
+      expect(errorSchema.animal?.__errors).toEqual(["must have required property 'My animal uiSchema'"]);
+    });
+
+    it('uses the property title when required is inside allOf', () => {
+      const v = customizeValidator();
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: { animal: { title: 'My animal', enum: ['Cat', 'Fish'] } },
+        allOf: [{ required: ['animal'] }],
+      };
+      const { errors, errorSchema } = v.validateFormData({}, schema);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].stack).toBe("must have required property 'My animal'");
+      expect(errorSchema.animal?.__errors).toEqual(["must have required property 'My animal'"]);
+    });
+
+    it('uses the property title when required is inside if-then-else', () => {
+      const v = customizeValidator();
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          hasPet: { type: 'boolean' },
+          animal: { title: 'My animal', enum: ['Cat', 'Fish'] },
+        },
+        if: { properties: { hasPet: { const: true } }, required: ['hasPet'] },
+        then: { required: ['animal'] },
+      };
+      const { errors, errorSchema } = v.validateFormData({ hasPet: true }, schema);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].stack).toBe("must have required property 'My animal'");
+      expect(errorSchema.animal?.__errors).toEqual(["must have required property 'My animal'"]);
+    });
   });
 
   describe('customFormats option', () => {


### PR DESCRIPTION
### Reasons for making this change

Fixes #5134 as follows:

- In `utils` updated `retrieveSchema.ts`per [comment on old PR](https://github.com/rjsf-team/react-jsonschema-form/pull/5118/changes/BASE..d0cc380d162f3cb9bd6b87bbd3d2aad6f7de4a56#r3486971795) by restoring accidentally renamed variable

- In `validator-ajv8` and `validator-ata`:
  - Pass the root schema into `transformRJSFValidationErrors` and fall back to it when `parentSchema` yields no title
  - Also falls back to the instance path for `uiSchema` as well
  - Tests for both `allOf` and `if-then-else` cases were added

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
