### PR TITLE
refactor: convert AnyOfField from class to functional component

### DIFF
--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useReducer, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FieldProps, FormContextType, RJSFSchema, StrictRJSFSchema, UiSchema } from '@rjsf/utils';
 import {
   ANY_OF_KEY,
@@ -17,38 +17,6 @@ import {
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import omit from 'lodash/omit';
-
-/** Type used for the state of the `AnyOfField` component */
-interface AnyOfFieldState<T = any, S extends StrictRJSFSchema = RJSFSchema> {
-  /** The currently selected option */
-  selectedOption: number;
-  /** The option schemas after retrieving all $refs */
-  retrievedOptions: S[];
-  /** Snapshot of the `options` prop — used to detect changes and re-cache retrievedOptions */
-  prevOptions: S[];
-  /** Snapshot of `formData` — used to detect changes and re-match the selected option */
-  prevFormData: T | undefined;
-  /** Snapshot of `fieldPathId.$id` — used to suppress option re-matching when the field itself changes */
-  prevFieldId: string;
-}
-
-type AnyOfFieldAction<T = any, S extends StrictRJSFSchema = RJSFSchema> =
-  | { type: 'SET_SELECTED_OPTION'; payload: number }
-  | { type: 'UPDATE_STATE'; payload: AnyOfFieldState<T, S> };
-
-function anyOfFieldReducer<T = any, S extends StrictRJSFSchema = RJSFSchema>(
-  state: AnyOfFieldState<T, S>,
-  action: AnyOfFieldAction<T, S>,
-): AnyOfFieldState<T, S> {
-  switch (action.type) {
-    case 'SET_SELECTED_OPTION':
-      return { ...state, selectedOption: action.payload };
-    case 'UPDATE_STATE':
-      return action.payload;
-    default:
-      return state;
-  }
-}
 
 /** The `AnyOfField` component is used to render a field in the schema that is an `anyOf`, `allOf` or `oneOf`. It tracks
  * the currently selected option and cleans up any irrelevant data in `formData`.
@@ -76,66 +44,53 @@ function AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends 
   } = props;
   const { schemaUtils } = registry;
 
+  // retrievedOptions is purely derived from options — useMemo handles re-derivation automatically
+  // when options, schemaUtils, or formData change, with no render-phase dispatch needed.
+  const retrievedOptions = useMemo(
+    () => options.map((opt: S) => schemaUtils.retrieveSchema(opt, formData)),
+    [options, schemaUtils, formData],
+  );
+
+  const [selectedOption, setSelectedOption] = useState<number>(() => {
+    const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
+    return schemaUtils.getClosestMatchingOption(formData, retrievedOptions, 0, discriminator);
+  });
+
   /** Flag to skip the formData-change-driven option recalculation when the user just selected an option.
-   * Set to true in onOptionChange (before onChange is called), consumed and reset during the next render.
+   * Set to true in onOptionChange (before onChange is called), consumed and reset in the update effect.
    * This prevents the matching-option recalculation from overriding a user's explicit choice when
    * getDefaultFormState populates undefined properties that make deepEquals see a false formData change.
    */
   const skipNextOptionRecalculation = useRef(false);
+  const prevFormDataRef = useRef<T | undefined>(formData);
+  const prevFieldIdRef = useRef(fieldPathId.$id);
 
-  const [state, dispatch] = useReducer(
-    anyOfFieldReducer as (state: AnyOfFieldState<T, S>, action: AnyOfFieldAction<T, S>) => AnyOfFieldState<T, S>,
-    null,
-    (_: null): AnyOfFieldState<T, S> => {
-      const retrievedOptions = options.map((opt: S) => schemaUtils.retrieveSchema(opt, formData));
-      const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
-      return {
-        retrievedOptions,
-        selectedOption: schemaUtils.getClosestMatchingOption(formData, retrievedOptions, 0, discriminator),
-        prevOptions: options,
-        prevFormData: formData,
-        prevFieldId: fieldPathId.$id,
-      };
-    },
-  );
+  // Mirrors componentDidUpdate: re-match selectedOption when formData changes on the same field.
+  // Runs after every render (no deps array) to compare against prev values stored in refs.
+  // oxlint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    const prevFormData = prevFormDataRef.current;
+    const prevFieldId = prevFieldIdRef.current;
+    prevFormDataRef.current = formData;
+    prevFieldIdRef.current = fieldPathId.$id;
 
-  // getDerivedStateFromProps pattern: compute any state updates during the render phase rather than in a
-  // useEffect. When dispatch is called here, React immediately re-renders with the new state and discards
-  // the current render's output before any DOM commit, so there is no visible flicker or extra paint.
-  let nextState = state;
-
-  if (!deepEquals(state.prevOptions, options)) {
-    const retrievedOptions = options.map((opt: S) => schemaUtils.retrieveSchema(opt, formData));
-    nextState = { ...nextState, retrievedOptions, prevOptions: options };
-  }
-
-  if (!deepEquals(formData, state.prevFormData)) {
-    if (fieldPathId.$id === state.prevFieldId) {
+    if (!deepEquals(formData, prevFormData) && fieldPathId.$id === prevFieldId) {
       if (skipNextOptionRecalculation.current) {
         skipNextOptionRecalculation.current = false;
-      } else {
-        const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
-        const matchingOption = schemaUtils.getClosestMatchingOption(
-          formData,
-          nextState.retrievedOptions,
-          nextState.selectedOption,
-          discriminator,
-        );
-        if (matchingOption !== nextState.selectedOption) {
-          nextState = { ...nextState, selectedOption: matchingOption };
-        }
+        return;
+      }
+      const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
+      const matchingOption = schemaUtils.getClosestMatchingOption(
+        formData,
+        retrievedOptions,
+        selectedOption,
+        discriminator,
+      );
+      if (matchingOption !== selectedOption) {
+        setSelectedOption(matchingOption);
       }
     }
-    nextState = { ...nextState, prevFormData: formData };
-  }
-
-  if (fieldPathId.$id !== state.prevFieldId) {
-    nextState = { ...nextState, prevFieldId: fieldPathId.$id };
-  }
-
-  if (nextState !== state) {
-    dispatch({ type: 'UPDATE_STATE', payload: nextState });
-  }
+  });
 
   const fieldId = `${fieldPathId.$id}${schema.oneOf ? '__oneof_select' : '__anyof_select'}`;
 
@@ -147,7 +102,6 @@ function AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends 
    */
   const onOptionChange = useCallback(
     (option?: string) => {
-      const { selectedOption, retrievedOptions } = nextState;
       if (disabled || readonly) {
         return;
       }
@@ -165,12 +119,12 @@ function AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends 
         newFormData = schemaUtils.getDefaultFormState(newOption, newFormData, 'excludeObjectChildren') as T;
       }
 
-      dispatch({ type: 'SET_SELECTED_OPTION', payload: intOption });
+      setSelectedOption(intOption);
       skipNextOptionRecalculation.current = true;
       onChange(newFormData, fieldPathId.path, undefined, fieldId);
     },
-    // dispatch is stable (guaranteed by useReducer); skipNextOptionRecalculation is a ref (no re-render on write)
-    [nextState, disabled, readonly, schemaUtils, formData, fieldPathId, onChange, fieldId, dispatch],
+    // setSelectedOption is stable (guaranteed by useState); skipNextOptionRecalculation is a ref
+    [selectedOption, retrievedOptions, disabled, readonly, schemaUtils, formData, fieldPathId, onChange, fieldId],
   );
 
   const { widgets, fields, translateString, globalUiOptions } = registry;
