### PR TITLE
Fix 5142: omitExtraData preserves properties from if/then/else entries remaining in allOf after merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `retrieveSchema()` to preserve boolean conditional branches while resolving schemas, fixing [#4476](https://github.com/rjsf-team/react-jsonschema-form/issues/4476) ([#5101](https://github.com/rjsf-team/react-jsonschema-form/pull/5101))
 - Updated `Experimental_DefaultFormStateBehavior` to add a new `nestedDefaultsPrecedence` option
 - Updated `getDefaultFormState()` to use the new `nestedDefaultsPrecedence` option to control how defaults defined on multiple levels are merged together, fixing [#5089](https://github.com/rjsf-team/react-jsonschema-form/issues/5089)
+- Updated `omitExtraData()` to better handle `allOf`s containing multiple `if/then/else` blocks, matching fix in `SJSF`, fixing [#5142](https://github.com/rjsf-team/react-jsonschema-form/issues/5142)
 
 ## @rjsf/validator-ajv8
 

--- a/packages/utils/src/schema/omitExtraData.ts
+++ b/packages/utils/src/schema/omitExtraData.ts
@@ -448,6 +448,17 @@ export default function omitExtraData<
     }
     if (allOf) {
       localSchema = doMergeAllOf<S>(localSchema, experimental_customMergeAllOf);
+      // Schemas whose allOf entries contain if/then/else keywords may not fully merge: the merger
+      // can only hoist one if/then/else triple to the parent level, so additional entries stay in
+      // allOf. Process any that remain so their conditional properties are not silently dropped.
+      // See: https://github.com/rjsf-team/react-jsonschema-form/issues/5142
+      const remainingAllOf = localSchema.allOf;
+      if (remainingAllOf) {
+        for (let i = 0; i < remainingAllOf.length; i++) {
+          // oxlint-disable-next-line no-param-reassign
+          target = omit(remainingAllOf[i] as S | boolean, source, target);
+        }
+      }
     }
 
     let filtered = handleAnyOf(localSchema, source, handleOneOf(localSchema.oneOf, localSchema, source, target));

--- a/packages/utils/test/schema/omitExtraDataTest.ts
+++ b/packages/utils/test/schema/omitExtraDataTest.ts
@@ -1034,6 +1034,52 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
         expect(customMerge).toHaveBeenCalled();
         expect(result).toEqual({ foo: 'hi', bar: 1 });
       });
+
+      // Regression test for https://github.com/rjsf-team/react-jsonschema-form/issues/5142
+      // When allOf entries contain if/then/else, the merger can only hoist one triple to the
+      // parent level; subsequent entries remain in allOf after merging. Without the fix those
+      // remaining entries are never processed and their conditional properties are silently dropped.
+      it('preserves properties from if/then/else entries that remain in allOf after merging', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            prop1: { type: 'string', enum: ['without required', 'with required'] },
+          },
+          allOf: [
+            {
+              if: { properties: { prop1: { const: 'without required' } }, required: ['prop1'] },
+              then: {
+                properties: {
+                  prop3: { type: 'object', properties: { subprop1: { type: 'string' } } },
+                },
+              },
+            },
+            {
+              if: { properties: { prop1: { const: 'with required' } }, required: ['prop1'] },
+              then: {
+                required: ['prop2'],
+                properties: {
+                  prop2: {
+                    type: 'object',
+                    required: ['subprop1', 'subprop2'],
+                    properties: {
+                      subprop1: { type: 'string' },
+                      subprop2: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        };
+        const formData = { prop1: 'with required', prop2: { subprop1: '123', subprop2: '456' } };
+        // The merger hoists the first if/then to the top level; the second stays in allOf.
+        // isValid calls: (1) second allOf item's if-condition → true (prop1 matches "with required"),
+        //                (2) hoisted top-level if-condition → false (prop1 does not match "without required")
+        testValidator.setReturnValues({ isValid: [true, false] });
+        const result = omitExtraData(testValidator, schema, schema, formData);
+        expect(result).toEqual({ prop1: 'with required', prop2: { subprop1: '123', subprop2: '456' } });
+      });
     });
 
     describe('patternProperties support', () => {


### PR DESCRIPTION
### Reasons for making this change

Fixes #5142 by applying analog fix from SJSF (x0k/svelte-jsonschema-form#409)

- Fixed `omitExtraData()` by iterating any allOf items still present after doMergeAllOf and running omit() on each one

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
