### PR TITLE
peerDependencies should reference the `workspace:^`

### DIFF
--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -64,8 +64,8 @@
   },
   "peerDependencies": {
     "@ant-design/icons": "^6.0.0",
-    "@rjsf/core": "^6.6.x",
-    "@rjsf/utils": "^6.6.x",
+    "@rjsf/core": "workspace:^",
+    "@rjsf/utils": "workspace:^",
     "antd": "^5 || >6.3.5",
     "dayjs": "^1.8.0",
     "react": ">=18"

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -65,8 +65,8 @@
   },
   "peerDependencies": {
     "@chakra-ui/react": ">=3.16.1",
-    "@rjsf/core": "^6.6.x",
-    "@rjsf/utils": "^6.6.x",
+    "@rjsf/core": "workspace:^",
+    "@rjsf/utils": "workspace:^",
     "chakra-react-select": ">=6",
     "react": ">=18"
   },
@@ -78,7 +78,7 @@
     "jzander <jeremy.zander@gmail.com>",
     "Rodrigo Fuentes <rodrigofuentes@users.noreply.github.com>",
     "U.M Andrew <me@andrewmiracle.com>",
-    "Heath Chiavettone <heath.chiavettone@freenome.com"
+    "Heath Chiavettone <heath.chiavettone@freenome.com>"
   ],
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@rjsf/utils": "^6.6.x",
+    "@rjsf/utils": "workspace:^",
     "react": ">=18"
   },
   "dependencies": {

--- a/packages/daisyui/package.json
+++ b/packages/daisyui/package.json
@@ -71,8 +71,8 @@
     "tailwindcss": "^4.3.1"
   },
   "peerDependencies": {
-    "@rjsf/core": "^6.6.x",
-    "@rjsf/utils": "^6.6.x",
+    "@rjsf/core": "workspace:^",
+    "@rjsf/utils": "workspace:^",
     "daisyui": "^5.0.29",
     "react": ">=18"
   },

--- a/packages/fluentui-rc/package.json
+++ b/packages/fluentui-rc/package.json
@@ -68,8 +68,8 @@
     "@fluentui/react-components": "^9.63.0",
     "@fluentui/react-icons": "^2.0.298",
     "@fluentui/react-migration-v0-v9": "^9.3.10",
-    "@rjsf/core": "^6.6.x",
-    "@rjsf/utils": "^6.6.x",
+    "@rjsf/core": "workspace:^",
+    "@rjsf/utils": "workspace:^",
     "react": ">=18"
   },
   "devDependencies": {

--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -65,8 +65,8 @@
     "@mantine/core": ">=8",
     "@mantine/dates": ">=8",
     "@mantine/hooks": ">=8",
-    "@rjsf/core": "^6.6.x",
-    "@rjsf/utils": "^6.6.x",
+    "@rjsf/core": "workspace:^",
+    "@rjsf/utils": "workspace:^",
     "react": ">=18"
   },
   "devDependencies": {

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -65,8 +65,8 @@
     "@emotion/styled": "^11.6.0",
     "@mui/icons-material": "^7.0.0 || ^9.0.0",
     "@mui/material": "^7.0.0 || ^9.0.0",
-    "@rjsf/core": "^6.6.x",
-    "@rjsf/utils": "^6.6.x",
+    "@rjsf/core": "workspace:^",
+    "@rjsf/utils": "workspace:^",
     "react": ">=18"
   },
   "devDependencies": {

--- a/packages/primereact/package.json
+++ b/packages/primereact/package.json
@@ -62,8 +62,8 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@rjsf/core": "^6.6.x",
-    "@rjsf/utils": "^6.6.x",
+    "@rjsf/core": "workspace:^",
+    "@rjsf/utils": "workspace:^",
     "primeicons": ">=6.0.0",
     "primereact": ">=8.0.0",
     "react": ">=18"

--- a/packages/react-bootstrap/package.json
+++ b/packages/react-bootstrap/package.json
@@ -62,8 +62,8 @@
     ]
   },
   "peerDependencies": {
-    "@rjsf/core": "^6.6.x",
-    "@rjsf/utils": "^6.6.x",
+    "@rjsf/core": "workspace:^",
+    "@rjsf/utils": "workspace:^",
     "react": ">=18",
     "react-bootstrap": "^2.x"
   },

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -62,8 +62,8 @@
     ]
   },
   "peerDependencies": {
-    "@rjsf/core": "^6.6.x",
-    "@rjsf/utils": "^6.6.x",
+    "@rjsf/core": "workspace:^",
+    "@rjsf/utils": "workspace:^",
     "react": ">=18",
     "semantic-ui-react": "^2.1.3"
   },

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -65,8 +65,8 @@
     ]
   },
   "peerDependencies": {
-    "@rjsf/core": "^6.6.x",
-    "@rjsf/utils": "^6.6.x",
+    "@rjsf/core": "workspace:^",
+    "@rjsf/utils": "workspace:^",
     "react": ">=18"
   },
   "engineStrict": false,

--- a/packages/snapshot-tests/package.json
+++ b/packages/snapshot-tests/package.json
@@ -29,8 +29,8 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@rjsf/core": "^6.6.x",
-    "@rjsf/utils": "^6.6.x",
+    "@rjsf/core": "workspace:^",
+    "@rjsf/utils": "workspace:^",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "react": ">=18"

--- a/packages/validator-ajv8/package.json
+++ b/packages/validator-ajv8/package.json
@@ -84,7 +84,7 @@
     "lodash-es": "^4.18.1"
   },
   "peerDependencies": {
-    "@rjsf/utils": "^6.6.x"
+    "@rjsf/utils": "workspace:^"
   },
   "devDependencies": {
     "@rjsf/utils": "workspace:^",

--- a/packages/validator-ata/package.json
+++ b/packages/validator-ata/package.json
@@ -82,7 +82,7 @@
     "lodash-es": "^4.18.1"
   },
   "peerDependencies": {
-    "@rjsf/utils": "^6.6.x"
+    "@rjsf/utils": "workspace:^"
   },
   "devDependencies": {
     "@rjsf/utils": "workspace:^",


### PR DESCRIPTION
With this change, the `peerDependencies` should always reference the published workspace version