@@ -183,7 +137,6 @@ function AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends 
   const isOptionalRender = shouldRenderOptionalField<T, S, F>(registry, schema, required, uiSchema);
   const hasFormData = isFormDataAvailable<T>(formData);
 
-  const { selectedOption, retrievedOptions } = nextState;
   const {
     widget = 'select',
     placeholder,

--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useCallback, useReducer, useRef } from 'react';
 import type { FieldProps, FormContextType, RJSFSchema, StrictRJSFSchema, UiSchema } from '@rjsf/utils';
 import {
   ANY_OF_KEY,
@@ -19,11 +19,35 @@ import isEmpty from 'lodash/isEmpty';
 import omit from 'lodash/omit';
 
 /** Type used for the state of the `AnyOfField` component */
-interface AnyOfFieldState<S extends StrictRJSFSchema = RJSFSchema> {
+interface AnyOfFieldState<T = any, S extends StrictRJSFSchema = RJSFSchema> {
   /** The currently selected option */
   selectedOption: number;
   /** The option schemas after retrieving all $refs */
   retrievedOptions: S[];
+  /** Snapshot of the `options` prop — used to detect changes and re-cache retrievedOptions */
+  prevOptions: S[];
+  /** Snapshot of `formData` — used to detect changes and re-match the selected option */
+  prevFormData: T | undefined;
+  /** Snapshot of `fieldPathId.$id` — used to suppress option re-matching when the field itself changes */
+  prevFieldId: string;
+}
+
+type AnyOfFieldAction<T = any, S extends StrictRJSFSchema = RJSFSchema> =
+  | { type: 'SET_SELECTED_OPTION'; payload: number }
+  | { type: 'UPDATE_STATE'; payload: AnyOfFieldState<T, S> };
+
+function anyOfFieldReducer<T = any, S extends StrictRJSFSchema = RJSFSchema>(
+  state: AnyOfFieldState<T, S>,
+  action: AnyOfFieldAction<T, S>,
+): AnyOfFieldState<T, S> {
+  switch (action.type) {
+    case 'SET_SELECTED_OPTION':
+      return { ...state, selectedOption: action.payload };
+    case 'UPDATE_STATE':
+      return action.payload;
+    default:
+      return state;
+  }
 }
 
 /** The `AnyOfField` component is used to render a field in the schema that is an `anyOf`, `allOf` or `oneOf`. It tracks
@@ -31,89 +55,89 @@ interface AnyOfFieldState<S extends StrictRJSFSchema = RJSFSchema> {
  *
  * @param props - The `FieldProps` for this template
  */
-class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any> extends Component<
-  FieldProps<T, S, F>,
-  AnyOfFieldState<S>
-> {
+function AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: FieldProps<T, S, F>,
+) {
+  const {
+    name,
+    disabled = false,
+    errorSchema = {},
+    formData,
+    fieldPathId,
+    onBlur,
+    onChange,
+    onFocus,
+    options,
+    readonly,
+    registry,
+    required = false,
+    schema,
+    uiSchema,
+  } = props;
+  const { schemaUtils } = registry;
+
   /** Flag to skip the formData-change-driven option recalculation when the user just selected an option.
-   * Set to true in the setState callback of onOptionChange (after onChange is called), consumed and reset in
-   * componentDidUpdate. This prevents the matching-option recalculation from overriding a user's explicit choice
-   * when getDefaultFormState populates undefined properties that make deepEquals see a false formData change.
+   * Set to true in onOptionChange (before onChange is called), consumed and reset during the next render.
+   * This prevents the matching-option recalculation from overriding a user's explicit choice when
+   * getDefaultFormState populates undefined properties that make deepEquals see a false formData change.
    */
-  private skipNextOptionRecalculation = false;
-  /** Constructs an `AnyOfField` with the given `props` to initialize the initially selected option in state
-   *
-   * @param props - The `FieldProps` for this template
-   */
-  constructor(props: FieldProps<T, S, F>) {
-    super(props);
+  const skipNextOptionRecalculation = useRef(false);
 
-    const {
-      formData,
-      options,
-      registry: { schemaUtils },
-    } = this.props;
-    // cache the retrieved options in state in case they have $refs to save doing it later
+  const [state, dispatch] = useReducer(
+    anyOfFieldReducer as (state: AnyOfFieldState<T, S>, action: AnyOfFieldAction<T, S>) => AnyOfFieldState<T, S>,
+    null,
+    (_: null): AnyOfFieldState<T, S> => {
+      const retrievedOptions = options.map((opt: S) => schemaUtils.retrieveSchema(opt, formData));
+      const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
+      return {
+        retrievedOptions,
+        selectedOption: schemaUtils.getClosestMatchingOption(formData, retrievedOptions, 0, discriminator),
+        prevOptions: options,
+        prevFormData: formData,
+        prevFieldId: fieldPathId.$id,
+      };
+    },
+  );
+
+  // getDerivedStateFromProps pattern: compute any state updates during the render phase rather than in a
+  // useEffect. When dispatch is called here, React immediately re-renders with the new state and discards
+  // the current render's output before any DOM commit, so there is no visible flicker or extra paint.
+  let nextState = state;
+
+  if (!deepEquals(state.prevOptions, options)) {
     const retrievedOptions = options.map((opt: S) => schemaUtils.retrieveSchema(opt, formData));
-
-    this.state = {
-      retrievedOptions,
-      selectedOption: this.getMatchingOption(0, formData, retrievedOptions),
-    };
+    nextState = { ...nextState, retrievedOptions, prevOptions: options };
   }
 
-  /** React lifecycle method that is called when the props and/or state for this component is updated. It recomputes the
-   * currently selected option based on the overall `formData`
-   *
-   * @param prevProps - The previous `FieldProps` for this template
-   * @param prevState - The previous `AnyOfFieldState` for this template
-   */
-  componentDidUpdate(prevProps: Readonly<FieldProps<T, S, F>>, prevState: Readonly<AnyOfFieldState>) {
-    const { formData, options, fieldPathId } = this.props;
-    const { selectedOption } = this.state;
-    let newState = this.state;
-    if (!deepEquals(prevProps.options, options)) {
-      const {
-        registry: { schemaUtils },
-      } = this.props;
-      // re-cache the retrieved options in state in case they have $refs to save doing it later
-      const retrievedOptions = options.map((opt: S) => schemaUtils.retrieveSchema(opt, formData));
-      newState = { selectedOption, retrievedOptions };
-    }
-    if (!deepEquals(formData, prevProps.formData) && fieldPathId.$id === prevProps.fieldPathId.$id) {
-      if (this.skipNextOptionRecalculation) {
-        this.skipNextOptionRecalculation = false;
+  if (!deepEquals(formData, state.prevFormData)) {
+    if (fieldPathId.$id === state.prevFieldId) {
+      if (skipNextOptionRecalculation.current) {
+        skipNextOptionRecalculation.current = false;
       } else {
-        const { retrievedOptions } = newState;
-        const matchingOption = this.getMatchingOption(selectedOption, formData, retrievedOptions);
-
-        if (prevState && matchingOption !== selectedOption) {
-          newState = { selectedOption: matchingOption, retrievedOptions };
+        const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
+        const matchingOption = schemaUtils.getClosestMatchingOption(
+          formData,
+          nextState.retrievedOptions,
+          nextState.selectedOption,
+          discriminator,
+        );
+        if (matchingOption !== nextState.selectedOption) {
+          nextState = { ...nextState, selectedOption: matchingOption };
         }
       }
     }
-    if (newState !== this.state) {
-      // oxlint-disable-next-line react/no-did-update-set-state -- guarded to prevent infinite loop
-      this.setState(newState);
-    }
+    nextState = { ...nextState, prevFormData: formData };
   }
 
-  /** Determines the best matching option for the given `formData` and `options`.
-   *
-   * @param formData - The new formData
-   * @param options - The list of options to choose from
-   * @return - The index of the `option` that best matches the `formData`
-   */
-  getMatchingOption(selectedOption: number, formData: T | undefined, options: S[]) {
-    const {
-      schema,
-      registry: { schemaUtils },
-    } = this.props;
-
-    const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
-    const option = schemaUtils.getClosestMatchingOption(formData, options, selectedOption, discriminator);
-    return option;
+  if (fieldPathId.$id !== state.prevFieldId) {
+    nextState = { ...nextState, prevFieldId: fieldPathId.$id };
   }
+
+  if (nextState !== state) {
+    dispatch({ type: 'UPDATE_STATE', payload: nextState });
+  }
+
+  const fieldId = `${fieldPathId.$id}${schema.oneOf ? '__oneof_select' : '__anyof_select'}`;
 
   /** Callback handler to remember what the currently selected option is. In addition to that the `formData` is updated
    * to remove properties that are not part of the newly selected option schema, and then the updated data is passed to
@@ -121,177 +145,154 @@ class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
    *
    * @param option - The new option value being selected
    */
-  onOptionChange = (option?: string) => {
-    const { selectedOption, retrievedOptions } = this.state;
-    const { disabled = false, formData, onChange, readonly = false, registry, fieldPathId } = this.props;
-    if (disabled || readonly) {
-      return;
-    }
-    const { schemaUtils } = registry;
-    const intOption = option !== undefined ? parseInt(option, 10) : -1;
-    if (intOption === selectedOption) {
-      return;
-    }
-    const newOption = intOption >= 0 ? retrievedOptions[intOption] : undefined;
-    const oldOption = selectedOption >= 0 ? retrievedOptions[selectedOption] : undefined;
+  const onOptionChange = useCallback(
+    (option?: string) => {
+      const { selectedOption, retrievedOptions } = nextState;
+      if (disabled || readonly) {
+        return;
+      }
+      const intOption = option !== undefined ? parseInt(option, 10) : -1;
+      if (intOption === selectedOption) {
+        return;
+      }
+      const newOption = intOption >= 0 ? retrievedOptions[intOption] : undefined;
+      const oldOption = selectedOption >= 0 ? retrievedOptions[selectedOption] : undefined;
 
-    let newFormData = schemaUtils.sanitizeDataForNewSchema(newOption, oldOption, formData);
-    if (newOption) {
-      // Call getDefaultFormState to make sure defaults are populated on change. Pass "excludeObjectChildren"
-      // so that only the root objects themselves are created without adding undefined children properties
-      newFormData = schemaUtils.getDefaultFormState(newOption, newFormData, 'excludeObjectChildren') as T;
+      let newFormData = schemaUtils.sanitizeDataForNewSchema(newOption, oldOption, formData);
+      if (newOption) {
+        // Call getDefaultFormState to make sure defaults are populated on change. Pass "excludeObjectChildren"
+        // so that only the root objects themselves are created without adding undefined children properties
+        newFormData = schemaUtils.getDefaultFormState(newOption, newFormData, 'excludeObjectChildren') as T;
+      }
+
+      dispatch({ type: 'SET_SELECTED_OPTION', payload: intOption });
+      skipNextOptionRecalculation.current = true;
+      onChange(newFormData, fieldPathId.path, undefined, fieldId);
+    },
+    // dispatch is stable (guaranteed by useReducer); skipNextOptionRecalculation is a ref (no re-render on write)
+    [nextState, disabled, readonly, schemaUtils, formData, fieldPathId, onChange, fieldId, dispatch],
+  );
+
+  const { widgets, fields, translateString, globalUiOptions } = registry;
+  const { SchemaField: SchemaFieldComponent } = fields;
+  const MultiSchemaFieldTemplate = getTemplate<'MultiSchemaFieldTemplate', T, S, F>(
+    'MultiSchemaFieldTemplate',
+    registry,
+    globalUiOptions,
+  );
+  const isOptionalRender = shouldRenderOptionalField<T, S, F>(registry, schema, required, uiSchema);
+  const hasFormData = isFormDataAvailable<T>(formData);
+
+  const { selectedOption, retrievedOptions } = nextState;
+  const {
+    widget = 'select',
+    placeholder,
+    autofocus,
+    autocomplete,
+    title = schema.title,
+    ...uiOptions
+  } = getUiOptions<T, S, F>(uiSchema, globalUiOptions);
+  const Widget = getWidget<T, S, F>({ type: 'number' }, widget, widgets);
+  const rawErrors = get(errorSchema, ERRORS_KEY, []);
+  const fieldErrorSchema = omit(errorSchema, [ERRORS_KEY]);
+  const displayLabel = schemaUtils.getDisplayLabel(schema, uiSchema, globalUiOptions);
+
+  const option = selectedOption >= 0 ? retrievedOptions[selectedOption] || null : null;
+  let optionSchema: S | undefined | null;
+
+  if (option) {
+    const { required: schemaRequired, type: schemaType } = schema;
+    const parentProps: Partial<S> = {};
+    if (schemaRequired) {
+      parentProps.required = schemaRequired as S['required'];
     }
-
-    this.setState({ selectedOption: intOption }, () => {
-      this.skipNextOptionRecalculation = true;
-      onChange(newFormData, fieldPathId.path, undefined, this.getFieldId());
-    });
-  };
-
-  getFieldId() {
-    const { fieldPathId, schema } = this.props;
-    return `${fieldPathId.$id}${schema.oneOf ? '__oneof_select' : '__anyof_select'}`;
+    // Propagate the parent schema type to options that don't define their own.
+    // This is necessary when the parent constrains the type (e.g. { type: 'string',
+    // oneOf: [{ pattern: '...' }, { pattern: '...' }] }) but the option sub-schemas
+    // omit the type — without it, getSchemaType returns undefined and the option
+    // renders as FallbackField instead of the correct widget (e.g. StringField).
+    if (schemaType !== undefined && !('type' in option)) {
+      parentProps.type = schemaType;
+    }
+    // Merge in all the non-oneOf/anyOf properties and also skip the special ADDITIONAL_PROPERTY_FLAG property
+    optionSchema = Object.keys(parentProps).length > 0 ? (mergeSchemas(parentProps, option) as S) : option;
   }
 
-  /** Renders the `AnyOfField` selector along with a `SchemaField` for the value of the `formData`
-   */
-  render() {
-    const {
-      name,
-      disabled = false,
-      errorSchema = {},
-      formData,
-      onBlur,
-      onFocus,
-      readonly,
-      required = false,
-      registry,
-      schema,
-      uiSchema,
-    } = this.props;
-
-    const { widgets, fields, translateString, globalUiOptions, schemaUtils } = registry;
-    const { SchemaField: SchemaFieldComponent } = fields;
-    const MultiSchemaFieldTemplate = getTemplate<'MultiSchemaFieldTemplate', T, S, F>(
-      'MultiSchemaFieldTemplate',
-      registry,
-      globalUiOptions,
-    );
-    const isOptionalRender = shouldRenderOptionalField<T, S, F>(registry, schema, required, uiSchema);
-    const hasFormData = isFormDataAvailable<T>(formData);
-
-    const { selectedOption, retrievedOptions } = this.state;
-    const {
-      widget = 'select',
-      placeholder,
-      autofocus,
-      autocomplete,
-      title = schema.title,
-      ...uiOptions
-    } = getUiOptions<T, S, F>(uiSchema, globalUiOptions);
-    const Widget = getWidget<T, S, F>({ type: 'number' }, widget, widgets);
-    const rawErrors = get(errorSchema, ERRORS_KEY, []);
-    const fieldErrorSchema = omit(errorSchema, [ERRORS_KEY]);
-    const displayLabel = schemaUtils.getDisplayLabel(schema, uiSchema, globalUiOptions);
-
-    const option = selectedOption >= 0 ? retrievedOptions[selectedOption] || null : null;
-    let optionSchema: S | undefined | null;
-
-    if (option) {
-      const { required: schemaRequired, type: schemaType } = schema;
-      const parentProps: Partial<S> = {};
-      if (schemaRequired) {
-        parentProps.required = schemaRequired as S['required'];
-      }
-      // Propagate the parent schema type to options that don't define their own.
-      // This is necessary when the parent constrains the type (e.g. { type: 'string',
-      // oneOf: [{ pattern: '...' }, { pattern: '...' }] }) but the option sub-schemas
-      // omit the type — without it, getSchemaType returns undefined and the option
-      // renders as FallbackField instead of the correct widget (e.g. StringField).
-      if (schemaType !== undefined && !('type' in option)) {
-        parentProps.type = schemaType;
-      }
-      // Merge in all the non-oneOf/anyOf properties and also skip the special ADDITIONAL_PROPERTY_FLAG property
-      optionSchema = Object.keys(parentProps).length > 0 ? (mergeSchemas(parentProps, option) as S) : option;
+  // First we will check to see if there is an anyOf/oneOf override for the UI schema
+  let optionsUiSchema: UiSchema<T, S, F>[] = [];
+  if (ONE_OF_KEY in schema && uiSchema && ONE_OF_KEY in uiSchema) {
+    if (Array.isArray(uiSchema[ONE_OF_KEY])) {
+      optionsUiSchema = uiSchema[ONE_OF_KEY];
+    } else {
+      // oxlint-disable-next-line no-console
+      console.warn(`uiSchema.oneOf is not an array for "${title || name}"`);
     }
-
-    // First we will check to see if there is an anyOf/oneOf override for the UI schema
-    let optionsUiSchema: UiSchema<T, S, F>[] = [];
-    if (ONE_OF_KEY in schema && uiSchema && ONE_OF_KEY in uiSchema) {
-      if (Array.isArray(uiSchema[ONE_OF_KEY])) {
-        optionsUiSchema = uiSchema[ONE_OF_KEY];
-      } else {
-        // oxlint-disable-next-line no-console
-        console.warn(`uiSchema.oneOf is not an array for "${title || name}"`);
-      }
-    } else if (ANY_OF_KEY in schema && uiSchema && ANY_OF_KEY in uiSchema) {
-      if (Array.isArray(uiSchema[ANY_OF_KEY])) {
-        optionsUiSchema = uiSchema[ANY_OF_KEY];
-      } else {
-        // oxlint-disable-next-line no-console
-        console.warn(`uiSchema.anyOf is not an array for "${title || name}"`);
-      }
+  } else if (ANY_OF_KEY in schema && uiSchema && ANY_OF_KEY in uiSchema) {
+    if (Array.isArray(uiSchema[ANY_OF_KEY])) {
+      optionsUiSchema = uiSchema[ANY_OF_KEY];
+    } else {
+      // oxlint-disable-next-line no-console
+      console.warn(`uiSchema.anyOf is not an array for "${title || name}"`);
     }
-    // Then we pick the one that matches the selected option index, if one exists otherwise default to the main uiSchema
-    let optionUiSchema = uiSchema;
-    if (selectedOption >= 0 && optionsUiSchema.length > selectedOption) {
-      optionUiSchema = optionsUiSchema[selectedOption];
-    }
+  }
+  // Then we pick the one that matches the selected option index, if one exists otherwise default to the main uiSchema
+  let optionUiSchema = uiSchema;
+  if (selectedOption >= 0 && optionsUiSchema.length > selectedOption) {
+    optionUiSchema = optionsUiSchema[selectedOption];
+  }
 
-    const translateEnum: TranslatableString = title
-      ? TranslatableString.TitleOptionPrefix
-      : TranslatableString.OptionPrefix;
-    const translateParams = title ? [title] : [];
-    const enumOptions = retrievedOptions.map((opt: { title?: string }, index: number) => {
-      // Also see if there is an override title in the uiSchema for each option, otherwise use the title from the option
-      const { title: uiTitle = opt.title } = getUiOptions<T, S, F>(optionsUiSchema[index]);
-      return {
-        label: uiTitle || translateString(translateEnum, translateParams.concat(String(index + 1))),
-        value: index,
-      };
-    });
+  const translateEnum: TranslatableString = title
+    ? TranslatableString.TitleOptionPrefix
+    : TranslatableString.OptionPrefix;
+  const translateParams = title ? [title] : [];
+  const enumOptions = retrievedOptions.map((opt: { title?: string }, index: number) => {
+    const { title: uiTitle = opt.title } = getUiOptions<T, S, F>(optionsUiSchema[index]);
+    return {
+      label: uiTitle || translateString(translateEnum, translateParams.concat(String(index + 1))),
+      value: index,
+    };
+  });
 
-    const selector =
-      !isOptionalRender || hasFormData ? (
-        <Widget
-          id={this.getFieldId()}
-          name={`${name}${schema.oneOf ? '__oneof_select' : '__anyof_select'}`}
-          schema={{ type: 'number', default: 0 } as S}
-          onChange={this.onOptionChange}
-          onBlur={onBlur}
-          onFocus={onFocus}
-          disabled={disabled || isEmpty(enumOptions)}
-          multiple={false}
-          rawErrors={rawErrors}
-          errorSchema={fieldErrorSchema}
-          value={selectedOption >= 0 ? selectedOption : undefined}
-          options={{ enumOptions, ...uiOptions }}
-          registry={registry}
-          placeholder={placeholder}
-          autocomplete={autocomplete}
-          autofocus={autofocus}
-          label={title ?? name}
-          hideLabel={!displayLabel}
-          readonly={readonly}
-        />
-      ) : undefined;
-
-    const optionsSchemaField =
-      (optionSchema && optionSchema.type !== 'null' && (
-        <SchemaFieldComponent {...this.props} schema={optionSchema} uiSchema={optionUiSchema} />
-      )) ||
-      null;
-
-    return (
-      <MultiSchemaFieldTemplate
-        schema={schema}
+  const selector =
+    !isOptionalRender || hasFormData ? (
+      <Widget
+        id={fieldId}
+        name={`${name}${schema.oneOf ? '__oneof_select' : '__anyof_select'}`}
+        schema={{ type: 'number', default: 0 } as S}
+        onChange={onOptionChange}
+        onBlur={onBlur}
+        onFocus={onFocus}
+        disabled={disabled || isEmpty(enumOptions)}
+        multiple={false}
+        rawErrors={rawErrors}
+        errorSchema={fieldErrorSchema}
+        value={selectedOption >= 0 ? selectedOption : undefined}
+        options={{ enumOptions, ...uiOptions }}
         registry={registry}
-        uiSchema={uiSchema}
-        selector={selector}
-        optionSchemaField={optionsSchemaField}
+        placeholder={placeholder}
+        autocomplete={autocomplete}
+        autofocus={autofocus}
+        label={title ?? name}
+        hideLabel={!displayLabel}
+        readonly={readonly}
       />
-    );
-  }
+    ) : undefined;
+
+  const optionsSchemaField =
+    (optionSchema && optionSchema.type !== 'null' && (
+      <SchemaFieldComponent {...props} schema={optionSchema} uiSchema={optionUiSchema} />
+    )) ||
+    null;
+
+  return (
+    <MultiSchemaFieldTemplate
+      schema={schema}
+      registry={registry}
+      uiSchema={uiSchema}
+      selector={selector}
+      optionSchemaField={optionsSchemaField}
+    />
+  );
 }
 
 export default AnyOfField;

--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -8,6 +8,7 @@ import {
   getTemplate,
   getUiOptions,
   getWidget,
+  hashObject,
   isFormDataAvailable,
   mergeSchemas,
   ONE_OF_KEY,
@@ -44,11 +45,16 @@ function AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends 
   } = props;
   const { schemaUtils } = registry;
 
+  // Hash formData by value so the memo only invalidates when data actually changes, not on every
+  // new object reference. hashObject(undefined) throws, so null is used as the fallback.
+  const formDataHash = hashObject(formData ?? null);
+
   // retrievedOptions is purely derived from options — useMemo handles re-derivation automatically
-  // when options, schemaUtils, or formData change, with no render-phase dispatch needed.
+  // when options, schemaUtils, or formData's value changes, with no render-phase dispatch needed.
   const retrievedOptions = useMemo(
     () => options.map((opt: S) => schemaUtils.retrieveSchema(opt, formData)),
-    [options, schemaUtils, formData],
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- formDataHash is the value-stable proxy for formData
+    [options, schemaUtils, formDataHash],
   );
 
   const [selectedOption, setSelectedOption] = useState<number>(() => {


### PR DESCRIPTION
### Reasons for making this change

Replaces the class-based AnyOfField with a functional component using useReducer for state management. State snapshots (prevOptions, prevFormData, prevFieldId) replace the three useRef prev-trackers and useEffect, using React's getDerivedStateFromProps render-phase dispatch pattern instead — React re-renders immediately from those dispatches and discards the current render before any DOM commit. onOptionChange is wrapped in useCallback.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
