### PR TITLE
Fix playground: Use correct names for `nestedDefaultsPrecedence` option

### DIFF
--- a/packages/playground/src/components/OptionsDrawer.tsx
+++ b/packages/playground/src/components/OptionsDrawer.tsx
@@ -205,17 +205,17 @@ const liveSettingsBooleanSchema: RJSFSchema = {
         nestedDefaultsPrecedence: {
           type: 'string',
           title: 'Nested defaults precedence',
-          default: 'innermostWins',
+          default: 'descendantWins',
           oneOf: [
             {
               type: 'string',
-              title: 'Innermost default value wins',
-              enum: ['innermostWins'],
+              title: 'Innermost (descendant) default value value wins',
+              enum: ['descendantWins'],
             },
             {
               type: 'string',
-              title: 'Outermost default value wins',
-              enum: ['outermostWins'],
+              title: 'Outermost (ancestor) default value wins',
+              enum: ['ancestorWins'],
             },
           ],
         },

--- a/packages/playground/src/components/OptionsDrawer.tsx
+++ b/packages/playground/src/components/OptionsDrawer.tsx
@@ -209,7 +209,7 @@ const liveSettingsBooleanSchema: RJSFSchema = {
           oneOf: [
             {
               type: 'string',
-              title: 'Innermost (descendant) default value value wins',
+              title: 'Innermost (descendant) default value wins',
               enum: ['descendantWins'],
             },
             {


### PR DESCRIPTION
### Reasons for making this change

This is a follow-up PR to #5110 to fix the option names in the playground. As pointed out [here](https://github.com/rjsf-team/react-jsonschema-form/pull/5110#discussion_r3499273581), I missed updating those when renaming them from `innermostWins`/`outermostWins` to `descendantWins`/`ancestorWins`. This PR updates them in the playground accordingly. I decided to keep the short description text consistent with the description in `packages/utils/src/types.ts`, hence the "Innermost (descendant) [...]" and "Outermost (ancestor) [...]".

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

No addition to the changelog since the initial change hasn't been released yet.

Quick confirmation that setting the option in the playground actually works now:
<img width="1156" height="1006" alt="image" src="https://github.com/user-attachments/assets/c1a305d1-2849-431b-be19-5307547148c0" />


As for why this happened, I probably didn't miss the change initially when renaming things but remember doing some kind of git oopsie on what would have been the final commit, which led me to manually copy-paste some changes. I'm guessing that's where I forgot updating that file.

Sorry for the trouble and thanks to @x0k for pointing out the error :+1: