### PR TITLE
Fix 4448: preserve empty string titles in oneOf/anyOf options list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
+- Fixed `optionsList()` to preserve an explicitly empty string `title` on `oneOf`/`anyOf` options instead of falling back to the option's value, fixing [#4448](https://github.com/rjsf-team/react-jsonschema-form/issues/4448)
 - Updated `types.ts` to add `CyclicSchemaExpandProps` type and `CyclicSchemaExpandTemplate` in the `TemplatesType`
 - Updated `resolveAllReferences()` to add a new `markCycleOnDetection` prop which adds `RJSF_REF_CYCLE_KEY` marker (from `constants.ts`) to a schema that has been detected to have a cycle, partially fixing [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907)
 - Updated `hashForSchema()` to filter keys to remove `RJSF_REF_KEY` prefixed keys before hashing the schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,6 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
-- Fixed `optionsList()` to preserve an explicitly empty string `title` on `oneOf`/`anyOf` options instead of falling back to the option's value, fixing [#4448](https://github.com/rjsf-team/react-jsonschema-form/issues/4448)
 - Updated `types.ts` to add `CyclicSchemaExpandProps` type and `CyclicSchemaExpandTemplate` in the `TemplatesType`
 - Updated `resolveAllReferences()` to add a new `markCycleOnDetection` prop which adds `RJSF_REF_CYCLE_KEY` marker (from `constants.ts`) to a schema that has been detected to have a cycle, partially fixing [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907)
 - Updated `hashForSchema()` to filter keys to remove `RJSF_REF_KEY` prefixed keys before hashing the schema
@@ -86,6 +85,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `Experimental_DefaultFormStateBehavior` to add a new `nestedDefaultsPrecedence` option
 - Updated `getDefaultFormState()` to use the new `nestedDefaultsPrecedence` option to control how defaults defined on multiple levels are merged together, fixing [#5089](https://github.com/rjsf-team/react-jsonschema-form/issues/5089)
 - Updated `omitExtraData()` to better handle `allOf`s containing multiple `if/then/else` blocks, matching fix in `SJSF`, fixing [#5142](https://github.com/rjsf-team/react-jsonschema-form/issues/5142)
+- Fixed `optionsList()` to preserve an explicitly empty string `title` on `oneOf`/`anyOf` options instead of falling back to the option's value, fixing [#4448](https://github.com/rjsf-team/react-jsonschema-form/issues/4448)
 
 ## @rjsf/validator-ajv8
 

--- a/packages/utils/src/optionsList.ts
+++ b/packages/utils/src/optionsList.ts
@@ -87,10 +87,11 @@ export default function optionsList<T = any, S extends StrictRJSFSchema = RJSFSc
     if (selectorField) {
       const innerSchema: S = get(aSchema, [PROPERTIES_KEY, selectorField], {}) as S;
       value = get(innerSchema, DEFAULT_KEY, get(innerSchema, CONST_KEY));
-      label = label || innerSchema?.title || aSchema.title || String(value);
+      // Use nullish coalescing so that an explicitly empty string title is preserved
+      label = label ?? innerSchema?.title ?? aSchema.title ?? String(value);
     } else {
       value = toConstant(aSchema);
-      label = label || aSchema.title || String(value);
+      label = label ?? aSchema.title ?? String(value);
     }
     return {
       schema: aSchema,

--- a/packages/utils/test/optionsList.test.ts
+++ b/packages/utils/test/optionsList.test.ts
@@ -242,6 +242,44 @@ describe('optionsList()', () => {
         })),
       );
     });
+    it('should keep an empty string title for a oneOf option instead of falling back to the value', () => {
+      const oneOfSchema: RJSFSchema = {
+        type: 'string',
+        oneOf: [
+          {
+            const: 'empty',
+            title: '',
+          },
+          {
+            const: 'active',
+          },
+        ],
+      };
+      expect(optionsList(oneOfSchema)).toEqual([
+        { schema: oneOfSchema.oneOf![0], label: '', value: 'empty' },
+        { schema: oneOfSchema.oneOf![1], label: 'active', value: 'active' },
+      ]);
+    });
+    it('should keep an empty string title for a discriminator option instead of falling back to the value', () => {
+      const anyOfSchema: RJSFSchema = {
+        discriminator: {
+          propertyName: 'animal',
+        },
+        anyOf: [
+          {
+            type: 'object',
+            title: '',
+            properties: {
+              animal: {
+                type: 'string',
+                const: 'dog',
+              },
+            },
+          },
+        ],
+      };
+      expect(optionsList(anyOfSchema)).toEqual([{ schema: anyOfSchema.anyOf![0], label: '', value: 'dog' }]);
+    });
     it('should generate options for an anyOf object schema with a discriminator, titles in object', () => {
       const anyOfSchema: RJSFSchema = {
         title: 'string',


### PR DESCRIPTION
#### Reasons for making this change

`optionsList()` builds oneOf/anyOf option labels with `||` chains, so an explicitly empty string title (`{ const: 'empty', title: '' }`) is treated as missing and the label falls back to the const value. switched the fallbacks to `??` so an empty title is kept while `undefined` still falls through to the schema title / value as before. added tests for the plain oneOf case and the discriminator path.

fixes #4448

#### Checklist

- [x] I'm updating documentation — n/a, behavior matches the documented title precedence
- [x] I'm adding or updating code
  - [x] I've added and/or updated tests
  - [x] I've updated the CHANGELOG.md (in the follow-up commit with this PR's number)
