### PR TITLE
fix: passing value prop on CommandItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated the single select trigger to use native button semantics with expanded and disabled state coverage, fixing [#4764](https://github.com/rjsf-team/react-jsonschema-form/issues/4764) ([#5117](https://github.com/rjsf-team/react-jsonschema-form/pull/5117))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
+- Fixed a small visual bug [#5126](https://github.com/rjsf-team/react-jsonschema-form/issues/5126) that caused hovering over items of `FancySelect` and `FancyMultiSelect` that have the same label to incorrectly highlight more than one element ([#5141](https://github.com/rjsf-team/react-jsonschema-form/pull/5141))
 
 ## @rjsf/utils
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated the single select trigger to use native button semantics with expanded and disabled state coverage, fixing [#4764](https://github.com/rjsf-team/react-jsonschema-form/issues/4764) ([#5117](https://github.com/rjsf-team/react-jsonschema-form/pull/5117))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
-- Fixed a small visual bug [#5126](https://github.com/rjsf-team/react-jsonschema-form/issues/5126) that caused hovering over items of `FancySelect` and `FancyMultiSelect` that have the same label to incorrectly highlight more than one element ([#5141](https://github.com/rjsf-team/react-jsonschema-form/pull/5141))
+- Fixed a small visual bug that caused hovering over items of `FancySelect` and `FancyMultiSelect` that have the same label to incorrectly highlight more than one element, fixing [#5126](https://github.com/rjsf-team/react-jsonschema-form/issues/5126)
 
 ## @rjsf/utils
 

--- a/packages/shadcn/src/components/ui/fancy-multi-select.tsx
+++ b/packages/shadcn/src/components/ui/fancy-multi-select.tsx
@@ -208,6 +208,7 @@ export function FancyMultiSelect({
                     aria-controls={`${item.value}-command-item`}
                     aria-labelledby={`${item.value}-command-item`}
                     id={`${item.value}-command-item`}
+                    value={item.value}
                     onSelect={() => handleSelect(item)}
                     className='cursor-pointer'
                   >

--- a/packages/shadcn/src/components/ui/fancy-select.tsx
+++ b/packages/shadcn/src/components/ui/fancy-select.tsx
@@ -142,6 +142,7 @@ export function FancySelect({
                       e.preventDefault();
                       e.stopPropagation();
                     }}
+                    value={item.value}
                     onSelect={() => {
                       if (!item.disabled) {
                         onValueChange?.(item.value);

--- a/packages/shadcn/test/SelectWidget.test.tsx
+++ b/packages/shadcn/test/SelectWidget.test.tsx
@@ -78,4 +78,94 @@ describe('SelectWidget', () => {
     await user.tab();
     expect(screen.getByRole('button', { name: 'After select' })).toHaveFocus();
   });
+
+  test('hovering over elements with duplicate labels only highlights the correct one by value', async () => {
+    const user = userEvent.setup();
+    render(
+      <SelectWidget
+        {...makeWidgetMockProps({
+          autofocus: false,
+          disabled: false,
+          readonly: false,
+          rawErrors: [],
+          value: undefined,
+          placeholder: 'Select a vehicle',
+          options: {
+            enumOptions: [
+              { label: 'Car', value: 'car1' },
+              { label: 'Car', value: 'car2' },
+              { label: 'Bike', value: 'bike' },
+            ],
+          },
+        })}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', { name: /select a vehicle/i });
+    await user.click(trigger);
+
+    const carOptions = screen.getAllByRole('option', { name: 'Car' });
+    expect(carOptions).toHaveLength(2);
+
+    await user.hover(carOptions[0]);
+
+    expect(carOptions[0]).toHaveAttribute('aria-selected', 'true');
+    expect(carOptions[0]).toHaveAttribute('data-selected', 'true');
+
+    expect(carOptions[1]).toHaveAttribute('aria-selected', 'false');
+    expect(carOptions[1]).toHaveAttribute('data-selected', 'false');
+
+    await user.hover(carOptions[1]);
+
+    expect(carOptions[0]).toHaveAttribute('aria-selected', 'false');
+    expect(carOptions[0]).toHaveAttribute('data-selected', 'false');
+
+    expect(carOptions[1]).toHaveAttribute('aria-selected', 'true');
+    expect(carOptions[1]).toHaveAttribute('data-selected', 'true');
+  });
+
+  test('multi-select: hovering over elements with duplicate labels only highlights the correct one by value', async () => {
+    const user = userEvent.setup();
+    render(
+      <SelectWidget
+        {...makeWidgetMockProps({
+          autofocus: false,
+          disabled: false,
+          readonly: false,
+          multiple: true,
+          rawErrors: [],
+          value: [],
+          options: {
+            enumOptions: [
+              { label: 'Car', value: 'car1' },
+              { label: 'Car', value: 'car2' },
+              { label: 'Bike', value: 'bike' },
+            ],
+          },
+        })}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText('Select ...');
+    await user.click(input);
+
+    const carOptions = screen.getAllByRole('option', { name: 'Car' });
+    expect(carOptions).toHaveLength(2);
+
+    await user.hover(carOptions[0]);
+
+    expect(carOptions[0]).toHaveAttribute('aria-selected', 'true');
+    expect(carOptions[0]).toHaveAttribute('data-selected', 'true');
+
+    expect(carOptions[1]).toHaveAttribute('aria-selected', 'false');
+    expect(carOptions[1]).toHaveAttribute('data-selected', 'false');
+
+    await user.hover(carOptions[1]);
+
+    expect(carOptions[0]).toHaveAttribute('aria-selected', 'false');
+    expect(carOptions[0]).toHaveAttribute('data-selected', 'false');
+
+    expect(carOptions[1]).toHaveAttribute('aria-selected', 'true');
+    expect(carOptions[1]).toHaveAttribute('data-selected', 'true');
+  });
 });


### PR DESCRIPTION
### Reasons for making this change

Now CommandItem on the fancy-select and fancy-multi-select components for shadcn package passes the list item value as a value prop to avoid a small visual bug when hovering over two elements with the same label

Fixes #5126

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
