### PR TITLE
fix(core): prevent cleared fields from re-defaulting when another field is cleared (#5125 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `MultiSchemaField` to propagate the parent schema's `type` to option sub-schemas that don't define their own, so the correct widget (e.g. `StringField`) renders for the selected option instead of `FallbackField`, fixing [#5119](https://github.com/rjsf-team/react-jsonschema-form/issues/5119)
 - Fixed nested `constAsDefaults` values being skipped in matching conditional `allOf` schemas, fixing [#4963](https://github.com/rjsf-team/react-jsonschema-form/issues/4963)
 - Fixed `processPendingChange` so that clearing a string field that has a schema `default` value no longer re-applies the default, fixing [#5125](https://github.com/rjsf-team/react-jsonschema-form/issues/5125)
+- Fixed a regression introduced in [#5136](https://github.com/rjsf-team/react-jsonschema-form/pull/5136) where clearing a second field caused a previously-cleared field to be re-populated with its schema default; added `omitUndefinedLeaves()` to strip `undefined`-valued keys from formData before AJV validation so that the [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix is preserved
 
 ## @rjsf/daisyui
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `MultiSchemaField` to propagate the parent schema's `type` to option sub-schemas that don't define their own, so the correct widget (e.g. `StringField`) renders for the selected option instead of `FallbackField`, fixing [#5119](https://github.com/rjsf-team/react-jsonschema-form/issues/5119)
 - Fixed nested `constAsDefaults` values being skipped in matching conditional `allOf` schemas, fixing [#4963](https://github.com/rjsf-team/react-jsonschema-form/issues/4963)
 - Fixed `processPendingChange` so that clearing a string field that has a schema `default` value no longer re-applies the default, fixing [#5125](https://github.com/rjsf-team/react-jsonschema-form/issues/5125)
-- Fixed a regression introduced in [#5136](https://github.com/rjsf-team/react-jsonschema-form/pull/5136) where clearing a second field caused a previously-cleared field to be re-populated with its schema default; uses `JSON.parse(JSON.stringify(...))` to strip `undefined`-valued keys from formData before AJV validation so that the [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix is preserved ([#5138](https://github.com/rjsf-team/react-jsonschema-form/pull/5138))
+- Fixed a regression introduced in [#5136](https://github.com/rjsf-team/react-jsonschema-form/pull/5136) where clearing a second field caused a previously-cleared field to be re-populated with its schema default; uses `JSON.parse(JSON.stringify(...))` to strip `undefined`-valued keys from formData before AJV validation so that the [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix is preserved
 
 ## @rjsf/daisyui
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `MultiSchemaField` to propagate the parent schema's `type` to option sub-schemas that don't define their own, so the correct widget (e.g. `StringField`) renders for the selected option instead of `FallbackField`, fixing [#5119](https://github.com/rjsf-team/react-jsonschema-form/issues/5119)
 - Fixed nested `constAsDefaults` values being skipped in matching conditional `allOf` schemas, fixing [#4963](https://github.com/rjsf-team/react-jsonschema-form/issues/4963)
 - Fixed `processPendingChange` so that clearing a string field that has a schema `default` value no longer re-applies the default, fixing [#5125](https://github.com/rjsf-team/react-jsonschema-form/issues/5125)
-- Fixed a regression introduced in [#5136](https://github.com/rjsf-team/react-jsonschema-form/pull/5136) where clearing a second field caused a previously-cleared field to be re-populated with its schema default; added `omitUndefinedLeaves()` to strip `undefined`-valued keys from formData before AJV validation so that the [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix is preserved ([#5138](https://github.com/rjsf-team/react-jsonschema-form/pull/5138))
+- Fixed a regression introduced in [#5136](https://github.com/rjsf-team/react-jsonschema-form/pull/5136) where clearing a second field caused a previously-cleared field to be re-populated with its schema default; uses `JSON.parse(JSON.stringify(...))` to strip `undefined`-valued keys from formData before AJV validation so that the [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix is preserved ([#5138](https://github.com/rjsf-team/react-jsonschema-form/pull/5138))
 
 ## @rjsf/daisyui
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `MultiSchemaField` to propagate the parent schema's `type` to option sub-schemas that don't define their own, so the correct widget (e.g. `StringField`) renders for the selected option instead of `FallbackField`, fixing [#5119](https://github.com/rjsf-team/react-jsonschema-form/issues/5119)
 - Fixed nested `constAsDefaults` values being skipped in matching conditional `allOf` schemas, fixing [#4963](https://github.com/rjsf-team/react-jsonschema-form/issues/4963)
 - Fixed `processPendingChange` so that clearing a string field that has a schema `default` value no longer re-applies the default, fixing [#5125](https://github.com/rjsf-team/react-jsonschema-form/issues/5125)
-- Fixed a regression introduced in [#5136](https://github.com/rjsf-team/react-jsonschema-form/pull/5136) where clearing a second field caused a previously-cleared field to be re-populated with its schema default; added `omitUndefinedLeaves()` to strip `undefined`-valued keys from formData before AJV validation so that the [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix is preserved
+- Fixed a regression introduced in [#5136](https://github.com/rjsf-team/react-jsonschema-form/pull/5136) where clearing a second field caused a previously-cleared field to be re-populated with its schema default; added `omitUndefinedLeaves()` to strip `undefined`-valued keys from formData before AJV validation so that the [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix is preserved ([#5138](https://github.com/rjsf-team/react-jsonschema-form/pull/5138))
 
 ## @rjsf/daisyui
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -765,9 +765,14 @@ export default class Form<
     // When a pre-resolved schema is provided (e.g., from live validation), use it directly.
     // Otherwise validate against the original schema so AJV sees the full constraint set.
     const validationSchema = retrievedSchema ?? schema;
+
+    // JSON.stringify drops keys with `undefined` values; JSON.parse on the result gives AJV a clean
+    // object that avoids spurious type errors for `type: "string"` fields that were cleared (#4518).
+    const validationFormData = formData ? JSON.parse(JSON.stringify(formData)) : undefined;
+
     return schemaUtils
       .getValidator()
-      .validateFormData(formData, validationSchema, customValidate, transformErrors, uiSchema);
+      .validateFormData(validationFormData, validationSchema, customValidate, transformErrors, uiSchema);
   }
 
   /** Renders any errors contained in the `state` in using the `ErrorList`, if not disabled by `showErrorList`. */
@@ -1065,18 +1070,13 @@ export default class Form<
       // If we have custom errors and the path has an error, then we need to clear it
       customErrors.clearErrors(path);
     }
-
-    // JSON.stringify drops keys with `undefined` values; JSON.parse on the result gives AJV a clean
-    // object that avoids spurious type errors for `type: "string"` fields that were cleared (#4518).
-    const formDataForValidation = newFormData ? JSON.parse(JSON.stringify(newFormData)) : undefined;
-
     // If there are pending changes in the queue, skip live validation since it will happen with the last change
     if (mustValidate && this.pendingChanges.length === 1) {
       const liveValidation = this.liveValidate(
         schema,
         schemaUtils,
         mergeBaseErrorSchema,
-        formDataForValidation,
+        newFormData,
         extraErrors,
         customErrors,
         retrievedSchema,
@@ -1373,12 +1373,7 @@ export default class Form<
   validateFormWithFormData = (formData?: T): boolean => {
     const { extraErrors, extraErrorsBlockSubmit, focusOnFirstError, onError } = this.props;
     const { errors: prevErrors } = this.state;
-
-    // JSON.stringify drops keys with `undefined` values; JSON.parse on the result gives AJV a clean
-    // object that avoids spurious type errors for `type: "string"` fields that were cleared (#4518).
-    const formDataForValidation = formData ? JSON.parse(JSON.stringify(formData)) : undefined;
-
-    const schemaValidation = this.validate(formDataForValidation);
+    const schemaValidation = this.validate(formData);
     // Always merge extraErrors so they remain visible in state regardless of extraErrorsBlockSubmit.
     const { errors, errorSchema } = extraErrors ? Form.mergeErrors<T>(schemaValidation, extraErrors) : schemaValidation;
     // hasError gates submission: schema errors always block; extraErrors only block when

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -817,6 +817,38 @@ export default class Form<
     return { errors, errorSchema };
   }
 
+  /** Strips keys with `undefined` values from a form data object (recursively).
+   * Used to prevent AJV from receiving `{ [key]: undefined }` for fields such as
+   * `type: "string"` under `patternProperties`, which would cause a spurious type
+   * error (#4518), while still keeping the `undefined` key in state so that
+   * `mergeDefaultsWithFormData` does not re-apply schema defaults when the user has
+   * explicitly cleared a field (#5125 regression).
+   *
+   * @param formData - The form data to strip
+   * @returns - A copy of `formData` with all `undefined`-valued keys omitted
+   * @private
+   */
+  private static omitUndefinedLeaves<T>(formData: T): T {
+    // If the formData is not an object, return it as is (base case for recursion)
+    if (!isObject(formData)) {
+      return formData;
+    }
+
+    // If the formData is an object, create a new object to hold the result
+    const result: any = {};
+
+    for (const key of Object.keys(formData as object)) {
+      const value = (formData as any)[key];
+
+      if (value !== undefined) {
+        result[key] = Form.omitUndefinedLeaves(value);
+      }
+    }
+
+    // Return the result object with all `undefined`-valued keys omitted
+    return result as T;
+  }
+
   /** Performs live validation and then updates and returns the errors and error schemas by potentially merging in
    * `extraErrors` and `customErrors`.
    *
@@ -993,7 +1025,7 @@ export default class Form<
         }
 
         if (plainLeafWasCleared) {
-          _unset(formData, path);
+          _set(formData, path, undefined);
         } else {
           _set(formData, path, valueForPath);
         }
@@ -1013,10 +1045,13 @@ export default class Form<
       formData = newState.formData;
       retrievedSchema = newState.retrievedSchema;
 
-      // Re-unset after merging defaults so the user's clear is preserved (#5125) and
-      // the validator never sees { [key]: undefined } (#4518).
-      if (plainLeafWasCleared) {
-        _unset(formData, path);
+      // Re-set to undefined after merging defaults so the user's clear is preserved in
+      // state (#5125 regression: without this, clearing a second field re-applies the
+      // default to previously-cleared fields). The undefined key is stripped from the
+      // formData copy passed to AJV via omitUndefinedLeaves() so the validator never
+      // sees { [key]: undefined } for type:"string" or patternProperties fields (#4518).
+      if (plainLeafWasCleared && formData) {
+        _set(formData, path, undefined);
       }
     }
 
@@ -1068,7 +1103,7 @@ export default class Form<
         schema,
         schemaUtils,
         mergeBaseErrorSchema,
-        newFormData,
+        Form.omitUndefinedLeaves(newFormData),
         extraErrors,
         customErrors,
         retrievedSchema,
@@ -1365,7 +1400,7 @@ export default class Form<
   validateFormWithFormData = (formData?: T): boolean => {
     const { extraErrors, extraErrorsBlockSubmit, focusOnFirstError, onError } = this.props;
     const { errors: prevErrors } = this.state;
-    const schemaValidation = this.validate(formData);
+    const schemaValidation = this.validate(Form.omitUndefinedLeaves(formData));
     // Always merge extraErrors so they remain visible in state regardless of extraErrorsBlockSubmit.
     const { errors, errorSchema } = extraErrors ? Form.mergeErrors<T>(schemaValidation, extraErrors) : schemaValidation;
     // hasError gates submission: schema errors always block; extraErrors only block when

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -817,38 +817,6 @@ export default class Form<
     return { errors, errorSchema };
   }
 
-  /** Strips keys with `undefined` values from a form data object (recursively).
-   * Used to prevent AJV from receiving `{ [key]: undefined }` for fields such as
-   * `type: "string"` under `patternProperties`, which would cause a spurious type
-   * error (#4518), while still keeping the `undefined` key in state so that
-   * `mergeDefaultsWithFormData` does not re-apply schema defaults when the user has
-   * explicitly cleared a field (#5125 regression).
-   *
-   * @param formData - The form data to strip
-   * @returns - A copy of `formData` with all `undefined`-valued keys omitted
-   * @private
-   */
-  private static omitUndefinedLeaves<T>(formData: T): T {
-    // If the formData is not an object, return it as is (base case for recursion)
-    if (!isObject(formData)) {
-      return formData;
-    }
-
-    // If the formData is an object, create a new object to hold the result
-    const result: any = {};
-
-    for (const key of Object.keys(formData as object)) {
-      const value = (formData as any)[key];
-
-      if (value !== undefined) {
-        result[key] = Form.omitUndefinedLeaves(value);
-      }
-    }
-
-    // Return the result object with all `undefined`-valued keys omitted
-    return result as T;
-  }
-
   /** Performs live validation and then updates and returns the errors and error schemas by potentially merging in
    * `extraErrors` and `customErrors`.
    *
@@ -1048,7 +1016,7 @@ export default class Form<
       // Re-set to undefined after merging defaults so the user's clear is preserved in
       // state (#5125 regression: without this, clearing a second field re-applies the
       // default to previously-cleared fields). The undefined key is stripped from the
-      // formData copy passed to AJV via omitUndefinedLeaves() so the validator never
+      // formData copy passed to AJV via JSON.parse(JSON.stringify(...)) so the validator never
       // sees { [key]: undefined } for type:"string" or patternProperties fields (#4518).
       if (plainLeafWasCleared && formData) {
         _set(formData, path, undefined);
@@ -1097,13 +1065,18 @@ export default class Form<
       // If we have custom errors and the path has an error, then we need to clear it
       customErrors.clearErrors(path);
     }
+
+    // JSON.stringify drops keys with `undefined` values; JSON.parse on the result gives AJV a clean
+    // object that avoids spurious type errors for `type: "string"` fields that were cleared (#4518).
+    const formDataForValidation = newFormData ? JSON.parse(JSON.stringify(newFormData)) : undefined;
+
     // If there are pending changes in the queue, skip live validation since it will happen with the last change
     if (mustValidate && this.pendingChanges.length === 1) {
       const liveValidation = this.liveValidate(
         schema,
         schemaUtils,
         mergeBaseErrorSchema,
-        Form.omitUndefinedLeaves(newFormData),
+        formDataForValidation,
         extraErrors,
         customErrors,
         retrievedSchema,
@@ -1400,7 +1373,12 @@ export default class Form<
   validateFormWithFormData = (formData?: T): boolean => {
     const { extraErrors, extraErrorsBlockSubmit, focusOnFirstError, onError } = this.props;
     const { errors: prevErrors } = this.state;
-    const schemaValidation = this.validate(Form.omitUndefinedLeaves(formData));
+
+    // JSON.stringify drops keys with `undefined` values; JSON.parse on the result gives AJV a clean
+    // object that avoids spurious type errors for `type: "string"` fields that were cleared (#4518).
+    const formDataForValidation = formData ? JSON.parse(JSON.stringify(formData)) : undefined;
+
+    const schemaValidation = this.validate(formDataForValidation);
     // Always merge extraErrors so they remain visible in state regardless of extraErrorsBlockSubmit.
     const { errors, errorSchema } = extraErrors ? Form.mergeErrors<T>(schemaValidation, extraErrors) : schemaValidation;
     // hasError gates submission: schema errors always block; extraErrors only block when

--- a/packages/core/test/Form.test.tsx
+++ b/packages/core/test/Form.test.tsx
@@ -6142,6 +6142,49 @@ describe('clearing a field with a schema default does not re-apply the default (
     const { formData } = onSubmit.mock.calls[onSubmit.mock.calls.length - 1][0];
     expect(formData).not.toHaveProperty('name', 'Chuck');
   });
+
+  it('clearing a second field does not re-apply the default to a previously-cleared field', async () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        someStrings: { type: 'string', default: 'Chuck' },
+        someNumbers: { type: 'number', default: 1 },
+      },
+    };
+
+    const { container, node, onSubmit, onError } = createFormComponent({ schema });
+    const stringsInput = container.querySelector<HTMLInputElement>('#root_someStrings');
+    const numbersInput = container.querySelector<HTMLInputElement>('#root_someNumbers');
+
+    expect(stringsInput).toBeInTheDocument();
+    expect(numbersInput).toBeInTheDocument();
+    expect(stringsInput!.value).toBe('Chuck');
+    expect(numbersInput!.value).toBe('1');
+
+    // Clear the first field
+    await user.clear(stringsInput!);
+    expect(stringsInput!.value).toBe('');
+
+    // Clear the second field — the first must NOT get its default re-applied
+    await user.clear(numbersInput!);
+    expect(stringsInput!.value).toBe('');
+    expect(numbersInput!.value).toBe('');
+
+    // Clear the first field again — the second must NOT get its default re-applied
+    await user.clear(stringsInput!);
+    expect(stringsInput!.value).toBe('');
+    expect(numbersInput!.value).toBe('');
+
+    // Submitting should succeed and the cleared field must not carry the default
+    await submitForm(node, user);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalled();
+
+    // The formData must not contain the default values for either field
+    const { formData } = onSubmit.mock.calls[onSubmit.mock.calls.length - 1][0];
+    expect(formData).not.toHaveProperty('someStrings', 'Chuck');
+    expect(formData).not.toHaveProperty('someNumbers', 1);
+  });
 });
 
 describe('enum-based array values do not update when dependencies change (#1357 and #2492)', () => {


### PR DESCRIPTION
### Reasons for making this change

This fixes a regression introduced in #5136.
After clearing field A, clearing field B caused field A to be re-populated with its schema default.
The fix uses `_set(formData, path, undefined)` instead of `_unset` to keep the cleared key present in state, preventing `mergeDefaultsWithFormData` from re-applying the default. A new private helper `omitUndefinedLeaves()` strips `undefined`-valued keys before AJV validation to preserve the #4518 fix.

fixes #5125

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
