### PR TITLE
Fix 4214: show selected option descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,17 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/antd
 
+- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
 
 ## @rjsf/chakra-ui
 
+- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
 
 ## @rjsf/core
 
+- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Fixed [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907) and [#4262](https://github.com/rjsf-team/react-jsonschema-form/issues/4262) as follows:
   - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
   - Added `CyclicSchemaField` to the list of fields, that renders the `CyclicSchemaExpandTemplate` initially and, if expanded, will render the `SchemaField` with the `RJSF_REF_CYCLE_KEY` tag turned off
@@ -42,40 +45,49 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/daisyui
 
+- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
 
 ## @rjsf/fluentui-rc
 
+- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
 
 ## @rjsf/mantine
 
+- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
 
 ## @rjsf/mui
 
+- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
 
 ## @rjsf/primereact
 
+- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
 
 ## @rjsf/react-bootstrap
 
+- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
 
 ## @rjsf/semantic-ui
 
+- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
 
 ## @rjsf/shadcn
 
+- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Updated the single select trigger to use native button semantics with expanded and disabled state coverage, fixing [#4764](https://github.com/rjsf-team/react-jsonschema-form/issues/4764) ([#5117](https://github.com/rjsf-team/react-jsonschema-form/pull/5117))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
 - Fixed a small visual bug that caused hovering over items of `FancySelect` and `FancyMultiSelect` that have the same label to incorrectly highlight more than one element, fixing [#5126](https://github.com/rjsf-team/react-jsonschema-form/issues/5126)
 
 ## @rjsf/utils
 
+- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Updated `types.ts` to add `CyclicSchemaExpandProps` type and `CyclicSchemaExpandTemplate` in the `TemplatesType`
 - Updated `resolveAllReferences()` to add a new `markCycleOnDetection` prop which adds `RJSF_REF_CYCLE_KEY` marker (from `constants.ts`) to a schema that has been detected to have a cycle, partially fixing [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907)
 - Updated `hashForSchema()` to filter keys to remove `RJSF_REF_KEY` prefixed keys before hashing the schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,17 +20,16 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/antd
 
-- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
+- Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 
 ## @rjsf/chakra-ui
 
-- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
+- Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 
 ## @rjsf/core
 
-- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Fixed [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907) and [#4262](https://github.com/rjsf-team/react-jsonschema-form/issues/4262) as follows:
   - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
   - Added `CyclicSchemaField` to the list of fields, that renders the `CyclicSchemaExpandTemplate` initially and, if expanded, will render the `SchemaField` with the `RJSF_REF_CYCLE_KEY` tag turned off
@@ -42,52 +41,52 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed nested `constAsDefaults` values being skipped in matching conditional `allOf` schemas, fixing [#4963](https://github.com/rjsf-team/react-jsonschema-form/issues/4963)
 - Fixed `processPendingChange` so that clearing a string field that has a schema `default` value no longer re-applies the default, fixing [#5125](https://github.com/rjsf-team/react-jsonschema-form/issues/5125)
 - Fixed a regression introduced in [#5136](https://github.com/rjsf-team/react-jsonschema-form/pull/5136) where clearing a second field caused a previously-cleared field to be re-populated with its schema default; uses `JSON.parse(JSON.stringify(...))` to strip `undefined`-valued keys from formData before AJV validation so that the [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix is preserved
+- Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 
 ## @rjsf/daisyui
 
-- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
+- Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 
 ## @rjsf/fluentui-rc
 
-- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
+- Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 
 ## @rjsf/mantine
 
-- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
+- Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 
 ## @rjsf/mui
 
-- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
+- Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 
 ## @rjsf/primereact
 
-- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
+- Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 
 ## @rjsf/react-bootstrap
 
-- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
+- Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 
 ## @rjsf/semantic-ui
 
-- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
+- Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 
 ## @rjsf/shadcn
 
-- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Updated the single select trigger to use native button semantics with expanded and disabled state coverage, fixing [#4764](https://github.com/rjsf-team/react-jsonschema-form/issues/4764) ([#5117](https://github.com/rjsf-team/react-jsonschema-form/pull/5117))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
 - Fixed a small visual bug that caused hovering over items of `FancySelect` and `FancyMultiSelect` that have the same label to incorrectly highlight more than one element, fixing [#5126](https://github.com/rjsf-team/react-jsonschema-form/issues/5126)
+- Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 
 ## @rjsf/utils
 
-- Fix 4214: show selected option descriptions ([#5152](https://github.com/rjsf-team/react-jsonschema-form/pull/5152))
 - Updated `types.ts` to add `CyclicSchemaExpandProps` type and `CyclicSchemaExpandTemplate` in the `TemplatesType`
 - Updated `resolveAllReferences()` to add a new `markCycleOnDetection` prop which adds `RJSF_REF_CYCLE_KEY` marker (from `constants.ts`) to a schema that has been detected to have a cycle, partially fixing [#3907](https://github.com/rjsf-team/react-jsonschema-form/issues/3907)
 - Updated `hashForSchema()` to filter keys to remove `RJSF_REF_KEY` prefixed keys before hashing the schema
@@ -99,6 +98,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `getDefaultFormState()` to use the new `nestedDefaultsPrecedence` option to control how defaults defined on multiple levels are merged together, fixing [#5089](https://github.com/rjsf-team/react-jsonschema-form/issues/5089)
 - Updated `omitExtraData()` to better handle `allOf`s containing multiple `if/then/else` blocks, matching fix in `SJSF`, fixing [#5142](https://github.com/rjsf-team/react-jsonschema-form/issues/5142)
 - Fixed `optionsList()` to preserve an explicitly empty string `title` on `oneOf`/`anyOf` options instead of falling back to the option's value, fixing [#4448](https://github.com/rjsf-team/react-jsonschema-form/issues/4448)
+- Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 
 ## @rjsf/validator-ajv8
 

--- a/packages/antd/src/widgets/SelectWidget/index.tsx
+++ b/packages/antd/src/widgets/SelectWidget/index.tsx
@@ -7,6 +7,7 @@ import {
   enumOptionValueEncoder,
   getOptionValueFormat,
   logUnsupportedDefaultForEnum,
+  SelectedOptionDescription,
 } from '@rjsf/utils';
 import type { SelectProps } from 'antd';
 import { Select } from 'antd';
@@ -41,6 +42,7 @@ export default function SelectWidget<
   readonly,
   value,
   schema,
+  uiSchema,
 }: WidgetProps<T, S, F>) {
   const [open, setOpen] = useState(false);
   const { formContext } = registry;
@@ -97,26 +99,36 @@ export default function SelectWidget<
   }, [enumDisabled, enumOptions, placeholder, showPlaceholderOption, optionValueFormat]);
 
   return (
-    <Select
-      open={open}
-      autoFocus={autofocus}
-      disabled={disabled || (readonlyAsDisabled && readonly)}
-      getPopupContainer={getPopupContainer}
-      id={id}
-      mode={multiple ? 'multiple' : undefined}
-      onBlur={!readonly ? handleBlur : undefined}
-      onChange={!readonly ? handleChange : undefined}
-      onFocus={!readonly ? handleFocus : undefined}
-      placeholder={placeholder}
-      style={SELECT_STYLE}
-      value={selectValue}
-      {...extraProps}
-      // When the open change is called, set the open state, needed so that the select opens properly in the playground
-      onOpenChange={setOpen}
-      showSearch={{ filterOption }}
-      aria-describedby={ariaDescribedByIds(id)}
-      options={selectOptions}
-    />
+    <>
+      <Select
+        open={open}
+        autoFocus={autofocus}
+        disabled={disabled || (readonlyAsDisabled && readonly)}
+        getPopupContainer={getPopupContainer}
+        id={id}
+        mode={multiple ? 'multiple' : undefined}
+        onBlur={!readonly ? handleBlur : undefined}
+        onChange={!readonly ? handleChange : undefined}
+        onFocus={!readonly ? handleFocus : undefined}
+        placeholder={placeholder}
+        style={SELECT_STYLE}
+        value={selectValue}
+        {...extraProps}
+        // When the open change is called, set the open state, needed so that the select opens properly in the playground
+        onOpenChange={setOpen}
+        showSearch={{ filterOption }}
+        aria-describedby={ariaDescribedByIds(id)}
+        options={selectOptions}
+      />
+      <SelectedOptionDescription
+        id={id}
+        multiple={multiple}
+        options={options}
+        registry={registry}
+        uiSchema={uiSchema}
+        value={value}
+      />
+    </>
   );
 }
 

--- a/packages/antd/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Form.test.tsx.snap
@@ -15840,6 +15840,94 @@ exports[`single fields > select widget with selected oneOf option description 1`
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description and hidden label 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ypkju9 ant-form-item-horizontal"
+      >
+        <div
+          class="ant-row ant-form-item-row css-dev-only-do-not-override-ypkju9 css-var-root"
+        >
+          <div
+            class="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-ypkju9 css-var-root"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <div
+                  class="ant-select ant-select-outlined ant-select-in-form-item ant-select-has-feedback css-var-root ant-select-css-var css-dev-only-do-not-override-ypkju9 ant-select-single ant-select-show-arrow ant-select-show-search"
+                  name="root"
+                  style="width: 100%;"
+                >
+                  <div
+                    class="ant-select-content ant-select-content-has-value"
+                    title="Foo"
+                  >
+                    Foo
+                    <input
+                      aria-autocomplete="list"
+                      aria-describedby="root__error root__description root__help"
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      autocomplete="off"
+                      class="ant-select-input"
+                      id="root"
+                      role="combobox"
+                      type="search"
+                      value=""
+                    />
+                  </div>
+                  <div
+                    class="ant-select-suffix"
+                  >
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <button
+      class="ant-btn css-dev-only-do-not-override-ypkju9 css-var-root ant-btn-submit"
+      type="submit"
+    >
+      <span>
+        Submit
+      </span>
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <form

--- a/packages/antd/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Form.test.tsx.snap
@@ -15747,6 +15747,99 @@ exports[`single fields > select widget with description in schema and FieldTempl
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="ant-form-item css-var-root ant-form-css-var css-dev-only-do-not-override-ypkju9 ant-form-item-horizontal"
+      >
+        <div
+          class="ant-row ant-form-item-row css-dev-only-do-not-override-ypkju9 css-var-root"
+        >
+          <div
+            class="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-ypkju9 css-var-root"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <div
+                  class="ant-select ant-select-outlined ant-select-in-form-item ant-select-has-feedback css-var-root ant-select-css-var css-dev-only-do-not-override-ypkju9 ant-select-single ant-select-show-arrow ant-select-show-search"
+                  name="root"
+                  style="width: 100%;"
+                >
+                  <div
+                    class="ant-select-content ant-select-content-has-value"
+                    title="Foo"
+                  >
+                    Foo
+                    <input
+                      aria-autocomplete="list"
+                      aria-describedby="root__error root__description root__help"
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      autocomplete="off"
+                      class="ant-select-input"
+                      id="root"
+                      role="combobox"
+                      type="search"
+                      value=""
+                    />
+                  </div>
+                  <div
+                    class="ant-select-suffix"
+                  >
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </div>
+                <span
+                  id="root__description"
+                >
+                  Foo description
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <button
+      class="ant-btn css-dev-only-do-not-override-ypkju9 css-var-root ant-btn-submit"
+      type="submit"
+    >
+      <span>
+        Submit
+      </span>
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <form

--- a/packages/chakra-ui/src/NativeSelectWidget/NativeSelectWidget.tsx
+++ b/packages/chakra-ui/src/NativeSelectWidget/NativeSelectWidget.tsx
@@ -8,6 +8,7 @@ import {
   enumOptionsValueForIndex,
   labelValue,
   logUnsupportedDefaultForEnum,
+  SelectedOptionDescription,
 } from '@rjsf/utils';
 import type { OptionsOrGroups } from 'chakra-react-select';
 
@@ -134,6 +135,7 @@ export default function NativeSelectWidget<
         </NativeSelect.Field>
         <NativeSelect.Indicator />
       </NativeSelect.Root>
+      <SelectedOptionDescription {...props} />
     </Field>
   );
 }

--- a/packages/chakra-ui/src/NativeSelectWidget/NativeSelectWidget.tsx
+++ b/packages/chakra-ui/src/NativeSelectWidget/NativeSelectWidget.tsx
@@ -112,6 +112,7 @@ export default function NativeSelectWidget<
       label={labelValue(label, hideLabel || !label)}
       {...chakraProps}
     >
+      <SelectedOptionDescription {...props} />
       <NativeSelect.Root>
         <NativeSelect.Field
           id={id}
@@ -135,7 +136,6 @@ export default function NativeSelectWidget<
         </NativeSelect.Field>
         <NativeSelect.Indicator />
       </NativeSelect.Root>
-      <SelectedOptionDescription {...props} />
     </Field>
   );
 }

--- a/packages/chakra-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/chakra-ui/src/SelectWidget/SelectWidget.tsx
@@ -11,6 +11,7 @@ import {
   getOptionValueFormat,
   labelValue,
   logUnsupportedDefaultForEnum,
+  SelectedOptionDescription,
 } from '@rjsf/utils';
 import type { OptionsOrGroups } from 'chakra-react-select';
 
@@ -137,6 +138,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
           </ChakraSelect.Content>
         </ChakraSelect.Positioner>
       </SelectRoot>
+      <SelectedOptionDescription {...props} />
     </Field>
   );
 }

--- a/packages/chakra-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/chakra-ui/src/SelectWidget/SelectWidget.tsx
@@ -108,6 +108,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
       position='relative'
       {...chakraProps}
     >
+      <SelectedOptionDescription {...props} />
       <SelectRoot
         collection={selectOptions}
         id={id}
@@ -138,7 +139,6 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
           </ChakraSelect.Content>
         </ChakraSelect.Positioner>
       </SelectRoot>
-      <SelectedOptionDescription {...props} />
     </Field>
   );
 }

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -544,7 +544,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r99:::legend"
+        aria-labelledby="fieldset:::r9c:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -560,7 +560,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9a:::legend"
+                  aria-labelledby="fieldset:::r9d:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -598,7 +598,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                 class="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r9b:::legend"
+                                  aria-labelledby="fieldset:::r9e:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -629,7 +629,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r9c:::legend"
+                                            aria-labelledby="fieldset:::r9f:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -641,15 +641,15 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r9d:"
+                                                id="field:::r9g:"
                                                 role="group"
                                               >
                                                 <label
                                                   class="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  for=":r9d:"
-                                                  id="field:::r9d:::label"
+                                                  for=":r9g:"
+                                                  id="field:::r9g:::label"
                                                 >
                                                   title
                                                 </label>
@@ -674,7 +674,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r9e:::legend"
+                                            aria-labelledby="fieldset:::r9h:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -686,7 +686,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r9f:"
+                                                id="field:::r9i:"
                                                 role="group"
                                               >
                                                 <label
@@ -696,13 +696,13 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="unchecked"
                                                   dir="ltr"
-                                                  for=":r9f:"
+                                                  for=":r9i:"
                                                   id="checkbox:root_tasks_0_done"
                                                 >
                                                   <input
                                                     aria-invalid="false"
-                                                    aria-labelledby="field:::r9f:::label"
-                                                    id=":r9f:"
+                                                    aria-labelledby="field:::r9i:::label"
+                                                    id=":r9i:"
                                                     name="root[tasks][0][done]"
                                                     style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                                     type="checkbox"
@@ -729,7 +729,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="unchecked"
                                                     dir="ltr"
-                                                    id="field:::r9f:::label"
+                                                    id="field:::r9i:::label"
                                                   >
                                                     <p>
                                                       done
@@ -851,7 +851,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                 class="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r9h:::legend"
+                                  aria-labelledby="fieldset:::r9k:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -882,7 +882,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r9i:::legend"
+                                            aria-labelledby="fieldset:::r9l:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -894,15 +894,15 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r9j:"
+                                                id="field:::r9m:"
                                                 role="group"
                                               >
                                                 <label
                                                   class="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  for=":r9j:"
-                                                  id="field:::r9j:::label"
+                                                  for=":r9m:"
+                                                  id="field:::r9m:::label"
                                                 >
                                                   title
                                                 </label>
@@ -927,7 +927,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r9k:::legend"
+                                            aria-labelledby="fieldset:::r9n:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -939,7 +939,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r9l:"
+                                                id="field:::r9o:"
                                                 role="group"
                                               >
                                                 <label
@@ -949,14 +949,14 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="checked"
                                                   dir="ltr"
-                                                  for=":r9l:"
+                                                  for=":r9o:"
                                                   id="checkbox:root_tasks_1_done"
                                                 >
                                                   <input
                                                     aria-invalid="false"
-                                                    aria-labelledby="field:::r9l:::label"
+                                                    aria-labelledby="field:::r9o:::label"
                                                     checked=""
-                                                    id=":r9l:"
+                                                    id=":r9o:"
                                                     name="root[tasks][1][done]"
                                                     style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                                     type="checkbox"
@@ -987,7 +987,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="checked"
                                                     dir="ltr"
-                                                    id="field:::r9l:::label"
+                                                    id="field:::r9o:::label"
                                                   >
                                                     <p>
                                                       done
@@ -1597,7 +1597,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r93:::legend"
+        aria-labelledby="fieldset:::r96:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -1613,7 +1613,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r94:::legend"
+                  aria-labelledby="fieldset:::r97:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -1651,7 +1651,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r95:::legend"
+                                  aria-labelledby="fieldset:::r98:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -1663,7 +1663,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                                       class="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::r96:"
+                                      id="field:::r99:"
                                       role="group"
                                     >
                                       <label
@@ -1671,8 +1671,8 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":r96:"
-                                        id="field:::r96:::label"
+                                        for=":r99:"
+                                        id="field:::r99:::label"
                                       >
                                         tags-1
                                         <span
@@ -1805,7 +1805,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r97:::legend"
+                                  aria-labelledby="fieldset:::r9a:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -1817,7 +1817,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                                       class="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::r98:"
+                                      id="field:::r9b:"
                                       role="group"
                                     >
                                       <label
@@ -1825,8 +1825,8 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":r98:"
-                                        id="field:::r98:::label"
+                                        for=":r9b:"
+                                        id="field:::r9b:::label"
                                       >
                                         tags-2
                                         <span
@@ -2324,7 +2324,7 @@ exports[`nameGenerator > bracketNameGenerator > checkboxes field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9v:::legend"
+        aria-labelledby="fieldset:::ra2:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -2340,7 +2340,7 @@ exports[`nameGenerator > bracketNameGenerator > checkboxes field 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::ra0:::legend"
+                  aria-labelledby="fieldset:::ra3:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -2349,7 +2349,7 @@ exports[`nameGenerator > bracketNameGenerator > checkboxes field 1`] = `
                     class="fieldset__content emotion-1"
                   >
                     <fieldset
-                      aria-labelledby="fieldset:::ra1:::legend"
+                      aria-labelledby="fieldset:::ra4:::legend"
                       class="fieldset__root emotion-5"
                       data-part="root"
                       data-scope="fieldset"
@@ -2358,7 +2358,7 @@ exports[`nameGenerator > bracketNameGenerator > checkboxes field 1`] = `
                         class="fieldset__legend emotion-6"
                         data-part="legend"
                         data-scope="fieldset"
-                        id="fieldset:::ra1:::legend"
+                        id="fieldset:::ra4:::legend"
                       >
                         choices
                       </legend>
@@ -2792,7 +2792,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r8o:::legend"
+        aria-labelledby="fieldset:::r8r:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -2808,7 +2808,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8p:::legend"
+                  aria-labelledby="fieldset:::r8s:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -2839,7 +2839,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8q:::legend"
+                            aria-labelledby="fieldset:::r8t:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -2851,15 +2851,15 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                                 class="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r8r:"
+                                id="field:::r8u:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r8r:"
-                                  id="field:::r8r:::label"
+                                  for=":r8u:"
+                                  id="field:::r8u:::label"
                                 >
                                   firstName
                                 </label>
@@ -2884,7 +2884,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8s:::legend"
+                            aria-labelledby="fieldset:::r8v:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -2896,15 +2896,15 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                                 class="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r8t:"
+                                id="field:::r90:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r8t:"
-                                  id="field:::r8t:::label"
+                                  for=":r90:"
+                                  id="field:::r90:::label"
                                 >
                                   lastName
                                 </label>
@@ -2929,7 +2929,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8u:::legend"
+                            aria-labelledby="fieldset:::r91:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -2960,7 +2960,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r8v:::legend"
+                                      aria-labelledby="fieldset:::r92:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -2972,15 +2972,15 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                                           class="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r90:"
+                                          id="field:::r93:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":r90:"
-                                            id="field:::r90:::label"
+                                            for=":r93:"
+                                            id="field:::r93:::label"
                                           >
                                             street
                                           </label>
@@ -3005,7 +3005,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r91:::legend"
+                                      aria-labelledby="fieldset:::r94:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -3017,15 +3017,15 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                                           class="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r92:"
+                                          id="field:::r95:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":r92:"
-                                            id="field:::r92:::label"
+                                            for=":r95:"
+                                            id="field:::r95:::label"
                                           >
                                             city
                                           </label>
@@ -3372,7 +3372,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9r:::legend"
+        aria-labelledby="fieldset:::r9u:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -3388,7 +3388,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9s:::legend"
+                  aria-labelledby="fieldset:::r9v:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -3400,28 +3400,28 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r9t:"
+                      id="field:::ra0:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":r9t:"
-                        id="field:::r9t:::label"
+                        for=":ra0:"
+                        id="field:::ra0:::label"
                       >
                         option
                       </label>
                       <div
                         aria-describedby="root_option__error root_option__description root_option__help"
-                        aria-labelledby="fieldset:::r9s:::legend"
+                        aria-labelledby="fieldset:::r9v:::legend"
                         aria-orientation="vertical"
                         class="chakra-radio-group__root"
                         data-orientation="vertical"
                         data-part="root"
                         data-scope="radio-group"
                         dir="ltr"
-                        id="radio-group::r9u:"
+                        id="radio-group::ra1:"
                         role="radiogroup"
                         style="position: relative;"
                       >
@@ -3436,13 +3436,13 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                             data-ssr=""
                             data-state="unchecked"
                             dir="ltr"
-                            for="radio-group::r9u::radio:input:0"
+                            for="radio-group::ra1::radio:input:0"
                             id="root_option-0"
                           >
                             <input
-                              aria-labelledby="radio-group::r9u::radio:label:0"
-                              data-ownedby="radio-group::r9u:"
-                              id="radio-group::r9u::radio:input:0"
+                              aria-labelledby="radio-group::ra1::radio:label:0"
+                              data-ownedby="radio-group::ra1:"
+                              id="radio-group::ra1::radio:input:0"
                               name="root[option]"
                               style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                               type="radio"
@@ -3457,7 +3457,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::r9u::radio:control:0"
+                              id="radio-group::ra1::radio:control:0"
                             />
                             <span
                               class="chakra-radio-group__itemText"
@@ -3467,7 +3467,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::r9u::radio:label:0"
+                              id="radio-group::ra1::radio:label:0"
                             >
                               foo
                             </span>
@@ -3480,13 +3480,13 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                             data-ssr=""
                             data-state="unchecked"
                             dir="ltr"
-                            for="radio-group::r9u::radio:input:1"
+                            for="radio-group::ra1::radio:input:1"
                             id="root_option-1"
                           >
                             <input
-                              aria-labelledby="radio-group::r9u::radio:label:1"
-                              data-ownedby="radio-group::r9u:"
-                              id="radio-group::r9u::radio:input:1"
+                              aria-labelledby="radio-group::ra1::radio:label:1"
+                              data-ownedby="radio-group::ra1:"
+                              id="radio-group::ra1::radio:input:1"
                               name="root[option]"
                               style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                               type="radio"
@@ -3501,7 +3501,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::r9u::radio:control:1"
+                              id="radio-group::ra1::radio:control:1"
                             />
                             <span
                               class="chakra-radio-group__itemText"
@@ -3511,7 +3511,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::r9u::radio:label:1"
+                              id="radio-group::ra1::radio:label:1"
                             >
                               bar
                             </span>
@@ -4027,7 +4027,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9n:::legend"
+        aria-labelledby="fieldset:::r9q:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -4043,7 +4043,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9o:::legend"
+                  aria-labelledby="fieldset:::r9r:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -4055,15 +4055,15 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r9p:"
+                      id="field:::r9s:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":r9p:"
-                        id="field:::r9p:::label"
+                        for=":r9s:"
+                        id="field:::r9s:::label"
                       >
                         color
                       </label>
@@ -4077,8 +4077,8 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                       >
                         <select
                           aria-hidden="true"
-                          aria-labelledby="field:::r9p:::label"
-                          id=":r9p:"
+                          aria-labelledby="field:::r9s:::label"
+                          id=":r9s:"
                           name="root[color]"
                           style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                           tabindex="-1"
@@ -4123,7 +4123,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                               aria-expanded="false"
                               aria-haspopup="listbox"
                               aria-invalid="false"
-                              aria-labelledby="field:::r9p:::label"
+                              aria-labelledby="field:::r9s:::label"
                               aria-required="false"
                               class="chakra-select__trigger emotion-10"
                               data-part="trigger"
@@ -4174,7 +4174,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                           style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                         >
                           <div
-                            aria-labelledby="field:::r9p:::label"
+                            aria-labelledby="field:::r9s:::label"
                             class="chakra-select__content emotion-16"
                             data-part="content"
                             data-scope="select"
@@ -4650,7 +4650,7 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r8g:::legend"
+        aria-labelledby="fieldset:::r8j:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -4666,7 +4666,7 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8h:::legend"
+                  aria-labelledby="fieldset:::r8k:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -4678,15 +4678,15 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r8i:"
+                      id="field:::r8l:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":r8i:"
-                        id="field:::r8i:::label"
+                        for=":r8l:"
+                        id="field:::r8l:::label"
                       >
                         firstName
                       </label>
@@ -4711,7 +4711,7 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                 class="rjsf-field rjsf-field-number"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8j:::legend"
+                  aria-labelledby="fieldset:::r8m:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -4723,15 +4723,15 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r8k:"
+                      id="field:::r8n:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":r8k:"
-                        id="field:::r8k:::label"
+                        for=":r8n:"
+                        id="field:::r8n:::label"
                       >
                         age
                       </label>
@@ -4757,7 +4757,7 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                 class="rjsf-field rjsf-field-boolean"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8l:::legend"
+                  aria-labelledby="fieldset:::r8o:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -4769,7 +4769,7 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r8m:"
+                      id="field:::r8p:"
                       role="group"
                     >
                       <label
@@ -4779,13 +4779,13 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                         data-scope="checkbox"
                         data-state="unchecked"
                         dir="ltr"
-                        for=":r8m:"
+                        for=":r8p:"
                         id="checkbox:root_active"
                       >
                         <input
                           aria-invalid="false"
-                          aria-labelledby="field:::r8m:::label"
-                          id=":r8m:"
+                          aria-labelledby="field:::r8p:::label"
+                          id=":r8p:"
                           name="root[active]"
                           style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                           type="checkbox"
@@ -4812,7 +4812,7 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                           data-scope="checkbox"
                           data-state="unchecked"
                           dir="ltr"
-                          id="field:::r8m:::label"
+                          id="field:::r8p:::label"
                         >
                           <p>
                             active
@@ -5075,7 +5075,7 @@ exports[`nameGenerator > bracketNameGenerator > textarea field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::ra5:::legend"
+        aria-labelledby="fieldset:::ra8:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -5091,7 +5091,7 @@ exports[`nameGenerator > bracketNameGenerator > textarea field 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::ra6:::legend"
+                  aria-labelledby="fieldset:::ra9:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -5103,15 +5103,15 @@ exports[`nameGenerator > bracketNameGenerator > textarea field 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::ra7:"
+                      id="field:::raa:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":ra7:"
-                        id="field:::ra7:::label"
+                        for=":raa:"
+                        id="field:::raa:::label"
                       >
                         description
                       </label>
@@ -5694,7 +5694,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::rb1:::legend"
+        aria-labelledby="fieldset:::rb4:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -5710,7 +5710,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rb2:::legend"
+                  aria-labelledby="fieldset:::rb5:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -5748,7 +5748,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                 class="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::rb3:::legend"
+                                  aria-labelledby="fieldset:::rb6:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -5779,7 +5779,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::rb4:::legend"
+                                            aria-labelledby="fieldset:::rb7:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -5791,15 +5791,15 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rb5:"
+                                                id="field:::rb8:"
                                                 role="group"
                                               >
                                                 <label
                                                   class="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  for=":rb5:"
-                                                  id="field:::rb5:::label"
+                                                  for=":rb8:"
+                                                  id="field:::rb8:::label"
                                                 >
                                                   title
                                                 </label>
@@ -5824,7 +5824,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::rb6:::legend"
+                                            aria-labelledby="fieldset:::rb9:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -5836,7 +5836,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rb7:"
+                                                id="field:::rba:"
                                                 role="group"
                                               >
                                                 <label
@@ -5846,13 +5846,13 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="unchecked"
                                                   dir="ltr"
-                                                  for=":rb7:"
+                                                  for=":rba:"
                                                   id="checkbox:root_tasks_0_done"
                                                 >
                                                   <input
                                                     aria-invalid="false"
-                                                    aria-labelledby="field:::rb7:::label"
-                                                    id=":rb7:"
+                                                    aria-labelledby="field:::rba:::label"
+                                                    id=":rba:"
                                                     name="root.tasks.0.done"
                                                     style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                                     type="checkbox"
@@ -5879,7 +5879,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="unchecked"
                                                     dir="ltr"
-                                                    id="field:::rb7:::label"
+                                                    id="field:::rba:::label"
                                                   >
                                                     <p>
                                                       done
@@ -6001,7 +6001,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                 class="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::rb9:::legend"
+                                  aria-labelledby="fieldset:::rbc:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -6032,7 +6032,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::rba:::legend"
+                                            aria-labelledby="fieldset:::rbd:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -6044,15 +6044,15 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rbb:"
+                                                id="field:::rbe:"
                                                 role="group"
                                               >
                                                 <label
                                                   class="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  for=":rbb:"
-                                                  id="field:::rbb:::label"
+                                                  for=":rbe:"
+                                                  id="field:::rbe:::label"
                                                 >
                                                   title
                                                 </label>
@@ -6077,7 +6077,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::rbc:::legend"
+                                            aria-labelledby="fieldset:::rbf:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -6089,7 +6089,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rbd:"
+                                                id="field:::rbg:"
                                                 role="group"
                                               >
                                                 <label
@@ -6099,14 +6099,14 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="checked"
                                                   dir="ltr"
-                                                  for=":rbd:"
+                                                  for=":rbg:"
                                                   id="checkbox:root_tasks_1_done"
                                                 >
                                                   <input
                                                     aria-invalid="false"
-                                                    aria-labelledby="field:::rbd:::label"
+                                                    aria-labelledby="field:::rbg:::label"
                                                     checked=""
-                                                    id=":rbd:"
+                                                    id=":rbg:"
                                                     name="root.tasks.1.done"
                                                     style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                                     type="checkbox"
@@ -6137,7 +6137,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="checked"
                                                     dir="ltr"
-                                                    id="field:::rbd:::label"
+                                                    id="field:::rbg:::label"
                                                   >
                                                     <p>
                                                       done
@@ -6747,7 +6747,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::rar:::legend"
+        aria-labelledby="fieldset:::rau:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -6763,7 +6763,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::ras:::legend"
+                  aria-labelledby="fieldset:::rav:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -6801,7 +6801,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::rat:::legend"
+                                  aria-labelledby="fieldset:::rb0:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -6813,7 +6813,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                                       class="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::rau:"
+                                      id="field:::rb1:"
                                       role="group"
                                     >
                                       <label
@@ -6821,8 +6821,8 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":rau:"
-                                        id="field:::rau:::label"
+                                        for=":rb1:"
+                                        id="field:::rb1:::label"
                                       >
                                         tags-1
                                         <span
@@ -6955,7 +6955,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::rav:::legend"
+                                  aria-labelledby="fieldset:::rb2:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -6967,7 +6967,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                                       class="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::rb0:"
+                                      id="field:::rb3:"
                                       role="group"
                                     >
                                       <label
@@ -6975,8 +6975,8 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":rb0:"
-                                        id="field:::rb0:::label"
+                                        for=":rb3:"
+                                        id="field:::rb3:::label"
                                       >
                                         tags-2
                                         <span
@@ -7416,7 +7416,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::rag:::legend"
+        aria-labelledby="fieldset:::raj:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -7432,7 +7432,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rah:::legend"
+                  aria-labelledby="fieldset:::rak:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -7463,7 +7463,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::rai:::legend"
+                            aria-labelledby="fieldset:::ral:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -7475,15 +7475,15 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                                 class="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::raj:"
+                                id="field:::ram:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":raj:"
-                                  id="field:::raj:::label"
+                                  for=":ram:"
+                                  id="field:::ram:::label"
                                 >
                                   firstName
                                 </label>
@@ -7508,7 +7508,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::rak:::legend"
+                            aria-labelledby="fieldset:::ran:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -7520,15 +7520,15 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                                 class="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::ral:"
+                                id="field:::rao:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":ral:"
-                                  id="field:::ral:::label"
+                                  for=":rao:"
+                                  id="field:::rao:::label"
                                 >
                                   lastName
                                 </label>
@@ -7553,7 +7553,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::ram:::legend"
+                            aria-labelledby="fieldset:::rap:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -7584,7 +7584,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::ran:::legend"
+                                      aria-labelledby="fieldset:::raq:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -7596,15 +7596,15 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                                           class="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::rao:"
+                                          id="field:::rar:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":rao:"
-                                            id="field:::rao:::label"
+                                            for=":rar:"
+                                            id="field:::rar:::label"
                                           >
                                             street
                                           </label>
@@ -7629,7 +7629,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::rap:::legend"
+                                      aria-labelledby="fieldset:::ras:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -7641,15 +7641,15 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                                           class="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::raq:"
+                                          id="field:::rat:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":raq:"
-                                            id="field:::raq:::label"
+                                            for=":rat:"
+                                            id="field:::rat:::label"
                                           >
                                             city
                                           </label>
@@ -8183,7 +8183,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::rbf:::legend"
+        aria-labelledby="fieldset:::rbi:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -8199,7 +8199,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rbg:::legend"
+                  aria-labelledby="fieldset:::rbj:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -8211,15 +8211,15 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::rbh:"
+                      id="field:::rbk:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":rbh:"
-                        id="field:::rbh:::label"
+                        for=":rbk:"
+                        id="field:::rbk:::label"
                       >
                         color
                       </label>
@@ -8233,8 +8233,8 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                       >
                         <select
                           aria-hidden="true"
-                          aria-labelledby="field:::rbh:::label"
-                          id=":rbh:"
+                          aria-labelledby="field:::rbk:::label"
+                          id=":rbk:"
                           name="root.color"
                           style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                           tabindex="-1"
@@ -8279,7 +8279,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                               aria-expanded="false"
                               aria-haspopup="listbox"
                               aria-invalid="false"
-                              aria-labelledby="field:::rbh:::label"
+                              aria-labelledby="field:::rbk:::label"
                               aria-required="false"
                               class="chakra-select__trigger emotion-10"
                               data-part="trigger"
@@ -8330,7 +8330,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                           style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                         >
                           <div
-                            aria-labelledby="field:::rbh:::label"
+                            aria-labelledby="field:::rbk:::label"
                             class="chakra-select__content emotion-16"
                             data-part="content"
                             data-scope="select"
@@ -8806,7 +8806,7 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::ra8:::legend"
+        aria-labelledby="fieldset:::rab:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -8822,7 +8822,7 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::ra9:::legend"
+                  aria-labelledby="fieldset:::rac:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -8834,15 +8834,15 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::raa:"
+                      id="field:::rad:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":raa:"
-                        id="field:::raa:::label"
+                        for=":rad:"
+                        id="field:::rad:::label"
                       >
                         firstName
                       </label>
@@ -8867,7 +8867,7 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                 class="rjsf-field rjsf-field-number"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rab:::legend"
+                  aria-labelledby="fieldset:::rae:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -8879,15 +8879,15 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::rac:"
+                      id="field:::raf:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":rac:"
-                        id="field:::rac:::label"
+                        for=":raf:"
+                        id="field:::raf:::label"
                       >
                         age
                       </label>
@@ -8913,7 +8913,7 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                 class="rjsf-field rjsf-field-boolean"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rad:::legend"
+                  aria-labelledby="fieldset:::rag:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -8925,7 +8925,7 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::rae:"
+                      id="field:::rah:"
                       role="group"
                     >
                       <label
@@ -8935,13 +8935,13 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                         data-scope="checkbox"
                         data-state="unchecked"
                         dir="ltr"
-                        for=":rae:"
+                        for=":rah:"
                         id="checkbox:root_active"
                       >
                         <input
                           aria-invalid="false"
-                          aria-labelledby="field:::rae:::label"
-                          id=":rae:"
+                          aria-labelledby="field:::rah:::label"
+                          id=":rah:"
                           name="root.active"
                           style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                           type="checkbox"
@@ -8968,7 +8968,7 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                           data-scope="checkbox"
                           data-state="unchecked"
                           dir="ltr"
-                          id="field:::rae:::label"
+                          id="field:::rah:::label"
                         >
                           <p>
                             active
@@ -9345,7 +9345,7 @@ exports[`single fields > Cyclic schema 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4k:::legend"
+        aria-labelledby="fieldset:::r4n:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -9382,7 +9382,7 @@ exports[`single fields > Cyclic schema 1`] = `
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4l:::legend"
+                  aria-labelledby="fieldset:::r4o:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -11574,7 +11574,7 @@ exports[`single fields > checkboxes field 1`] = `
       class="rjsf-field rjsf-field-array"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3e:::legend"
+        aria-labelledby="fieldset:::r3h:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -11583,7 +11583,7 @@ exports[`single fields > checkboxes field 1`] = `
           class="fieldset__content emotion-1"
         >
           <fieldset
-            aria-labelledby="fieldset:::r3f:::legend"
+            aria-labelledby="fieldset:::r3i:::legend"
             class="fieldset__root emotion-2"
             data-part="root"
             data-scope="fieldset"
@@ -11592,7 +11592,7 @@ exports[`single fields > checkboxes field 1`] = `
               class="fieldset__legend emotion-3"
               data-part="legend"
               data-scope="fieldset"
-              id="fieldset:::r3f:::legend"
+              id="fieldset:::r3i:::legend"
             >
               An enum list rendered as checkboxes
             </legend>
@@ -13141,7 +13141,7 @@ exports[`single fields > field with description 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3r:::legend"
+        aria-labelledby="fieldset:::r3u:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -13157,7 +13157,7 @@ exports[`single fields > field with description 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r3s:::legend"
+                  aria-labelledby="fieldset:::r3v:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -13166,7 +13166,7 @@ exports[`single fields > field with description 1`] = `
                     class="fieldset__legend emotion-4"
                     data-part="legend"
                     data-scope="fieldset"
-                    id="fieldset:::r3s:::legend"
+                    id="fieldset:::r3v:::legend"
                   >
                     <sup
                       class="emotion-5"
@@ -13182,15 +13182,15 @@ exports[`single fields > field with description 1`] = `
                       class="chakra-field__root emotion-7"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r3t:"
+                      id="field:::r40:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-8"
                         data-part="label"
                         data-scope="field"
-                        for=":r3t:"
-                        id="field:::r3t:::label"
+                        for=":r40:"
+                        id="field:::r40:::label"
                       >
                         my-field
                       </label>
@@ -13482,7 +13482,7 @@ exports[`single fields > field with description in uiSchema 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3u:::legend"
+        aria-labelledby="fieldset:::r41:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -13498,7 +13498,7 @@ exports[`single fields > field with description in uiSchema 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r3v:::legend"
+                  aria-labelledby="fieldset:::r42:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -13507,7 +13507,7 @@ exports[`single fields > field with description in uiSchema 1`] = `
                     class="fieldset__legend emotion-4"
                     data-part="legend"
                     data-scope="fieldset"
-                    id="fieldset:::r3v:::legend"
+                    id="fieldset:::r42:::legend"
                   >
                     <sup
                       class="emotion-5"
@@ -13523,15 +13523,15 @@ exports[`single fields > field with description in uiSchema 1`] = `
                       class="chakra-field__root emotion-7"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r40:"
+                      id="field:::r43:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-8"
                         data-part="label"
                         data-scope="field"
-                        for=":r40:"
-                        id="field:::r40:::label"
+                        for=":r43:"
+                        id="field:::r43:::label"
                       >
                         my-field
                       </label>
@@ -13823,7 +13823,7 @@ exports[`single fields > field with markdown description 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r41:::legend"
+        aria-labelledby="fieldset:::r44:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -13839,7 +13839,7 @@ exports[`single fields > field with markdown description 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r42:::legend"
+                  aria-labelledby="fieldset:::r45:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -13848,7 +13848,7 @@ exports[`single fields > field with markdown description 1`] = `
                     class="fieldset__legend emotion-4"
                     data-part="legend"
                     data-scope="fieldset"
-                    id="fieldset:::r42:::legend"
+                    id="fieldset:::r45:::legend"
                   >
                     <sup
                       class="emotion-5"
@@ -13870,15 +13870,15 @@ exports[`single fields > field with markdown description 1`] = `
                       class="chakra-field__root emotion-7"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r43:"
+                      id="field:::r46:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-8"
                         data-part="label"
                         data-scope="field"
-                        for=":r43:"
-                        id="field:::r43:::label"
+                        for=":r46:"
+                        id="field:::r46:::label"
                       >
                         my-field
                       </label>
@@ -14170,7 +14170,7 @@ exports[`single fields > field with markdown description in uiSchema 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r44:::legend"
+        aria-labelledby="fieldset:::r47:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -14186,7 +14186,7 @@ exports[`single fields > field with markdown description in uiSchema 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r45:::legend"
+                  aria-labelledby="fieldset:::r48:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -14195,7 +14195,7 @@ exports[`single fields > field with markdown description in uiSchema 1`] = `
                     class="fieldset__legend emotion-4"
                     data-part="legend"
                     data-scope="fieldset"
-                    id="fieldset:::r45:::legend"
+                    id="fieldset:::r48:::legend"
                   >
                     <sup
                       class="emotion-5"
@@ -14211,15 +14211,15 @@ exports[`single fields > field with markdown description in uiSchema 1`] = `
                       class="chakra-field__root emotion-7"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r46:"
+                      id="field:::r49:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-8"
                         data-part="label"
                         data-scope="field"
-                        for=":r46:"
-                        id="field:::r46:::label"
+                        for=":r49:"
+                        id="field:::r49:::label"
                       >
                         my-field
                       </label>
@@ -15649,7 +15649,7 @@ exports[`single fields > help and error display 1`] = `
       class="rjsf-field rjsf-field-string rjsf-field-error"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4i:::legend"
+        aria-labelledby="fieldset:::r4l:::legend"
         class="fieldset__root emotion-8"
         data-invalid=""
         data-part="root"
@@ -15669,7 +15669,7 @@ exports[`single fields > help and error display 1`] = `
             data-invalid=""
             data-part="root"
             data-scope="field"
-            id="field:::r4j:"
+            id="field:::r4m:"
             role="group"
           >
             <input
@@ -15851,7 +15851,7 @@ exports[`single fields > hidden field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3q:::legend"
+        aria-labelledby="fieldset:::r3t:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -16091,7 +16091,7 @@ exports[`single fields > hidden label 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4a:::legend"
+        aria-labelledby="fieldset:::r4d:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -16103,7 +16103,7 @@ exports[`single fields > hidden label 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r4b:"
+            id="field:::r4e:"
             role="group"
           >
             <input
@@ -17425,7 +17425,7 @@ exports[`single fields > optional data controls > does not show optional control
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4m:::legend"
+        aria-labelledby="fieldset:::r4p:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -17456,7 +17456,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4n:::legend"
+                  aria-labelledby="fieldset:::r4q:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -17487,7 +17487,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4o:::legend"
+                            aria-labelledby="fieldset:::r4r:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17499,15 +17499,15 @@ exports[`single fields > optional data controls > does not show optional control
                                 class="chakra-field__root emotion-14"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r4p:"
+                                id="field:::r4s:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-15"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r4p:"
-                                  id="field:::r4p:::label"
+                                  for=":r4s:"
+                                  id="field:::r4s:::label"
                                 >
                                   test
                                 </label>
@@ -17532,7 +17532,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4q:::legend"
+                            aria-labelledby="fieldset:::r4t:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17548,87 +17548,6 @@ exports[`single fields > optional data controls > does not show optional control
                                   class="chakra-heading emotion-3"
                                 >
                                   deepObjectOptional
-                                </h5>
-                                <span
-                                  aria-orientation="horizontal"
-                                  class="chakra-separator emotion-4"
-                                  role="separator"
-                                />
-                              </div>
-                              <div
-                                class="emotion-5"
-                              >
-                                <div>
-                                  <div
-                                    class="rjsf-field rjsf-field-string"
-                                  >
-                                    <fieldset
-                                      aria-labelledby="fieldset:::r4r:::legend"
-                                      class="fieldset__root emotion-0"
-                                      data-part="root"
-                                      data-scope="fieldset"
-                                    >
-                                      <div
-                                        class="fieldset__content emotion-1"
-                                      >
-                                        <div
-                                          class="chakra-field__root emotion-14"
-                                          data-part="root"
-                                          data-scope="field"
-                                          id="field:::r4s:"
-                                          role="group"
-                                        >
-                                          <label
-                                            class="chakra-field__label emotion-15"
-                                            data-part="label"
-                                            data-scope="field"
-                                            for=":r4s:"
-                                            id="field:::r4s:::label"
-                                          >
-                                            deepTest
-                                          </label>
-                                          <input
-                                            aria-describedby="root_nestedObjectOptional_deepObjectOptional_deepTest__error root_nestedObjectOptional_deepObjectOptional_deepTest__description root_nestedObjectOptional_deepObjectOptional_deepTest__help"
-                                            class="chakra-input emotion-16"
-                                            data-part="input"
-                                            data-scope="field"
-                                            id="root_nestedObjectOptional_deepObjectOptional_deepTest"
-                                            name="root_nestedObjectOptional_deepObjectOptional_deepTest"
-                                            placeholder=""
-                                            type="text"
-                                            value=""
-                                          />
-                                        </div>
-                                      </div>
-                                    </fieldset>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </fieldset>
-                        </div>
-                      </div>
-                      <div>
-                        <div
-                          class="rjsf-field rjsf-field-object"
-                        >
-                          <fieldset
-                            aria-labelledby="fieldset:::r4t:::legend"
-                            class="fieldset__root emotion-0"
-                            data-part="root"
-                            data-scope="fieldset"
-                          >
-                            <div
-                              class="fieldset__content emotion-1"
-                            >
-                              <div
-                                class="emotion-2"
-                                id="root_nestedObjectOptional_deepObject__title"
-                              >
-                                <h5
-                                  class="chakra-heading emotion-3"
-                                >
-                                  deepObject
                                 </h5>
                                 <span
                                   aria-orientation="horizontal"
@@ -17669,6 +17588,87 @@ exports[`single fields > optional data controls > does not show optional control
                                             deepTest
                                           </label>
                                           <input
+                                            aria-describedby="root_nestedObjectOptional_deepObjectOptional_deepTest__error root_nestedObjectOptional_deepObjectOptional_deepTest__description root_nestedObjectOptional_deepObjectOptional_deepTest__help"
+                                            class="chakra-input emotion-16"
+                                            data-part="input"
+                                            data-scope="field"
+                                            id="root_nestedObjectOptional_deepObjectOptional_deepTest"
+                                            name="root_nestedObjectOptional_deepObjectOptional_deepTest"
+                                            placeholder=""
+                                            type="text"
+                                            value=""
+                                          />
+                                        </div>
+                                      </div>
+                                    </fieldset>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </fieldset>
+                        </div>
+                      </div>
+                      <div>
+                        <div
+                          class="rjsf-field rjsf-field-object"
+                        >
+                          <fieldset
+                            aria-labelledby="fieldset:::r50:::legend"
+                            class="fieldset__root emotion-0"
+                            data-part="root"
+                            data-scope="fieldset"
+                          >
+                            <div
+                              class="fieldset__content emotion-1"
+                            >
+                              <div
+                                class="emotion-2"
+                                id="root_nestedObjectOptional_deepObject__title"
+                              >
+                                <h5
+                                  class="chakra-heading emotion-3"
+                                >
+                                  deepObject
+                                </h5>
+                                <span
+                                  aria-orientation="horizontal"
+                                  class="chakra-separator emotion-4"
+                                  role="separator"
+                                />
+                              </div>
+                              <div
+                                class="emotion-5"
+                              >
+                                <div>
+                                  <div
+                                    class="rjsf-field rjsf-field-string"
+                                  >
+                                    <fieldset
+                                      aria-labelledby="fieldset:::r51:::legend"
+                                      class="fieldset__root emotion-0"
+                                      data-part="root"
+                                      data-scope="fieldset"
+                                    >
+                                      <div
+                                        class="fieldset__content emotion-1"
+                                      >
+                                        <div
+                                          class="chakra-field__root emotion-14"
+                                          data-part="root"
+                                          data-scope="field"
+                                          id="field:::r52:"
+                                          role="group"
+                                        >
+                                          <label
+                                            class="chakra-field__label emotion-15"
+                                            data-part="label"
+                                            data-scope="field"
+                                            for=":r52:"
+                                            id="field:::r52:::label"
+                                          >
+                                            deepTest
+                                          </label>
+                                          <input
                                             aria-describedby="root_nestedObjectOptional_deepObject_deepTest__error root_nestedObjectOptional_deepObject_deepTest__description root_nestedObjectOptional_deepObject_deepTest__help"
                                             class="chakra-input emotion-16"
                                             data-part="input"
@@ -17694,7 +17694,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r50:::legend"
+                            aria-labelledby="fieldset:::r53:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17768,7 +17768,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r51:::legend"
+                            aria-labelledby="fieldset:::r54:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17842,7 +17842,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r52:::legend"
+                            aria-labelledby="fieldset:::r55:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17921,7 +17921,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r53:::legend"
+                  aria-labelledby="fieldset:::r56:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -17995,7 +17995,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r54:::legend"
+                  aria-labelledby="fieldset:::r57:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18026,7 +18026,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r55:::legend"
+                            aria-labelledby="fieldset:::r58:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -18038,15 +18038,15 @@ exports[`single fields > optional data controls > does not show optional control
                                 class="chakra-field__root emotion-14"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r56:"
+                                id="field:::r59:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-15"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r56:"
-                                  id="field:::r56:::label"
+                                  for=":r59:"
+                                  id="field:::r59:::label"
                                 >
                                   test
                                 </label>
@@ -18076,7 +18076,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r57:::legend"
+                  aria-labelledby="fieldset:::r5a:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18150,7 +18150,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r58:::legend"
+                  aria-labelledby="fieldset:::r5b:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18171,15 +18171,15 @@ exports[`single fields > optional data controls > does not show optional control
                             class="chakra-field__root emotion-100"
                             data-part="root"
                             data-scope="field"
-                            id="field:::r59:"
+                            id="field:::r5c:"
                             role="group"
                           >
                             <label
                               class="chakra-field__label emotion-15"
                               data-part="label"
                               data-scope="field"
-                              for=":r59:"
-                              id="field:::r59:::label"
+                              for=":r5c:"
+                              id="field:::r5c:::label"
                             >
                               optionalObjectWithOneofs
                             </label>
@@ -18193,8 +18193,8 @@ exports[`single fields > optional data controls > does not show optional control
                             >
                               <select
                                 aria-hidden="true"
-                                aria-labelledby="field:::r59:::label"
-                                id=":r59:"
+                                aria-labelledby="field:::r5c:::label"
+                                id=":r5c:"
                                 name="root_optionalObjectWithOneofs__oneof_select"
                                 style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                 tabindex="-1"
@@ -18237,7 +18237,7 @@ exports[`single fields > optional data controls > does not show optional control
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-invalid="false"
-                                    aria-labelledby="field:::r59:::label"
+                                    aria-labelledby="field:::r5c:::label"
                                     aria-required="false"
                                     class="chakra-select__trigger emotion-105"
                                     data-part="trigger"
@@ -18289,7 +18289,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                               >
                                 <div
-                                  aria-labelledby="field:::r59:::label"
+                                  aria-labelledby="field:::r5c:::label"
                                   class="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -18398,7 +18398,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5b:::legend"
+                            aria-labelledby="fieldset:::r5e:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -18429,7 +18429,7 @@ exports[`single fields > optional data controls > does not show optional control
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r5c:::legend"
+                                      aria-labelledby="fieldset:::r5f:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -18443,7 +18443,7 @@ exports[`single fields > optional data controls > does not show optional control
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r5d:"
+                                          id="field:::r5g:"
                                           role="group"
                                         >
                                           <label
@@ -18452,8 +18452,8 @@ exports[`single fields > optional data controls > does not show optional control
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            for=":r5d:"
-                                            id="field:::r5d:::label"
+                                            for=":r5g:"
+                                            id="field:::r5g:::label"
                                           >
                                             name
                                           </label>
@@ -18491,7 +18491,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5e:::legend"
+                  aria-labelledby="fieldset:::r5h:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18512,15 +18512,15 @@ exports[`single fields > optional data controls > does not show optional control
                             class="chakra-field__root emotion-100"
                             data-part="root"
                             data-scope="field"
-                            id="field:::r5f:"
+                            id="field:::r5i:"
                             role="group"
                           >
                             <label
                               class="chakra-field__label emotion-15"
                               data-part="label"
                               data-scope="field"
-                              for=":r5f:"
-                              id="field:::r5f:::label"
+                              for=":r5i:"
+                              id="field:::r5i:::label"
                             >
                               optionalArrayWithAnyofs
                             </label>
@@ -18534,8 +18534,8 @@ exports[`single fields > optional data controls > does not show optional control
                             >
                               <select
                                 aria-hidden="true"
-                                aria-labelledby="field:::r5f:::label"
-                                id=":r5f:"
+                                aria-labelledby="field:::r5i:::label"
+                                id=":r5i:"
                                 name="root_optionalArrayWithAnyofs__anyof_select"
                                 style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                 tabindex="-1"
@@ -18578,7 +18578,7 @@ exports[`single fields > optional data controls > does not show optional control
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-invalid="false"
-                                    aria-labelledby="field:::r5f:::label"
+                                    aria-labelledby="field:::r5i:::label"
                                     aria-required="false"
                                     class="chakra-select__trigger emotion-105"
                                     data-part="trigger"
@@ -18630,7 +18630,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                               >
                                 <div
-                                  aria-labelledby="field:::r5f:::label"
+                                  aria-labelledby="field:::r5i:::label"
                                   class="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -18739,7 +18739,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5h:::legend"
+                            aria-labelledby="fieldset:::r5k:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19472,7 +19472,7 @@ exports[`single fields > optional data controls > does not show optional control
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r6j:::legend"
+        aria-labelledby="fieldset:::r6m:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -19504,7 +19504,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6k:::legend"
+                  aria-labelledby="fieldset:::r6n:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -19536,7 +19536,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6l:::legend"
+                            aria-labelledby="fieldset:::r6o:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19550,7 +19550,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r6m:"
+                                id="field:::r6p:"
                                 role="group"
                               >
                                 <label
@@ -19559,8 +19559,8 @@ exports[`single fields > optional data controls > does not show optional control
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  for=":r6m:"
-                                  id="field:::r6m:::label"
+                                  for=":r6p:"
+                                  id="field:::r6p:::label"
                                 >
                                   test
                                 </label>
@@ -19588,7 +19588,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6n:::legend"
+                            aria-labelledby="fieldset:::r6q:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19604,95 +19604,6 @@ exports[`single fields > optional data controls > does not show optional control
                                   class="chakra-heading emotion-3"
                                 >
                                   deepObjectOptional
-                                </h5>
-                                <span
-                                  aria-orientation="horizontal"
-                                  class="chakra-separator emotion-4"
-                                  role="separator"
-                                />
-                              </div>
-                              <div
-                                class="emotion-5"
-                              >
-                                <div />
-                                <div>
-                                  <div
-                                    class="rjsf-field rjsf-field-string"
-                                  >
-                                    <fieldset
-                                      aria-labelledby="fieldset:::r6o:::legend"
-                                      class="fieldset__root emotion-0"
-                                      data-part="root"
-                                      data-scope="fieldset"
-                                    >
-                                      <div
-                                        class="fieldset__content emotion-1"
-                                      >
-                                        <div
-                                          class="chakra-field__root emotion-14"
-                                          data-disabled=""
-                                          data-part="root"
-                                          data-readonly=""
-                                          data-scope="field"
-                                          id="field:::r6p:"
-                                          role="group"
-                                        >
-                                          <label
-                                            class="chakra-field__label emotion-15"
-                                            data-disabled=""
-                                            data-part="label"
-                                            data-readonly=""
-                                            data-scope="field"
-                                            for=":r6p:"
-                                            id="field:::r6p:::label"
-                                          >
-                                            deepTest
-                                          </label>
-                                          <input
-                                            aria-describedby="root_nestedObjectOptional_deepObjectOptional_deepTest__error root_nestedObjectOptional_deepObjectOptional_deepTest__description root_nestedObjectOptional_deepObjectOptional_deepTest__help"
-                                            class="chakra-input emotion-16"
-                                            data-part="input"
-                                            data-readonly=""
-                                            data-scope="field"
-                                            disabled=""
-                                            id="root_nestedObjectOptional_deepObjectOptional_deepTest"
-                                            name="root_nestedObjectOptional_deepObjectOptional_deepTest"
-                                            placeholder=""
-                                            readonly=""
-                                            type="text"
-                                            value=""
-                                          />
-                                        </div>
-                                      </div>
-                                    </fieldset>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </fieldset>
-                        </div>
-                      </div>
-                      <div>
-                        <div
-                          class="rjsf-field rjsf-field-object"
-                        >
-                          <fieldset
-                            aria-labelledby="fieldset:::r6q:::legend"
-                            class="fieldset__root emotion-0"
-                            data-part="root"
-                            data-scope="fieldset"
-                          >
-                            <div
-                              class="fieldset__content emotion-1"
-                            >
-                              <div
-                                class="emotion-2"
-                                id="root_nestedObjectOptional_deepObject__title"
-                              >
-                                <h5
-                                  class="chakra-heading emotion-3"
-                                >
-                                  deepObject
                                 </h5>
                                 <span
                                   aria-orientation="horizontal"
@@ -19738,6 +19649,95 @@ exports[`single fields > optional data controls > does not show optional control
                                             deepTest
                                           </label>
                                           <input
+                                            aria-describedby="root_nestedObjectOptional_deepObjectOptional_deepTest__error root_nestedObjectOptional_deepObjectOptional_deepTest__description root_nestedObjectOptional_deepObjectOptional_deepTest__help"
+                                            class="chakra-input emotion-16"
+                                            data-part="input"
+                                            data-readonly=""
+                                            data-scope="field"
+                                            disabled=""
+                                            id="root_nestedObjectOptional_deepObjectOptional_deepTest"
+                                            name="root_nestedObjectOptional_deepObjectOptional_deepTest"
+                                            placeholder=""
+                                            readonly=""
+                                            type="text"
+                                            value=""
+                                          />
+                                        </div>
+                                      </div>
+                                    </fieldset>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </fieldset>
+                        </div>
+                      </div>
+                      <div>
+                        <div
+                          class="rjsf-field rjsf-field-object"
+                        >
+                          <fieldset
+                            aria-labelledby="fieldset:::r6t:::legend"
+                            class="fieldset__root emotion-0"
+                            data-part="root"
+                            data-scope="fieldset"
+                          >
+                            <div
+                              class="fieldset__content emotion-1"
+                            >
+                              <div
+                                class="emotion-2"
+                                id="root_nestedObjectOptional_deepObject__title"
+                              >
+                                <h5
+                                  class="chakra-heading emotion-3"
+                                >
+                                  deepObject
+                                </h5>
+                                <span
+                                  aria-orientation="horizontal"
+                                  class="chakra-separator emotion-4"
+                                  role="separator"
+                                />
+                              </div>
+                              <div
+                                class="emotion-5"
+                              >
+                                <div />
+                                <div>
+                                  <div
+                                    class="rjsf-field rjsf-field-string"
+                                  >
+                                    <fieldset
+                                      aria-labelledby="fieldset:::r6u:::legend"
+                                      class="fieldset__root emotion-0"
+                                      data-part="root"
+                                      data-scope="fieldset"
+                                    >
+                                      <div
+                                        class="fieldset__content emotion-1"
+                                      >
+                                        <div
+                                          class="chakra-field__root emotion-14"
+                                          data-disabled=""
+                                          data-part="root"
+                                          data-readonly=""
+                                          data-scope="field"
+                                          id="field:::r6v:"
+                                          role="group"
+                                        >
+                                          <label
+                                            class="chakra-field__label emotion-15"
+                                            data-disabled=""
+                                            data-part="label"
+                                            data-readonly=""
+                                            data-scope="field"
+                                            for=":r6v:"
+                                            id="field:::r6v:::label"
+                                          >
+                                            deepTest
+                                          </label>
+                                          <input
                                             aria-describedby="root_nestedObjectOptional_deepObject_deepTest__error root_nestedObjectOptional_deepObject_deepTest__description root_nestedObjectOptional_deepObject_deepTest__help"
                                             class="chakra-input emotion-16"
                                             data-part="input"
@@ -19766,7 +19766,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6t:::legend"
+                            aria-labelledby="fieldset:::r70:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19841,7 +19841,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6u:::legend"
+                            aria-labelledby="fieldset:::r71:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19916,7 +19916,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6v:::legend"
+                            aria-labelledby="fieldset:::r72:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19996,7 +19996,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r70:::legend"
+                  aria-labelledby="fieldset:::r73:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -20071,7 +20071,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r71:::legend"
+                  aria-labelledby="fieldset:::r74:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -20103,7 +20103,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r72:::legend"
+                            aria-labelledby="fieldset:::r75:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -20117,7 +20117,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r73:"
+                                id="field:::r76:"
                                 role="group"
                               >
                                 <label
@@ -20126,8 +20126,8 @@ exports[`single fields > optional data controls > does not show optional control
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  for=":r73:"
-                                  id="field:::r73:::label"
+                                  for=":r76:"
+                                  id="field:::r76:::label"
                                 >
                                   test
                                 </label>
@@ -20160,7 +20160,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r74:::legend"
+                  aria-labelledby="fieldset:::r77:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -20235,7 +20235,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r75:::legend"
+                  aria-labelledby="fieldset:::r78:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -20258,7 +20258,7 @@ exports[`single fields > optional data controls > does not show optional control
                             data-part="root"
                             data-readonly=""
                             data-scope="field"
-                            id="field:::r76:"
+                            id="field:::r79:"
                             role="group"
                           >
                             <label
@@ -20267,8 +20267,8 @@ exports[`single fields > optional data controls > does not show optional control
                               data-part="label"
                               data-readonly=""
                               data-scope="field"
-                              for=":r76:"
-                              id="field:::r76:::label"
+                              for=":r79:"
+                              id="field:::r79:::label"
                             >
                               optionalObjectWithOneofs
                             </label>
@@ -20283,9 +20283,9 @@ exports[`single fields > optional data controls > does not show optional control
                             >
                               <select
                                 aria-hidden="true"
-                                aria-labelledby="field:::r76:::label"
+                                aria-labelledby="field:::r79:::label"
                                 disabled=""
-                                id=":r76:"
+                                id=":r79:"
                                 name="root_optionalObjectWithOneofs__oneof_select"
                                 style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                 tabindex="-1"
@@ -20330,7 +20330,7 @@ exports[`single fields > optional data controls > does not show optional control
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-invalid="false"
-                                    aria-labelledby="field:::r76:::label"
+                                    aria-labelledby="field:::r79:::label"
                                     aria-required="false"
                                     class="chakra-select__trigger emotion-105"
                                     data-disabled=""
@@ -20388,7 +20388,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                               >
                                 <div
-                                  aria-labelledby="field:::r76:::label"
+                                  aria-labelledby="field:::r79:::label"
                                   class="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -20503,7 +20503,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r78:::legend"
+                            aria-labelledby="fieldset:::r7b:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -20535,7 +20535,7 @@ exports[`single fields > optional data controls > does not show optional control
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r79:::legend"
+                                      aria-labelledby="fieldset:::r7c:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -20549,7 +20549,7 @@ exports[`single fields > optional data controls > does not show optional control
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r7a:"
+                                          id="field:::r7d:"
                                           role="group"
                                         >
                                           <label
@@ -20558,8 +20558,8 @@ exports[`single fields > optional data controls > does not show optional control
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            for=":r7a:"
-                                            id="field:::r7a:::label"
+                                            for=":r7d:"
+                                            id="field:::r7d:::label"
                                           >
                                             name
                                           </label>
@@ -20597,7 +20597,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7b:::legend"
+                  aria-labelledby="fieldset:::r7e:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -20620,7 +20620,7 @@ exports[`single fields > optional data controls > does not show optional control
                             data-part="root"
                             data-readonly=""
                             data-scope="field"
-                            id="field:::r7c:"
+                            id="field:::r7f:"
                             role="group"
                           >
                             <label
@@ -20629,8 +20629,8 @@ exports[`single fields > optional data controls > does not show optional control
                               data-part="label"
                               data-readonly=""
                               data-scope="field"
-                              for=":r7c:"
-                              id="field:::r7c:::label"
+                              for=":r7f:"
+                              id="field:::r7f:::label"
                             >
                               optionalArrayWithAnyofs
                             </label>
@@ -20645,9 +20645,9 @@ exports[`single fields > optional data controls > does not show optional control
                             >
                               <select
                                 aria-hidden="true"
-                                aria-labelledby="field:::r7c:::label"
+                                aria-labelledby="field:::r7f:::label"
                                 disabled=""
-                                id=":r7c:"
+                                id=":r7f:"
                                 name="root_optionalArrayWithAnyofs__anyof_select"
                                 style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                 tabindex="-1"
@@ -20692,7 +20692,7 @@ exports[`single fields > optional data controls > does not show optional control
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-invalid="false"
-                                    aria-labelledby="field:::r7c:::label"
+                                    aria-labelledby="field:::r7f:::label"
                                     aria-required="false"
                                     class="chakra-select__trigger emotion-105"
                                     data-disabled=""
@@ -20750,7 +20750,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                               >
                                 <div
-                                  aria-labelledby="field:::r7c:::label"
+                                  aria-labelledby="field:::r7f:::label"
                                   class="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -20865,7 +20865,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7e:::legend"
+                            aria-labelledby="fieldset:::r7h:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21557,7 +21557,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r5t:::legend"
+        aria-labelledby="fieldset:::r60:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -21588,7 +21588,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5u:::legend"
+                  aria-labelledby="fieldset:::r61:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -21657,7 +21657,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5v:::legend"
+                            aria-labelledby="fieldset:::r62:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21669,15 +21669,15 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                 class="chakra-field__root emotion-17"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r60:"
+                                id="field:::r63:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-18"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r60:"
-                                  id="field:::r60:::label"
+                                  for=":r63:"
+                                  id="field:::r63:::label"
                                 >
                                   test
                                 </label>
@@ -21702,7 +21702,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r61:::legend"
+                            aria-labelledby="fieldset:::r64:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21772,7 +21772,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r62:::legend"
+                            aria-labelledby="fieldset:::r65:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21803,7 +21803,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r63:::legend"
+                                      aria-labelledby="fieldset:::r66:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -21815,15 +21815,15 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                           class="chakra-field__root emotion-17"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r64:"
+                                          id="field:::r67:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-18"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":r64:"
-                                            id="field:::r64:::label"
+                                            for=":r67:"
+                                            id="field:::r67:::label"
                                           >
                                             deepTest
                                           </label>
@@ -21853,7 +21853,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r65:::legend"
+                            aria-labelledby="fieldset:::r68:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21927,7 +21927,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r66:::legend"
+                            aria-labelledby="fieldset:::r69:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22001,7 +22001,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r67:::legend"
+                            aria-labelledby="fieldset:::r6a:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22080,7 +22080,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r68:::legend"
+                  aria-labelledby="fieldset:::r6b:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -22156,7 +22156,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r69:::legend"
+                                  aria-labelledby="fieldset:::r6c:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -22168,7 +22168,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                       class="chakra-field__root emotion-17"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::r6a:"
+                                      id="field:::r6d:"
                                       role="group"
                                     >
                                       <label
@@ -22176,8 +22176,8 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":r6a:"
-                                        id="field:::r6a:::label"
+                                        for=":r6d:"
+                                        id="field:::r6d:::label"
                                       >
                                         nestedArrayOptional-1
                                         <span
@@ -22290,7 +22290,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6b:::legend"
+                  aria-labelledby="fieldset:::r6e:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -22321,7 +22321,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6c:::legend"
+                            aria-labelledby="fieldset:::r6f:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22333,15 +22333,15 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                 class="chakra-field__root emotion-17"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r6d:"
+                                id="field:::r6g:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-18"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r6d:"
-                                  id="field:::r6d:::label"
+                                  for=":r6g:"
+                                  id="field:::r6g:::label"
                                 >
                                   test
                                 </label>
@@ -22371,7 +22371,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6e:::legend"
+                  aria-labelledby="fieldset:::r6h:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -22445,7 +22445,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6f:::legend"
+                  aria-labelledby="fieldset:::r6i:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -22466,7 +22466,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6g:::legend"
+                            aria-labelledby="fieldset:::r6j:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22541,7 +22541,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6h:::legend"
+                  aria-labelledby="fieldset:::r6k:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -22562,7 +22562,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6i:::legend"
+                            aria-labelledby="fieldset:::r6l:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23143,7 +23143,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r7q:::legend"
+        aria-labelledby="fieldset:::r7t:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -23175,7 +23175,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7r:::legend"
+                  aria-labelledby="fieldset:::r7u:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23207,7 +23207,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7s:::legend"
+                            aria-labelledby="fieldset:::r7v:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23221,7 +23221,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r7t:"
+                                id="field:::r80:"
                                 role="group"
                               >
                                 <label
@@ -23230,8 +23230,8 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  for=":r7t:"
-                                  id="field:::r7t:::label"
+                                  for=":r80:"
+                                  id="field:::r80:::label"
                                 >
                                   test
                                 </label>
@@ -23259,7 +23259,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7u:::legend"
+                            aria-labelledby="fieldset:::r81:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23302,7 +23302,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7v:::legend"
+                            aria-labelledby="fieldset:::r82:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23334,7 +23334,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r80:::legend"
+                                      aria-labelledby="fieldset:::r83:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -23348,7 +23348,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r81:"
+                                          id="field:::r84:"
                                           role="group"
                                         >
                                           <label
@@ -23357,8 +23357,8 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            for=":r81:"
-                                            id="field:::r81:::label"
+                                            for=":r84:"
+                                            id="field:::r84:::label"
                                           >
                                             deepTest
                                           </label>
@@ -23391,7 +23391,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r82:::legend"
+                            aria-labelledby="fieldset:::r85:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23466,7 +23466,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r83:::legend"
+                            aria-labelledby="fieldset:::r86:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23511,7 +23511,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r84:::legend"
+                            aria-labelledby="fieldset:::r87:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23591,7 +23591,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r85:::legend"
+                  aria-labelledby="fieldset:::r88:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23629,7 +23629,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r86:::legend"
+                                  aria-labelledby="fieldset:::r89:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -23643,7 +23643,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                       data-part="root"
                                       data-readonly=""
                                       data-scope="field"
-                                      id="field:::r87:"
+                                      id="field:::r8a:"
                                       role="group"
                                     >
                                       <label
@@ -23653,8 +23653,8 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                         data-readonly=""
                                         data-required=""
                                         data-scope="field"
-                                        for=":r87:"
-                                        id="field:::r87:::label"
+                                        for=":r8a:"
+                                        id="field:::r8a:::label"
                                       >
                                         nestedArrayOptional-1
                                         <span
@@ -23772,7 +23772,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r88:::legend"
+                  aria-labelledby="fieldset:::r8b:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23804,7 +23804,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r89:::legend"
+                            aria-labelledby="fieldset:::r8c:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23818,7 +23818,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r8a:"
+                                id="field:::r8d:"
                                 role="group"
                               >
                                 <label
@@ -23827,8 +23827,8 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  for=":r8a:"
-                                  id="field:::r8a:::label"
+                                  for=":r8d:"
+                                  id="field:::r8d:::label"
                                 >
                                   test
                                 </label>
@@ -23861,7 +23861,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8b:::legend"
+                  aria-labelledby="fieldset:::r8e:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23936,7 +23936,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8c:::legend"
+                  aria-labelledby="fieldset:::r8f:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23957,7 +23957,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8d:::legend"
+                            aria-labelledby="fieldset:::r8g:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24005,7 +24005,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8e:::legend"
+                  aria-labelledby="fieldset:::r8h:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24026,7 +24026,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8f:::legend"
+                            aria-labelledby="fieldset:::r8i:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24519,7 +24519,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r5i:::legend"
+        aria-labelledby="fieldset:::r5l:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -24550,7 +24550,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5j:::legend"
+                  aria-labelledby="fieldset:::r5m:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24620,7 +24620,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5k:::legend"
+                  aria-labelledby="fieldset:::r5n:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24694,7 +24694,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5l:::legend"
+                  aria-labelledby="fieldset:::r5o:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24725,7 +24725,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5m:::legend"
+                            aria-labelledby="fieldset:::r5p:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24737,15 +24737,15 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                                 class="chakra-field__root emotion-32"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r5n:"
+                                id="field:::r5q:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-33"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r5n:"
-                                  id="field:::r5n:::label"
+                                  for=":r5q:"
+                                  id="field:::r5q:::label"
                                 >
                                   test
                                 </label>
@@ -24775,7 +24775,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5o:::legend"
+                  aria-labelledby="fieldset:::r5r:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24849,7 +24849,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5p:::legend"
+                  aria-labelledby="fieldset:::r5s:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24870,7 +24870,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5q:::legend"
+                            aria-labelledby="fieldset:::r5t:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24945,7 +24945,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5r:::legend"
+                  aria-labelledby="fieldset:::r5u:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24966,7 +24966,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5s:::legend"
+                            aria-labelledby="fieldset:::r5v:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -25378,7 +25378,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r7f:::legend"
+        aria-labelledby="fieldset:::r7i:::legend"
         class="fieldset__root emotion-0"
         data-disabled=""
         data-part="root"
@@ -25412,7 +25412,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7g:::legend"
+                  aria-labelledby="fieldset:::r7j:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25457,7 +25457,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7h:::legend"
+                  aria-labelledby="fieldset:::r7k:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25504,7 +25504,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7i:::legend"
+                  aria-labelledby="fieldset:::r7l:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25538,7 +25538,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7j:::legend"
+                            aria-labelledby="fieldset:::r7m:::legend"
                             class="fieldset__root emotion-0"
                             data-disabled=""
                             data-part="root"
@@ -25553,7 +25553,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                                 data-disabled=""
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r7k:"
+                                id="field:::r7n:"
                                 role="group"
                               >
                                 <label
@@ -25561,8 +25561,8 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                                   data-disabled=""
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r7k:"
-                                  id="field:::r7k:::label"
+                                  for=":r7n:"
+                                  id="field:::r7n:::label"
                                 >
                                   test
                                 </label>
@@ -25593,7 +25593,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7l:::legend"
+                  aria-labelledby="fieldset:::r7o:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25670,7 +25670,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7m:::legend"
+                  aria-labelledby="fieldset:::r7p:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25693,7 +25693,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7n:::legend"
+                            aria-labelledby="fieldset:::r7q:::legend"
                             class="fieldset__root emotion-0"
                             data-disabled=""
                             data-part="root"
@@ -25743,7 +25743,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7o:::legend"
+                  aria-labelledby="fieldset:::r7r:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25766,7 +25766,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7p:::legend"
+                            aria-labelledby="fieldset:::r7s:::legend"
                             class="fieldset__root emotion-0"
                             data-disabled=""
                             data-part="root"
@@ -26344,7 +26344,7 @@ exports[`single fields > radio field 1`] = `
       class="rjsf-field rjsf-field-boolean"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3k:::legend"
+        aria-labelledby="fieldset:::r3n:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -26356,19 +26356,19 @@ exports[`single fields > radio field 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r3l:"
+            id="field:::r3o:"
             role="group"
           >
             <div
               aria-describedby="root__error root__description root__help"
-              aria-labelledby="fieldset:::r3k:::legend"
+              aria-labelledby="fieldset:::r3n:::legend"
               aria-orientation="vertical"
               class="chakra-radio-group__root"
               data-orientation="vertical"
               data-part="root"
               data-scope="radio-group"
               dir="ltr"
-              id="radio-group::r3m:"
+              id="radio-group::r3p:"
               role="radiogroup"
               style="position: relative;"
             >
@@ -26383,13 +26383,13 @@ exports[`single fields > radio field 1`] = `
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r3m::radio:input:0"
+                  for="radio-group::r3p::radio:input:0"
                   id="root-0"
                 >
                   <input
-                    aria-labelledby="radio-group::r3m::radio:label:0"
-                    data-ownedby="radio-group::r3m:"
-                    id="radio-group::r3m::radio:input:0"
+                    aria-labelledby="radio-group::r3p::radio:label:0"
+                    data-ownedby="radio-group::r3p:"
+                    id="radio-group::r3p::radio:input:0"
                     name="root"
                     style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -26404,7 +26404,7 @@ exports[`single fields > radio field 1`] = `
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r3m::radio:control:0"
+                    id="radio-group::r3p::radio:control:0"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -26414,7 +26414,7 @@ exports[`single fields > radio field 1`] = `
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r3m::radio:label:0"
+                    id="radio-group::r3p::radio:label:0"
                   >
                     Yes
                   </span>
@@ -26427,13 +26427,13 @@ exports[`single fields > radio field 1`] = `
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r3m::radio:input:1"
+                  for="radio-group::r3p::radio:input:1"
                   id="root-1"
                 >
                   <input
-                    aria-labelledby="radio-group::r3m::radio:label:1"
-                    data-ownedby="radio-group::r3m:"
-                    id="radio-group::r3m::radio:input:1"
+                    aria-labelledby="radio-group::r3p::radio:label:1"
+                    data-ownedby="radio-group::r3p:"
+                    id="radio-group::r3p::radio:input:1"
                     name="root"
                     style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -26448,7 +26448,7 @@ exports[`single fields > radio field 1`] = `
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r3m::radio:control:1"
+                    id="radio-group::r3p::radio:control:1"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -26458,7 +26458,7 @@ exports[`single fields > radio field 1`] = `
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r3m::radio:label:1"
+                    id="radio-group::r3p::radio:label:1"
                   >
                     No
                   </span>
@@ -27159,7 +27159,7 @@ exports[`single fields > schema examples 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4e:::legend"
+        aria-labelledby="fieldset:::r4h:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -27171,7 +27171,7 @@ exports[`single fields > schema examples 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r4f:"
+            id="field:::r4i:"
             role="group"
           >
             <input
@@ -27424,7 +27424,7 @@ exports[`single fields > schema examples with mixed types (string examples and n
       class="rjsf-field rjsf-field-integer"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4g:::legend"
+        aria-labelledby="fieldset:::r4j:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -27436,7 +27436,7 @@ exports[`single fields > schema examples with mixed types (string examples and n
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r4h:"
+            id="field:::r4k:"
             role="group"
           >
             <input
@@ -34892,6 +34892,677 @@ exports[`single fields > select widget with description in schema and FieldTempl
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description 1`] = `
+<DocumentFragment>
+  @layer recipes {
+  .emotion-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+  }
+
+  .emotion-0>:not(style, [hidden])~:not(style, [hidden]) {
+    --space-y-reverse: 0;
+    margin-top: calc(var(--chakra-spacing-4) * calc(1 - var(--space-y-reverse)));
+    margin-bottom: calc(var(--chakra-spacing-4) * var(--space-y-reverse));
+  }
+}
+
+@layer recipes {
+  .emotion-1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+    gap: var(--chakra-spacing-4);
+  }
+}
+
+.emotion-2 {
+  margin-bottom: var(--chakra-spacing-1);
+  position: relative;
+}
+
+@layer recipes {
+  .emotion-2 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    width: 100%;
+    position: relative;
+    gap: var(--chakra-spacing-1\\.5);
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+.emotion-3 {
+  font-size: var(--chakra-font-sizes-md);
+}
+
+@layer recipes {
+  .emotion-4 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    gap: var(--chakra-spacing-1\\.5);
+    width: var(--chakra-sizes-full);
+    --select-trigger-height: var(--chakra-sizes-10);
+    --select-trigger-padding-x: var(--chakra-spacing-3);
+  }
+}
+
+@layer recipes {
+  .emotion-5 {
+    position: relative;
+  }
+}
+
+@layer recipes {
+  .emotion-7 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: justify;
+    -webkit-justify-content: space-between;
+    justify-content: space-between;
+    width: var(--chakra-sizes-full);
+    min-height: var(--select-trigger-height);
+    --input-height: var(--select-trigger-height);
+    padding-inline: var(--select-trigger-padding-x);
+    border-radius: var(--chakra-radii-l2);
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    text-align: start;
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+    gap: var(--chakra-spacing-2);
+    background: var(--chakra-colors-transparent);
+    --bg-currentcolor: var(--chakra-colors-transparent);
+    border-width: 1px;
+    border-color: var(--chakra-colors-border);
+  }
+
+  .emotion-7:is(:focus-visible, [data-focus-visible]) {
+    outline-offset: 0px;
+    outline-width: var(--focus-ring-width, 1px);
+    outline-color: var(--focus-ring-color);
+    outline-style: var(--focus-ring-style, solid);
+    border-color: var(--focus-ring-color);
+  }
+
+  .emotion-7:is(:placeholder-shown, [data-placeholder-shown]) {
+    --mix-color: color-mix(in srgb, var(--chakra-colors-fg-muted) 80%, transparent);
+    color: var(--mix-color, var(--chakra-colors-fg-muted));
+  }
+
+  .emotion-7:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-7:is([data-invalid], [aria-invalid=true], [data-state=invalid]) {
+    border-color: var(--chakra-colors-border-error);
+  }
+
+  .emotion-7:is([aria-expanded=true], [data-expanded], [data-state=expanded]) {
+    border-color: var(--chakra-colors-border-emphasized);
+  }
+}
+
+@layer recipes {
+  .emotion-8 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    text-wrap: wrap;
+    max-width: 80%;
+  }
+}
+
+@layer recipes {
+  .emotion-9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    gap: var(--chakra-spacing-1);
+    position: absolute;
+    inset-inline-end: 0;
+    top: 0;
+    bottom: 0;
+    padding-inline: var(--select-trigger-padding-x);
+    pointer-events: none;
+  }
+}
+
+@layer recipes {
+  .emotion-10 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    color: var(--chakra-colors-fg-muted);
+  }
+
+  .emotion-10:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    color: var(--chakra-colors-fg-subtle);
+  }
+
+  .emotion-10:is([data-invalid], [aria-invalid=true], [data-state=invalid]) {
+    color: var(--chakra-colors-fg-error);
+  }
+
+  .emotion-10 :where(svg) {
+    width: var(--chakra-sizes-4);
+    height: var(--chakra-sizes-4);
+  }
+}
+
+.emotion-11 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.emotion-12 {
+  min-width: 100%!important;
+  z-index: 2!important;
+  top: calc(100% + 5px)!important;
+}
+
+@layer recipes {
+  .emotion-13 {
+    background: var(--chakra-colors-bg-panel);
+    --bg-currentcolor: var(--chakra-colors-bg-panel);
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    --select-z-index: var(--chakra-z-index-popover);
+    z-index: calc(var(--select-z-index) + var(--layer-index, 0));
+    border-radius: var(--chakra-radii-l2);
+    outline: 0;
+    max-height: var(--chakra-sizes-96);
+    overflow-y: auto;
+    box-shadow: var(--chakra-shadows-md);
+    padding: var(--chakra-spacing-1);
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+  }
+
+  .emotion-13:is([open], [data-open], [data-state=open]) {
+    transform-origin: var(--transform-origin);
+    -webkit-animation-duration: var(--chakra-durations-fast);
+    animation-duration: var(--chakra-durations-fast);
+  }
+
+  .emotion-13:is([open], [data-open], [data-state=open])[data-placement^=top] {
+    -webkit-animation-name: slide-from-bottom,fade-in;
+    animation-name: slide-from-bottom,fade-in;
+  }
+
+  .emotion-13:is([open], [data-open], [data-state=open])[data-placement^=bottom] {
+    -webkit-animation-name: slide-from-top,fade-in;
+    animation-name: slide-from-top,fade-in;
+  }
+
+  .emotion-13:is([open], [data-open], [data-state=open])[data-placement^=left] {
+    -webkit-animation-name: slide-from-right,fade-in;
+    animation-name: slide-from-right,fade-in;
+  }
+
+  .emotion-13:is([open], [data-open], [data-state=open])[data-placement^=right] {
+    -webkit-animation-name: slide-from-left,fade-in;
+    animation-name: slide-from-left,fade-in;
+  }
+
+  .emotion-13:is([closed], [data-closed], [data-state=closed]) {
+    transform-origin: var(--transform-origin);
+    -webkit-animation-duration: var(--chakra-durations-fastest);
+    animation-duration: var(--chakra-durations-fastest);
+  }
+
+  .emotion-13:is([closed], [data-closed], [data-state=closed])[data-placement^=top] {
+    -webkit-animation-name: slide-to-bottom,fade-out;
+    animation-name: slide-to-bottom,fade-out;
+  }
+
+  .emotion-13:is([closed], [data-closed], [data-state=closed])[data-placement^=bottom] {
+    -webkit-animation-name: slide-to-top,fade-out;
+    animation-name: slide-to-top,fade-out;
+  }
+
+  .emotion-13:is([closed], [data-closed], [data-state=closed])[data-placement^=left] {
+    -webkit-animation-name: slide-to-right,fade-out;
+    animation-name: slide-to-right,fade-out;
+  }
+
+  .emotion-13:is([closed], [data-closed], [data-state=closed])[data-placement^=right] {
+    -webkit-animation-name: slide-to-left,fade-out;
+    animation-name: slide-to-left,fade-out;
+  }
+}
+
+@layer recipes {
+  .emotion-14 {
+    position: relative;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    gap: var(--chakra-spacing-2);
+    cursor: var(--chakra-cursor-option);
+    -webkit-box-pack: justify;
+    -webkit-justify-content: space-between;
+    justify-content: space-between;
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+    text-align: start;
+    border-radius: var(--chakra-radii-l1);
+    padding-block: var(--chakra-spacing-1\\.5);
+    padding-inline: var(--chakra-spacing-2);
+  }
+
+  .emotion-14[data-highlighted] {
+    --mix-background: color-mix(in srgb, var(--chakra-colors-bg-emphasized) 60%, transparent);
+    background: var(--mix-background, var(--chakra-colors-bg-emphasized));
+    --bg-currentcolor: var(--mix-background, var(--chakra-colors-bg-emphasized));
+  }
+
+  .emotion-14:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+
+  .emotion-14 :where(svg) {
+    width: var(--chakra-sizes-4);
+    height: var(--chakra-sizes-4);
+  }
+}
+
+@layer recipes {
+  .emotion-15 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+  }
+}
+
+.emotion-20 {
+  margin-top: var(--chakra-spacing-3);
+}
+
+@layer recipes {
+  .emotion-21 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    position: relative;
+    border-radius: var(--chakra-radii-l2);
+    white-space: nowrap;
+    vertical-align: middle;
+    border-width: 1px;
+    border-color: var(--chakra-colors-transparent);
+    cursor: var(--chakra-cursor-button);
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    outline: 0;
+    line-height: 1.25rem;
+    isolation: isolate;
+    font-weight: var(--chakra-font-weights-medium);
+    transition-property: background-color,border-color,color,fill,stroke,opacity,box-shadow,translate,transform;
+    transition-duration: var(--chakra-durations-moderate);
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    height: var(--chakra-sizes-10);
+    min-width: var(--chakra-sizes-10);
+    font-size: var(--chakra-font-sizes-sm);
+    padding-inline: var(--chakra-spacing-4);
+    gap: var(--chakra-spacing-2);
+    background: var(--chakra-colors-color-palette-solid);
+    --bg-currentcolor: var(--chakra-colors-color-palette-solid);
+    color: var(--chakra-colors-color-palette-contrast);
+  }
+
+  .emotion-21:is(:focus-visible, [data-focus-visible]) {
+    outline-width: var(--focus-ring-width, 2px);
+    outline-offset: var(--focus-ring-offset, 2px);
+    outline-style: var(--focus-ring-style, solid);
+    outline-color: var(--focus-ring-color);
+  }
+
+  .emotion-21:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-21 :where(svg) {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    width: var(--chakra-sizes-5);
+    height: var(--chakra-sizes-5);
+  }
+
+  .emotion-21:is([aria-expanded=true], [data-expanded], [data-state=expanded]) {
+    --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+    background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+  }
+
+  @media (hover: hover) {
+    .emotion-21:is(:hover, [data-hover]):not(:disabled, [data-disabled]) {
+      --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+      background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+      --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    }
+  }
+}
+
+<form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <fieldset
+        aria-labelledby="fieldset:::r3e:::legend"
+        class="fieldset__root emotion-0"
+        data-part="root"
+        data-scope="fieldset"
+      >
+        <div
+          class="fieldset__content emotion-1"
+        >
+          <div
+            class="chakra-field__root emotion-2"
+            data-part="root"
+            data-scope="field"
+            id="field:::r3f:"
+            role="group"
+          >
+            <sup
+              class="emotion-3"
+              id="root__description"
+            >
+              Foo description
+            </sup>
+            <div
+              aria-describedby="root__error root__description root__help"
+              class="chakra-select__root emotion-4"
+              data-part="root"
+              data-scope="select"
+              dir="ltr"
+              id="select:root"
+            >
+              <select
+                aria-hidden="true"
+                aria-labelledby="field:::r3f:::label"
+                id=":r3f:"
+                name="root"
+                style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+                tabindex="-1"
+              >
+                <option
+                  selected=""
+                  value="0"
+                >
+                  Foo
+                </option>
+                <option
+                  value="1"
+                >
+                  Bar
+                </option>
+              </select>
+              <div
+                class="chakra-select__control emotion-5"
+                data-part="control"
+                data-scope="select"
+                data-state="closed"
+                dir="ltr"
+                id="select:root:control"
+              >
+                <div
+                  class="chakra-select__control emotion-5"
+                  data-part="control"
+                  data-scope="select"
+                  data-state="closed"
+                  dir="ltr"
+                  id="select:root:control"
+                >
+                  <button
+                    aria-controls="select:root:content"
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-invalid="false"
+                    aria-labelledby="field:::r3f:::label"
+                    aria-required="false"
+                    class="chakra-select__trigger emotion-7"
+                    data-part="trigger"
+                    data-scope="select"
+                    data-state="closed"
+                    dir="ltr"
+                    id="select:root:trigger"
+                    role="combobox"
+                    type="button"
+                  >
+                    <span
+                      class="chakra-select__valueText emotion-8"
+                      data-part="value-text"
+                      data-scope="select"
+                      dir="ltr"
+                    >
+                      Foo
+                    </span>
+                  </button>
+                  <div
+                    class="chakra-select__indicatorGroup emotion-9"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="chakra-select__indicator emotion-10"
+                      data-part="indicator"
+                      data-scope="select"
+                      data-state="closed"
+                      dir="ltr"
+                    >
+                      <svg
+                        class="emotion-11"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="m6 9 6 6 6-6"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="chakra-select__positioner emotion-12"
+                data-part="positioner"
+                data-scope="select"
+                dir="ltr"
+                id="select:root:positioner"
+                style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
+              >
+                <div
+                  aria-labelledby="field:::r3f:::label"
+                  class="chakra-select__content emotion-13"
+                  data-part="content"
+                  data-scope="select"
+                  data-state="closed"
+                  dir="ltr"
+                  hidden=""
+                  id="select:root:content"
+                  role="listbox"
+                  tabindex="0"
+                >
+                  <div
+                    aria-selected="true"
+                    class="chakra-select__item emotion-14"
+                    data-part="item"
+                    data-scope="select"
+                    data-state="checked"
+                    data-value="0"
+                    dir="ltr"
+                    id="select:root:option:0"
+                    role="option"
+                  >
+                    Foo
+                    <div
+                      aria-hidden="true"
+                      class="chakra-select__itemIndicator emotion-15"
+                      data-part="item-indicator"
+                      data-scope="select"
+                      data-state="checked"
+                    >
+                      <svg
+                        class="emotion-11"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 6 9 17l-5-5"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    aria-selected="false"
+                    class="chakra-select__item emotion-14"
+                    data-part="item"
+                    data-scope="select"
+                    data-state="unchecked"
+                    data-value="1"
+                    dir="ltr"
+                    id="select:root:option:1"
+                    role="option"
+                  >
+                    Bar
+                    <div
+                      aria-hidden="true"
+                      class="chakra-select__itemIndicator emotion-15"
+                      data-part="item-indicator"
+                      data-scope="select"
+                      data-state="unchecked"
+                      hidden=""
+                    >
+                      <svg
+                        class="emotion-11"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 6 9 17l-5-5"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div
+      class="emotion-20"
+    >
+      <button
+        class="chakra-button emotion-21"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+  <span
+    hidden=""
+  />
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   @layer recipes {
@@ -35174,7 +35845,7 @@ exports[`single fields > slider field 1`] = `
       class="rjsf-field rjsf-field-integer"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3n:::legend"
+        aria-labelledby="fieldset:::r3q:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -35186,7 +35857,7 @@ exports[`single fields > slider field 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r3o:"
+            id="field:::r3r:"
             role="group"
           >
             <div
@@ -38923,7 +39594,7 @@ exports[`single fields > title field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r47:::legend"
+        aria-labelledby="fieldset:::r4a:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -38954,7 +39625,7 @@ exports[`single fields > title field 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r48:::legend"
+                  aria-labelledby="fieldset:::r4b:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -38966,15 +39637,15 @@ exports[`single fields > title field 1`] = `
                       class="chakra-field__root emotion-8"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r49:"
+                      id="field:::r4c:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-9"
                         data-part="label"
                         data-scope="field"
-                        for=":r49:"
-                        id="field:::r49:::label"
+                        for=":r4c:"
+                        id="field:::r4c:::label"
                       >
                         Titre 2
                       </label>
@@ -39850,7 +40521,7 @@ exports[`single fields > using custom tagName 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4c:::legend"
+        aria-labelledby="fieldset:::r4f:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -39862,7 +40533,7 @@ exports[`single fields > using custom tagName 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r4d:"
+            id="field:::r4g:"
             role="group"
           >
             <input

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -544,7 +544,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9c:::legend"
+        aria-labelledby="fieldset:::r9f:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -560,7 +560,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9d:::legend"
+                  aria-labelledby="fieldset:::r9g:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -598,7 +598,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                 class="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r9e:::legend"
+                                  aria-labelledby="fieldset:::r9h:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -629,7 +629,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r9f:::legend"
+                                            aria-labelledby="fieldset:::r9i:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -641,15 +641,15 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r9g:"
+                                                id="field:::r9j:"
                                                 role="group"
                                               >
                                                 <label
                                                   class="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  for=":r9g:"
-                                                  id="field:::r9g:::label"
+                                                  for=":r9j:"
+                                                  id="field:::r9j:::label"
                                                 >
                                                   title
                                                 </label>
@@ -674,7 +674,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r9h:::legend"
+                                            aria-labelledby="fieldset:::r9k:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -686,7 +686,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r9i:"
+                                                id="field:::r9l:"
                                                 role="group"
                                               >
                                                 <label
@@ -696,13 +696,13 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="unchecked"
                                                   dir="ltr"
-                                                  for=":r9i:"
+                                                  for=":r9l:"
                                                   id="checkbox:root_tasks_0_done"
                                                 >
                                                   <input
                                                     aria-invalid="false"
-                                                    aria-labelledby="field:::r9i:::label"
-                                                    id=":r9i:"
+                                                    aria-labelledby="field:::r9l:::label"
+                                                    id=":r9l:"
                                                     name="root[tasks][0][done]"
                                                     style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                                     type="checkbox"
@@ -729,7 +729,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="unchecked"
                                                     dir="ltr"
-                                                    id="field:::r9i:::label"
+                                                    id="field:::r9l:::label"
                                                   >
                                                     <p>
                                                       done
@@ -851,7 +851,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                 class="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r9k:::legend"
+                                  aria-labelledby="fieldset:::r9n:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -882,7 +882,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r9l:::legend"
+                                            aria-labelledby="fieldset:::r9o:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -894,15 +894,15 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r9m:"
+                                                id="field:::r9p:"
                                                 role="group"
                                               >
                                                 <label
                                                   class="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  for=":r9m:"
-                                                  id="field:::r9m:::label"
+                                                  for=":r9p:"
+                                                  id="field:::r9p:::label"
                                                 >
                                                   title
                                                 </label>
@@ -927,7 +927,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r9n:::legend"
+                                            aria-labelledby="fieldset:::r9q:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -939,7 +939,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r9o:"
+                                                id="field:::r9r:"
                                                 role="group"
                                               >
                                                 <label
@@ -949,14 +949,14 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="checked"
                                                   dir="ltr"
-                                                  for=":r9o:"
+                                                  for=":r9r:"
                                                   id="checkbox:root_tasks_1_done"
                                                 >
                                                   <input
                                                     aria-invalid="false"
-                                                    aria-labelledby="field:::r9o:::label"
+                                                    aria-labelledby="field:::r9r:::label"
                                                     checked=""
-                                                    id=":r9o:"
+                                                    id=":r9r:"
                                                     name="root[tasks][1][done]"
                                                     style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                                     type="checkbox"
@@ -987,7 +987,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="checked"
                                                     dir="ltr"
-                                                    id="field:::r9o:::label"
+                                                    id="field:::r9r:::label"
                                                   >
                                                     <p>
                                                       done
@@ -1597,7 +1597,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r96:::legend"
+        aria-labelledby="fieldset:::r99:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -1613,7 +1613,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r97:::legend"
+                  aria-labelledby="fieldset:::r9a:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -1651,7 +1651,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r98:::legend"
+                                  aria-labelledby="fieldset:::r9b:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -1663,7 +1663,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                                       class="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::r99:"
+                                      id="field:::r9c:"
                                       role="group"
                                     >
                                       <label
@@ -1671,8 +1671,8 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":r99:"
-                                        id="field:::r99:::label"
+                                        for=":r9c:"
+                                        id="field:::r9c:::label"
                                       >
                                         tags-1
                                         <span
@@ -1805,7 +1805,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r9a:::legend"
+                                  aria-labelledby="fieldset:::r9d:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -1817,7 +1817,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                                       class="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::r9b:"
+                                      id="field:::r9e:"
                                       role="group"
                                     >
                                       <label
@@ -1825,8 +1825,8 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":r9b:"
-                                        id="field:::r9b:::label"
+                                        for=":r9e:"
+                                        id="field:::r9e:::label"
                                       >
                                         tags-2
                                         <span
@@ -2324,7 +2324,7 @@ exports[`nameGenerator > bracketNameGenerator > checkboxes field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::ra2:::legend"
+        aria-labelledby="fieldset:::ra5:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -2340,7 +2340,7 @@ exports[`nameGenerator > bracketNameGenerator > checkboxes field 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::ra3:::legend"
+                  aria-labelledby="fieldset:::ra6:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -2349,7 +2349,7 @@ exports[`nameGenerator > bracketNameGenerator > checkboxes field 1`] = `
                     class="fieldset__content emotion-1"
                   >
                     <fieldset
-                      aria-labelledby="fieldset:::ra4:::legend"
+                      aria-labelledby="fieldset:::ra7:::legend"
                       class="fieldset__root emotion-5"
                       data-part="root"
                       data-scope="fieldset"
@@ -2358,7 +2358,7 @@ exports[`nameGenerator > bracketNameGenerator > checkboxes field 1`] = `
                         class="fieldset__legend emotion-6"
                         data-part="legend"
                         data-scope="fieldset"
-                        id="fieldset:::ra4:::legend"
+                        id="fieldset:::ra7:::legend"
                       >
                         choices
                       </legend>
@@ -2792,7 +2792,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r8r:::legend"
+        aria-labelledby="fieldset:::r8u:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -2808,7 +2808,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8s:::legend"
+                  aria-labelledby="fieldset:::r8v:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -2839,7 +2839,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8t:::legend"
+                            aria-labelledby="fieldset:::r90:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -2851,15 +2851,15 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                                 class="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r8u:"
+                                id="field:::r91:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r8u:"
-                                  id="field:::r8u:::label"
+                                  for=":r91:"
+                                  id="field:::r91:::label"
                                 >
                                   firstName
                                 </label>
@@ -2884,7 +2884,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8v:::legend"
+                            aria-labelledby="fieldset:::r92:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -2896,15 +2896,15 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                                 class="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r90:"
+                                id="field:::r93:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r90:"
-                                  id="field:::r90:::label"
+                                  for=":r93:"
+                                  id="field:::r93:::label"
                                 >
                                   lastName
                                 </label>
@@ -2929,7 +2929,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r91:::legend"
+                            aria-labelledby="fieldset:::r94:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -2960,7 +2960,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r92:::legend"
+                                      aria-labelledby="fieldset:::r95:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -2972,15 +2972,15 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                                           class="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r93:"
+                                          id="field:::r96:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":r93:"
-                                            id="field:::r93:::label"
+                                            for=":r96:"
+                                            id="field:::r96:::label"
                                           >
                                             street
                                           </label>
@@ -3005,7 +3005,7 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r94:::legend"
+                                      aria-labelledby="fieldset:::r97:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -3017,15 +3017,15 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                                           class="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r95:"
+                                          id="field:::r98:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":r95:"
-                                            id="field:::r95:::label"
+                                            for=":r98:"
+                                            id="field:::r98:::label"
                                           >
                                             city
                                           </label>
@@ -3372,7 +3372,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9u:::legend"
+        aria-labelledby="fieldset:::ra1:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -3388,7 +3388,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9v:::legend"
+                  aria-labelledby="fieldset:::ra2:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -3400,28 +3400,28 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::ra0:"
+                      id="field:::ra3:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":ra0:"
-                        id="field:::ra0:::label"
+                        for=":ra3:"
+                        id="field:::ra3:::label"
                       >
                         option
                       </label>
                       <div
                         aria-describedby="root_option__error root_option__description root_option__help"
-                        aria-labelledby="fieldset:::r9v:::legend"
+                        aria-labelledby="fieldset:::ra2:::legend"
                         aria-orientation="vertical"
                         class="chakra-radio-group__root"
                         data-orientation="vertical"
                         data-part="root"
                         data-scope="radio-group"
                         dir="ltr"
-                        id="radio-group::ra1:"
+                        id="radio-group::ra4:"
                         role="radiogroup"
                         style="position: relative;"
                       >
@@ -3436,13 +3436,13 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                             data-ssr=""
                             data-state="unchecked"
                             dir="ltr"
-                            for="radio-group::ra1::radio:input:0"
+                            for="radio-group::ra4::radio:input:0"
                             id="root_option-0"
                           >
                             <input
-                              aria-labelledby="radio-group::ra1::radio:label:0"
-                              data-ownedby="radio-group::ra1:"
-                              id="radio-group::ra1::radio:input:0"
+                              aria-labelledby="radio-group::ra4::radio:label:0"
+                              data-ownedby="radio-group::ra4:"
+                              id="radio-group::ra4::radio:input:0"
                               name="root[option]"
                               style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                               type="radio"
@@ -3457,7 +3457,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::ra1::radio:control:0"
+                              id="radio-group::ra4::radio:control:0"
                             />
                             <span
                               class="chakra-radio-group__itemText"
@@ -3467,7 +3467,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::ra1::radio:label:0"
+                              id="radio-group::ra4::radio:label:0"
                             >
                               foo
                             </span>
@@ -3480,13 +3480,13 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                             data-ssr=""
                             data-state="unchecked"
                             dir="ltr"
-                            for="radio-group::ra1::radio:input:1"
+                            for="radio-group::ra4::radio:input:1"
                             id="root_option-1"
                           >
                             <input
-                              aria-labelledby="radio-group::ra1::radio:label:1"
-                              data-ownedby="radio-group::ra1:"
-                              id="radio-group::ra1::radio:input:1"
+                              aria-labelledby="radio-group::ra4::radio:label:1"
+                              data-ownedby="radio-group::ra4:"
+                              id="radio-group::ra4::radio:input:1"
                               name="root[option]"
                               style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                               type="radio"
@@ -3501,7 +3501,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::ra1::radio:control:1"
+                              id="radio-group::ra4::radio:control:1"
                             />
                             <span
                               class="chakra-radio-group__itemText"
@@ -3511,7 +3511,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::ra1::radio:label:1"
+                              id="radio-group::ra4::radio:label:1"
                             >
                               bar
                             </span>
@@ -4027,7 +4027,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9q:::legend"
+        aria-labelledby="fieldset:::r9t:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -4043,7 +4043,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9r:::legend"
+                  aria-labelledby="fieldset:::r9u:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -4055,15 +4055,15 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r9s:"
+                      id="field:::r9v:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":r9s:"
-                        id="field:::r9s:::label"
+                        for=":r9v:"
+                        id="field:::r9v:::label"
                       >
                         color
                       </label>
@@ -4077,8 +4077,8 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                       >
                         <select
                           aria-hidden="true"
-                          aria-labelledby="field:::r9s:::label"
-                          id=":r9s:"
+                          aria-labelledby="field:::r9v:::label"
+                          id=":r9v:"
                           name="root[color]"
                           style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                           tabindex="-1"
@@ -4123,7 +4123,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                               aria-expanded="false"
                               aria-haspopup="listbox"
                               aria-invalid="false"
-                              aria-labelledby="field:::r9s:::label"
+                              aria-labelledby="field:::r9v:::label"
                               aria-required="false"
                               class="chakra-select__trigger emotion-10"
                               data-part="trigger"
@@ -4174,7 +4174,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                           style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                         >
                           <div
-                            aria-labelledby="field:::r9s:::label"
+                            aria-labelledby="field:::r9v:::label"
                             class="chakra-select__content emotion-16"
                             data-part="content"
                             data-scope="select"
@@ -4650,7 +4650,7 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r8j:::legend"
+        aria-labelledby="fieldset:::r8m:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -4666,7 +4666,7 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8k:::legend"
+                  aria-labelledby="fieldset:::r8n:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -4678,15 +4678,15 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r8l:"
+                      id="field:::r8o:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":r8l:"
-                        id="field:::r8l:::label"
+                        for=":r8o:"
+                        id="field:::r8o:::label"
                       >
                         firstName
                       </label>
@@ -4711,7 +4711,7 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                 class="rjsf-field rjsf-field-number"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8m:::legend"
+                  aria-labelledby="fieldset:::r8p:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -4723,15 +4723,15 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r8n:"
+                      id="field:::r8q:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":r8n:"
-                        id="field:::r8n:::label"
+                        for=":r8q:"
+                        id="field:::r8q:::label"
                       >
                         age
                       </label>
@@ -4757,7 +4757,7 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                 class="rjsf-field rjsf-field-boolean"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8o:::legend"
+                  aria-labelledby="fieldset:::r8r:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -4769,7 +4769,7 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r8p:"
+                      id="field:::r8s:"
                       role="group"
                     >
                       <label
@@ -4779,13 +4779,13 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                         data-scope="checkbox"
                         data-state="unchecked"
                         dir="ltr"
-                        for=":r8p:"
+                        for=":r8s:"
                         id="checkbox:root_active"
                       >
                         <input
                           aria-invalid="false"
-                          aria-labelledby="field:::r8p:::label"
-                          id=":r8p:"
+                          aria-labelledby="field:::r8s:::label"
+                          id=":r8s:"
                           name="root[active]"
                           style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                           type="checkbox"
@@ -4812,7 +4812,7 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
                           data-scope="checkbox"
                           data-state="unchecked"
                           dir="ltr"
-                          id="field:::r8p:::label"
+                          id="field:::r8s:::label"
                         >
                           <p>
                             active
@@ -5075,7 +5075,7 @@ exports[`nameGenerator > bracketNameGenerator > textarea field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::ra8:::legend"
+        aria-labelledby="fieldset:::rab:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -5091,7 +5091,7 @@ exports[`nameGenerator > bracketNameGenerator > textarea field 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::ra9:::legend"
+                  aria-labelledby="fieldset:::rac:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -5103,15 +5103,15 @@ exports[`nameGenerator > bracketNameGenerator > textarea field 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::raa:"
+                      id="field:::rad:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":raa:"
-                        id="field:::raa:::label"
+                        for=":rad:"
+                        id="field:::rad:::label"
                       >
                         description
                       </label>
@@ -5694,7 +5694,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::rb4:::legend"
+        aria-labelledby="fieldset:::rb7:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -5710,7 +5710,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rb5:::legend"
+                  aria-labelledby="fieldset:::rb8:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -5748,7 +5748,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                 class="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::rb6:::legend"
+                                  aria-labelledby="fieldset:::rb9:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -5779,7 +5779,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::rb7:::legend"
+                                            aria-labelledby="fieldset:::rba:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -5791,15 +5791,15 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rb8:"
+                                                id="field:::rbb:"
                                                 role="group"
                                               >
                                                 <label
                                                   class="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  for=":rb8:"
-                                                  id="field:::rb8:::label"
+                                                  for=":rbb:"
+                                                  id="field:::rbb:::label"
                                                 >
                                                   title
                                                 </label>
@@ -5824,7 +5824,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::rb9:::legend"
+                                            aria-labelledby="fieldset:::rbc:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -5836,7 +5836,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rba:"
+                                                id="field:::rbd:"
                                                 role="group"
                                               >
                                                 <label
@@ -5846,13 +5846,13 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="unchecked"
                                                   dir="ltr"
-                                                  for=":rba:"
+                                                  for=":rbd:"
                                                   id="checkbox:root_tasks_0_done"
                                                 >
                                                   <input
                                                     aria-invalid="false"
-                                                    aria-labelledby="field:::rba:::label"
-                                                    id=":rba:"
+                                                    aria-labelledby="field:::rbd:::label"
+                                                    id=":rbd:"
                                                     name="root.tasks.0.done"
                                                     style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                                     type="checkbox"
@@ -5879,7 +5879,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="unchecked"
                                                     dir="ltr"
-                                                    id="field:::rba:::label"
+                                                    id="field:::rbd:::label"
                                                   >
                                                     <p>
                                                       done
@@ -6001,7 +6001,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                 class="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::rbc:::legend"
+                                  aria-labelledby="fieldset:::rbf:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -6032,7 +6032,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::rbd:::legend"
+                                            aria-labelledby="fieldset:::rbg:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -6044,15 +6044,15 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rbe:"
+                                                id="field:::rbh:"
                                                 role="group"
                                               >
                                                 <label
                                                   class="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  for=":rbe:"
-                                                  id="field:::rbe:::label"
+                                                  for=":rbh:"
+                                                  id="field:::rbh:::label"
                                                 >
                                                   title
                                                 </label>
@@ -6077,7 +6077,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                           class="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::rbf:::legend"
+                                            aria-labelledby="fieldset:::rbi:::legend"
                                             class="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -6089,7 +6089,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                 class="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rbg:"
+                                                id="field:::rbj:"
                                                 role="group"
                                               >
                                                 <label
@@ -6099,14 +6099,14 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="checked"
                                                   dir="ltr"
-                                                  for=":rbg:"
+                                                  for=":rbj:"
                                                   id="checkbox:root_tasks_1_done"
                                                 >
                                                   <input
                                                     aria-invalid="false"
-                                                    aria-labelledby="field:::rbg:::label"
+                                                    aria-labelledby="field:::rbj:::label"
                                                     checked=""
-                                                    id=":rbg:"
+                                                    id=":rbj:"
                                                     name="root.tasks.1.done"
                                                     style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                                     type="checkbox"
@@ -6137,7 +6137,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="checked"
                                                     dir="ltr"
-                                                    id="field:::rbg:::label"
+                                                    id="field:::rbj:::label"
                                                   >
                                                     <p>
                                                       done
@@ -6747,7 +6747,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::rau:::legend"
+        aria-labelledby="fieldset:::rb1:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -6763,7 +6763,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rav:::legend"
+                  aria-labelledby="fieldset:::rb2:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -6801,7 +6801,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::rb0:::legend"
+                                  aria-labelledby="fieldset:::rb3:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -6813,7 +6813,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                                       class="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::rb1:"
+                                      id="field:::rb4:"
                                       role="group"
                                     >
                                       <label
@@ -6821,8 +6821,8 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":rb1:"
-                                        id="field:::rb1:::label"
+                                        for=":rb4:"
+                                        id="field:::rb4:::label"
                                       >
                                         tags-1
                                         <span
@@ -6955,7 +6955,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::rb2:::legend"
+                                  aria-labelledby="fieldset:::rb5:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -6967,7 +6967,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                                       class="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::rb3:"
+                                      id="field:::rb6:"
                                       role="group"
                                     >
                                       <label
@@ -6975,8 +6975,8 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":rb3:"
-                                        id="field:::rb3:::label"
+                                        for=":rb6:"
+                                        id="field:::rb6:::label"
                                       >
                                         tags-2
                                         <span
@@ -7416,7 +7416,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::raj:::legend"
+        aria-labelledby="fieldset:::ram:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -7432,7 +7432,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rak:::legend"
+                  aria-labelledby="fieldset:::ran:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -7463,7 +7463,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::ral:::legend"
+                            aria-labelledby="fieldset:::rao:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -7475,15 +7475,15 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                                 class="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::ram:"
+                                id="field:::rap:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":ram:"
-                                  id="field:::ram:::label"
+                                  for=":rap:"
+                                  id="field:::rap:::label"
                                 >
                                   firstName
                                 </label>
@@ -7508,7 +7508,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::ran:::legend"
+                            aria-labelledby="fieldset:::raq:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -7520,15 +7520,15 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                                 class="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::rao:"
+                                id="field:::rar:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":rao:"
-                                  id="field:::rao:::label"
+                                  for=":rar:"
+                                  id="field:::rar:::label"
                                 >
                                   lastName
                                 </label>
@@ -7553,7 +7553,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::rap:::legend"
+                            aria-labelledby="fieldset:::ras:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -7584,7 +7584,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::raq:::legend"
+                                      aria-labelledby="fieldset:::rat:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -7596,15 +7596,15 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                                           class="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::rar:"
+                                          id="field:::rau:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":rar:"
-                                            id="field:::rar:::label"
+                                            for=":rau:"
+                                            id="field:::rau:::label"
                                           >
                                             street
                                           </label>
@@ -7629,7 +7629,7 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::ras:::legend"
+                                      aria-labelledby="fieldset:::rav:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -7641,15 +7641,15 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                                           class="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::rat:"
+                                          id="field:::rb0:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":rat:"
-                                            id="field:::rat:::label"
+                                            for=":rb0:"
+                                            id="field:::rb0:::label"
                                           >
                                             city
                                           </label>
@@ -8183,7 +8183,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::rbi:::legend"
+        aria-labelledby="fieldset:::rbl:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -8199,7 +8199,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rbj:::legend"
+                  aria-labelledby="fieldset:::rbm:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -8211,15 +8211,15 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::rbk:"
+                      id="field:::rbn:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":rbk:"
-                        id="field:::rbk:::label"
+                        for=":rbn:"
+                        id="field:::rbn:::label"
                       >
                         color
                       </label>
@@ -8233,8 +8233,8 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                       >
                         <select
                           aria-hidden="true"
-                          aria-labelledby="field:::rbk:::label"
-                          id=":rbk:"
+                          aria-labelledby="field:::rbn:::label"
+                          id=":rbn:"
                           name="root.color"
                           style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                           tabindex="-1"
@@ -8279,7 +8279,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                               aria-expanded="false"
                               aria-haspopup="listbox"
                               aria-invalid="false"
-                              aria-labelledby="field:::rbk:::label"
+                              aria-labelledby="field:::rbn:::label"
                               aria-required="false"
                               class="chakra-select__trigger emotion-10"
                               data-part="trigger"
@@ -8330,7 +8330,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                           style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                         >
                           <div
-                            aria-labelledby="field:::rbk:::label"
+                            aria-labelledby="field:::rbn:::label"
                             class="chakra-select__content emotion-16"
                             data-part="content"
                             data-scope="select"
@@ -8806,7 +8806,7 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::rab:::legend"
+        aria-labelledby="fieldset:::rae:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -8822,7 +8822,7 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rac:::legend"
+                  aria-labelledby="fieldset:::raf:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -8834,15 +8834,15 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::rad:"
+                      id="field:::rag:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":rad:"
-                        id="field:::rad:::label"
+                        for=":rag:"
+                        id="field:::rag:::label"
                       >
                         firstName
                       </label>
@@ -8867,7 +8867,7 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                 class="rjsf-field rjsf-field-number"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rae:::legend"
+                  aria-labelledby="fieldset:::rah:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -8879,15 +8879,15 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::raf:"
+                      id="field:::rai:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        for=":raf:"
-                        id="field:::raf:::label"
+                        for=":rai:"
+                        id="field:::rai:::label"
                       >
                         age
                       </label>
@@ -8913,7 +8913,7 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                 class="rjsf-field rjsf-field-boolean"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rag:::legend"
+                  aria-labelledby="fieldset:::raj:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -8925,7 +8925,7 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                       class="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::rah:"
+                      id="field:::rak:"
                       role="group"
                     >
                       <label
@@ -8935,13 +8935,13 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                         data-scope="checkbox"
                         data-state="unchecked"
                         dir="ltr"
-                        for=":rah:"
+                        for=":rak:"
                         id="checkbox:root_active"
                       >
                         <input
                           aria-invalid="false"
-                          aria-labelledby="field:::rah:::label"
-                          id=":rah:"
+                          aria-labelledby="field:::rak:::label"
+                          id=":rak:"
                           name="root.active"
                           style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                           type="checkbox"
@@ -8968,7 +8968,7 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
                           data-scope="checkbox"
                           data-state="unchecked"
                           dir="ltr"
-                          id="field:::rah:::label"
+                          id="field:::rak:::label"
                         >
                           <p>
                             active
@@ -9345,7 +9345,7 @@ exports[`single fields > Cyclic schema 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4n:::legend"
+        aria-labelledby="fieldset:::r4q:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -9382,7 +9382,7 @@ exports[`single fields > Cyclic schema 1`] = `
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4o:::legend"
+                  aria-labelledby="fieldset:::r4r:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -11574,7 +11574,7 @@ exports[`single fields > checkboxes field 1`] = `
       class="rjsf-field rjsf-field-array"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3h:::legend"
+        aria-labelledby="fieldset:::r3k:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -11583,7 +11583,7 @@ exports[`single fields > checkboxes field 1`] = `
           class="fieldset__content emotion-1"
         >
           <fieldset
-            aria-labelledby="fieldset:::r3i:::legend"
+            aria-labelledby="fieldset:::r3l:::legend"
             class="fieldset__root emotion-2"
             data-part="root"
             data-scope="fieldset"
@@ -11592,7 +11592,7 @@ exports[`single fields > checkboxes field 1`] = `
               class="fieldset__legend emotion-3"
               data-part="legend"
               data-scope="fieldset"
-              id="fieldset:::r3i:::legend"
+              id="fieldset:::r3l:::legend"
             >
               An enum list rendered as checkboxes
             </legend>
@@ -13141,7 +13141,7 @@ exports[`single fields > field with description 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3u:::legend"
+        aria-labelledby="fieldset:::r41:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -13157,7 +13157,7 @@ exports[`single fields > field with description 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r3v:::legend"
+                  aria-labelledby="fieldset:::r42:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -13166,7 +13166,7 @@ exports[`single fields > field with description 1`] = `
                     class="fieldset__legend emotion-4"
                     data-part="legend"
                     data-scope="fieldset"
-                    id="fieldset:::r3v:::legend"
+                    id="fieldset:::r42:::legend"
                   >
                     <sup
                       class="emotion-5"
@@ -13182,15 +13182,15 @@ exports[`single fields > field with description 1`] = `
                       class="chakra-field__root emotion-7"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r40:"
+                      id="field:::r43:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-8"
                         data-part="label"
                         data-scope="field"
-                        for=":r40:"
-                        id="field:::r40:::label"
+                        for=":r43:"
+                        id="field:::r43:::label"
                       >
                         my-field
                       </label>
@@ -13482,7 +13482,7 @@ exports[`single fields > field with description in uiSchema 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r41:::legend"
+        aria-labelledby="fieldset:::r44:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -13498,7 +13498,7 @@ exports[`single fields > field with description in uiSchema 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r42:::legend"
+                  aria-labelledby="fieldset:::r45:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -13507,7 +13507,7 @@ exports[`single fields > field with description in uiSchema 1`] = `
                     class="fieldset__legend emotion-4"
                     data-part="legend"
                     data-scope="fieldset"
-                    id="fieldset:::r42:::legend"
+                    id="fieldset:::r45:::legend"
                   >
                     <sup
                       class="emotion-5"
@@ -13523,15 +13523,15 @@ exports[`single fields > field with description in uiSchema 1`] = `
                       class="chakra-field__root emotion-7"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r43:"
+                      id="field:::r46:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-8"
                         data-part="label"
                         data-scope="field"
-                        for=":r43:"
-                        id="field:::r43:::label"
+                        for=":r46:"
+                        id="field:::r46:::label"
                       >
                         my-field
                       </label>
@@ -13823,7 +13823,7 @@ exports[`single fields > field with markdown description 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r44:::legend"
+        aria-labelledby="fieldset:::r47:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -13839,7 +13839,7 @@ exports[`single fields > field with markdown description 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r45:::legend"
+                  aria-labelledby="fieldset:::r48:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -13848,7 +13848,7 @@ exports[`single fields > field with markdown description 1`] = `
                     class="fieldset__legend emotion-4"
                     data-part="legend"
                     data-scope="fieldset"
-                    id="fieldset:::r45:::legend"
+                    id="fieldset:::r48:::legend"
                   >
                     <sup
                       class="emotion-5"
@@ -13870,15 +13870,15 @@ exports[`single fields > field with markdown description 1`] = `
                       class="chakra-field__root emotion-7"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r46:"
+                      id="field:::r49:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-8"
                         data-part="label"
                         data-scope="field"
-                        for=":r46:"
-                        id="field:::r46:::label"
+                        for=":r49:"
+                        id="field:::r49:::label"
                       >
                         my-field
                       </label>
@@ -14170,7 +14170,7 @@ exports[`single fields > field with markdown description in uiSchema 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r47:::legend"
+        aria-labelledby="fieldset:::r4a:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -14186,7 +14186,7 @@ exports[`single fields > field with markdown description in uiSchema 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r48:::legend"
+                  aria-labelledby="fieldset:::r4b:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -14195,7 +14195,7 @@ exports[`single fields > field with markdown description in uiSchema 1`] = `
                     class="fieldset__legend emotion-4"
                     data-part="legend"
                     data-scope="fieldset"
-                    id="fieldset:::r48:::legend"
+                    id="fieldset:::r4b:::legend"
                   >
                     <sup
                       class="emotion-5"
@@ -14211,15 +14211,15 @@ exports[`single fields > field with markdown description in uiSchema 1`] = `
                       class="chakra-field__root emotion-7"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r49:"
+                      id="field:::r4c:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-8"
                         data-part="label"
                         data-scope="field"
-                        for=":r49:"
-                        id="field:::r49:::label"
+                        for=":r4c:"
+                        id="field:::r4c:::label"
                       >
                         my-field
                       </label>
@@ -15649,7 +15649,7 @@ exports[`single fields > help and error display 1`] = `
       class="rjsf-field rjsf-field-string rjsf-field-error"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4l:::legend"
+        aria-labelledby="fieldset:::r4o:::legend"
         class="fieldset__root emotion-8"
         data-invalid=""
         data-part="root"
@@ -15669,7 +15669,7 @@ exports[`single fields > help and error display 1`] = `
             data-invalid=""
             data-part="root"
             data-scope="field"
-            id="field:::r4m:"
+            id="field:::r4p:"
             role="group"
           >
             <input
@@ -15851,7 +15851,7 @@ exports[`single fields > hidden field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3t:::legend"
+        aria-labelledby="fieldset:::r40:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -16091,7 +16091,7 @@ exports[`single fields > hidden label 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4d:::legend"
+        aria-labelledby="fieldset:::r4g:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -16103,7 +16103,7 @@ exports[`single fields > hidden label 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r4e:"
+            id="field:::r4h:"
             role="group"
           >
             <input
@@ -17425,7 +17425,7 @@ exports[`single fields > optional data controls > does not show optional control
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4p:::legend"
+        aria-labelledby="fieldset:::r4s:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -17456,7 +17456,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4q:::legend"
+                  aria-labelledby="fieldset:::r4t:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -17487,7 +17487,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4r:::legend"
+                            aria-labelledby="fieldset:::r4u:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17499,15 +17499,15 @@ exports[`single fields > optional data controls > does not show optional control
                                 class="chakra-field__root emotion-14"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r4s:"
+                                id="field:::r4v:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-15"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r4s:"
-                                  id="field:::r4s:::label"
+                                  for=":r4v:"
+                                  id="field:::r4v:::label"
                                 >
                                   test
                                 </label>
@@ -17532,7 +17532,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4t:::legend"
+                            aria-labelledby="fieldset:::r50:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17548,87 +17548,6 @@ exports[`single fields > optional data controls > does not show optional control
                                   class="chakra-heading emotion-3"
                                 >
                                   deepObjectOptional
-                                </h5>
-                                <span
-                                  aria-orientation="horizontal"
-                                  class="chakra-separator emotion-4"
-                                  role="separator"
-                                />
-                              </div>
-                              <div
-                                class="emotion-5"
-                              >
-                                <div>
-                                  <div
-                                    class="rjsf-field rjsf-field-string"
-                                  >
-                                    <fieldset
-                                      aria-labelledby="fieldset:::r4u:::legend"
-                                      class="fieldset__root emotion-0"
-                                      data-part="root"
-                                      data-scope="fieldset"
-                                    >
-                                      <div
-                                        class="fieldset__content emotion-1"
-                                      >
-                                        <div
-                                          class="chakra-field__root emotion-14"
-                                          data-part="root"
-                                          data-scope="field"
-                                          id="field:::r4v:"
-                                          role="group"
-                                        >
-                                          <label
-                                            class="chakra-field__label emotion-15"
-                                            data-part="label"
-                                            data-scope="field"
-                                            for=":r4v:"
-                                            id="field:::r4v:::label"
-                                          >
-                                            deepTest
-                                          </label>
-                                          <input
-                                            aria-describedby="root_nestedObjectOptional_deepObjectOptional_deepTest__error root_nestedObjectOptional_deepObjectOptional_deepTest__description root_nestedObjectOptional_deepObjectOptional_deepTest__help"
-                                            class="chakra-input emotion-16"
-                                            data-part="input"
-                                            data-scope="field"
-                                            id="root_nestedObjectOptional_deepObjectOptional_deepTest"
-                                            name="root_nestedObjectOptional_deepObjectOptional_deepTest"
-                                            placeholder=""
-                                            type="text"
-                                            value=""
-                                          />
-                                        </div>
-                                      </div>
-                                    </fieldset>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </fieldset>
-                        </div>
-                      </div>
-                      <div>
-                        <div
-                          class="rjsf-field rjsf-field-object"
-                        >
-                          <fieldset
-                            aria-labelledby="fieldset:::r50:::legend"
-                            class="fieldset__root emotion-0"
-                            data-part="root"
-                            data-scope="fieldset"
-                          >
-                            <div
-                              class="fieldset__content emotion-1"
-                            >
-                              <div
-                                class="emotion-2"
-                                id="root_nestedObjectOptional_deepObject__title"
-                              >
-                                <h5
-                                  class="chakra-heading emotion-3"
-                                >
-                                  deepObject
                                 </h5>
                                 <span
                                   aria-orientation="horizontal"
@@ -17669,6 +17588,87 @@ exports[`single fields > optional data controls > does not show optional control
                                             deepTest
                                           </label>
                                           <input
+                                            aria-describedby="root_nestedObjectOptional_deepObjectOptional_deepTest__error root_nestedObjectOptional_deepObjectOptional_deepTest__description root_nestedObjectOptional_deepObjectOptional_deepTest__help"
+                                            class="chakra-input emotion-16"
+                                            data-part="input"
+                                            data-scope="field"
+                                            id="root_nestedObjectOptional_deepObjectOptional_deepTest"
+                                            name="root_nestedObjectOptional_deepObjectOptional_deepTest"
+                                            placeholder=""
+                                            type="text"
+                                            value=""
+                                          />
+                                        </div>
+                                      </div>
+                                    </fieldset>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </fieldset>
+                        </div>
+                      </div>
+                      <div>
+                        <div
+                          class="rjsf-field rjsf-field-object"
+                        >
+                          <fieldset
+                            aria-labelledby="fieldset:::r53:::legend"
+                            class="fieldset__root emotion-0"
+                            data-part="root"
+                            data-scope="fieldset"
+                          >
+                            <div
+                              class="fieldset__content emotion-1"
+                            >
+                              <div
+                                class="emotion-2"
+                                id="root_nestedObjectOptional_deepObject__title"
+                              >
+                                <h5
+                                  class="chakra-heading emotion-3"
+                                >
+                                  deepObject
+                                </h5>
+                                <span
+                                  aria-orientation="horizontal"
+                                  class="chakra-separator emotion-4"
+                                  role="separator"
+                                />
+                              </div>
+                              <div
+                                class="emotion-5"
+                              >
+                                <div>
+                                  <div
+                                    class="rjsf-field rjsf-field-string"
+                                  >
+                                    <fieldset
+                                      aria-labelledby="fieldset:::r54:::legend"
+                                      class="fieldset__root emotion-0"
+                                      data-part="root"
+                                      data-scope="fieldset"
+                                    >
+                                      <div
+                                        class="fieldset__content emotion-1"
+                                      >
+                                        <div
+                                          class="chakra-field__root emotion-14"
+                                          data-part="root"
+                                          data-scope="field"
+                                          id="field:::r55:"
+                                          role="group"
+                                        >
+                                          <label
+                                            class="chakra-field__label emotion-15"
+                                            data-part="label"
+                                            data-scope="field"
+                                            for=":r55:"
+                                            id="field:::r55:::label"
+                                          >
+                                            deepTest
+                                          </label>
+                                          <input
                                             aria-describedby="root_nestedObjectOptional_deepObject_deepTest__error root_nestedObjectOptional_deepObject_deepTest__description root_nestedObjectOptional_deepObject_deepTest__help"
                                             class="chakra-input emotion-16"
                                             data-part="input"
@@ -17694,7 +17694,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r53:::legend"
+                            aria-labelledby="fieldset:::r56:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17768,7 +17768,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r54:::legend"
+                            aria-labelledby="fieldset:::r57:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17842,7 +17842,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r55:::legend"
+                            aria-labelledby="fieldset:::r58:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -17921,7 +17921,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r56:::legend"
+                  aria-labelledby="fieldset:::r59:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -17995,7 +17995,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r57:::legend"
+                  aria-labelledby="fieldset:::r5a:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18026,7 +18026,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r58:::legend"
+                            aria-labelledby="fieldset:::r5b:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -18038,15 +18038,15 @@ exports[`single fields > optional data controls > does not show optional control
                                 class="chakra-field__root emotion-14"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r59:"
+                                id="field:::r5c:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-15"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r59:"
-                                  id="field:::r59:::label"
+                                  for=":r5c:"
+                                  id="field:::r5c:::label"
                                 >
                                   test
                                 </label>
@@ -18076,7 +18076,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5a:::legend"
+                  aria-labelledby="fieldset:::r5d:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18150,7 +18150,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5b:::legend"
+                  aria-labelledby="fieldset:::r5e:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18171,15 +18171,15 @@ exports[`single fields > optional data controls > does not show optional control
                             class="chakra-field__root emotion-100"
                             data-part="root"
                             data-scope="field"
-                            id="field:::r5c:"
+                            id="field:::r5f:"
                             role="group"
                           >
                             <label
                               class="chakra-field__label emotion-15"
                               data-part="label"
                               data-scope="field"
-                              for=":r5c:"
-                              id="field:::r5c:::label"
+                              for=":r5f:"
+                              id="field:::r5f:::label"
                             >
                               optionalObjectWithOneofs
                             </label>
@@ -18193,8 +18193,8 @@ exports[`single fields > optional data controls > does not show optional control
                             >
                               <select
                                 aria-hidden="true"
-                                aria-labelledby="field:::r5c:::label"
-                                id=":r5c:"
+                                aria-labelledby="field:::r5f:::label"
+                                id=":r5f:"
                                 name="root_optionalObjectWithOneofs__oneof_select"
                                 style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                 tabindex="-1"
@@ -18237,7 +18237,7 @@ exports[`single fields > optional data controls > does not show optional control
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-invalid="false"
-                                    aria-labelledby="field:::r5c:::label"
+                                    aria-labelledby="field:::r5f:::label"
                                     aria-required="false"
                                     class="chakra-select__trigger emotion-105"
                                     data-part="trigger"
@@ -18289,7 +18289,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                               >
                                 <div
-                                  aria-labelledby="field:::r5c:::label"
+                                  aria-labelledby="field:::r5f:::label"
                                   class="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -18398,7 +18398,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5e:::legend"
+                            aria-labelledby="fieldset:::r5h:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -18429,7 +18429,7 @@ exports[`single fields > optional data controls > does not show optional control
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r5f:::legend"
+                                      aria-labelledby="fieldset:::r5i:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -18443,7 +18443,7 @@ exports[`single fields > optional data controls > does not show optional control
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r5g:"
+                                          id="field:::r5j:"
                                           role="group"
                                         >
                                           <label
@@ -18452,8 +18452,8 @@ exports[`single fields > optional data controls > does not show optional control
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            for=":r5g:"
-                                            id="field:::r5g:::label"
+                                            for=":r5j:"
+                                            id="field:::r5j:::label"
                                           >
                                             name
                                           </label>
@@ -18491,7 +18491,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5h:::legend"
+                  aria-labelledby="fieldset:::r5k:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18512,15 +18512,15 @@ exports[`single fields > optional data controls > does not show optional control
                             class="chakra-field__root emotion-100"
                             data-part="root"
                             data-scope="field"
-                            id="field:::r5i:"
+                            id="field:::r5l:"
                             role="group"
                           >
                             <label
                               class="chakra-field__label emotion-15"
                               data-part="label"
                               data-scope="field"
-                              for=":r5i:"
-                              id="field:::r5i:::label"
+                              for=":r5l:"
+                              id="field:::r5l:::label"
                             >
                               optionalArrayWithAnyofs
                             </label>
@@ -18534,8 +18534,8 @@ exports[`single fields > optional data controls > does not show optional control
                             >
                               <select
                                 aria-hidden="true"
-                                aria-labelledby="field:::r5i:::label"
-                                id=":r5i:"
+                                aria-labelledby="field:::r5l:::label"
+                                id=":r5l:"
                                 name="root_optionalArrayWithAnyofs__anyof_select"
                                 style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                 tabindex="-1"
@@ -18578,7 +18578,7 @@ exports[`single fields > optional data controls > does not show optional control
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-invalid="false"
-                                    aria-labelledby="field:::r5i:::label"
+                                    aria-labelledby="field:::r5l:::label"
                                     aria-required="false"
                                     class="chakra-select__trigger emotion-105"
                                     data-part="trigger"
@@ -18630,7 +18630,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                               >
                                 <div
-                                  aria-labelledby="field:::r5i:::label"
+                                  aria-labelledby="field:::r5l:::label"
                                   class="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -18739,7 +18739,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5k:::legend"
+                            aria-labelledby="fieldset:::r5n:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19472,7 +19472,7 @@ exports[`single fields > optional data controls > does not show optional control
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r6m:::legend"
+        aria-labelledby="fieldset:::r6p:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -19504,7 +19504,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6n:::legend"
+                  aria-labelledby="fieldset:::r6q:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -19536,7 +19536,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6o:::legend"
+                            aria-labelledby="fieldset:::r6r:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19550,7 +19550,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r6p:"
+                                id="field:::r6s:"
                                 role="group"
                               >
                                 <label
@@ -19559,8 +19559,8 @@ exports[`single fields > optional data controls > does not show optional control
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  for=":r6p:"
-                                  id="field:::r6p:::label"
+                                  for=":r6s:"
+                                  id="field:::r6s:::label"
                                 >
                                   test
                                 </label>
@@ -19588,7 +19588,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6q:::legend"
+                            aria-labelledby="fieldset:::r6t:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19604,95 +19604,6 @@ exports[`single fields > optional data controls > does not show optional control
                                   class="chakra-heading emotion-3"
                                 >
                                   deepObjectOptional
-                                </h5>
-                                <span
-                                  aria-orientation="horizontal"
-                                  class="chakra-separator emotion-4"
-                                  role="separator"
-                                />
-                              </div>
-                              <div
-                                class="emotion-5"
-                              >
-                                <div />
-                                <div>
-                                  <div
-                                    class="rjsf-field rjsf-field-string"
-                                  >
-                                    <fieldset
-                                      aria-labelledby="fieldset:::r6r:::legend"
-                                      class="fieldset__root emotion-0"
-                                      data-part="root"
-                                      data-scope="fieldset"
-                                    >
-                                      <div
-                                        class="fieldset__content emotion-1"
-                                      >
-                                        <div
-                                          class="chakra-field__root emotion-14"
-                                          data-disabled=""
-                                          data-part="root"
-                                          data-readonly=""
-                                          data-scope="field"
-                                          id="field:::r6s:"
-                                          role="group"
-                                        >
-                                          <label
-                                            class="chakra-field__label emotion-15"
-                                            data-disabled=""
-                                            data-part="label"
-                                            data-readonly=""
-                                            data-scope="field"
-                                            for=":r6s:"
-                                            id="field:::r6s:::label"
-                                          >
-                                            deepTest
-                                          </label>
-                                          <input
-                                            aria-describedby="root_nestedObjectOptional_deepObjectOptional_deepTest__error root_nestedObjectOptional_deepObjectOptional_deepTest__description root_nestedObjectOptional_deepObjectOptional_deepTest__help"
-                                            class="chakra-input emotion-16"
-                                            data-part="input"
-                                            data-readonly=""
-                                            data-scope="field"
-                                            disabled=""
-                                            id="root_nestedObjectOptional_deepObjectOptional_deepTest"
-                                            name="root_nestedObjectOptional_deepObjectOptional_deepTest"
-                                            placeholder=""
-                                            readonly=""
-                                            type="text"
-                                            value=""
-                                          />
-                                        </div>
-                                      </div>
-                                    </fieldset>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </fieldset>
-                        </div>
-                      </div>
-                      <div>
-                        <div
-                          class="rjsf-field rjsf-field-object"
-                        >
-                          <fieldset
-                            aria-labelledby="fieldset:::r6t:::legend"
-                            class="fieldset__root emotion-0"
-                            data-part="root"
-                            data-scope="fieldset"
-                          >
-                            <div
-                              class="fieldset__content emotion-1"
-                            >
-                              <div
-                                class="emotion-2"
-                                id="root_nestedObjectOptional_deepObject__title"
-                              >
-                                <h5
-                                  class="chakra-heading emotion-3"
-                                >
-                                  deepObject
                                 </h5>
                                 <span
                                   aria-orientation="horizontal"
@@ -19738,6 +19649,95 @@ exports[`single fields > optional data controls > does not show optional control
                                             deepTest
                                           </label>
                                           <input
+                                            aria-describedby="root_nestedObjectOptional_deepObjectOptional_deepTest__error root_nestedObjectOptional_deepObjectOptional_deepTest__description root_nestedObjectOptional_deepObjectOptional_deepTest__help"
+                                            class="chakra-input emotion-16"
+                                            data-part="input"
+                                            data-readonly=""
+                                            data-scope="field"
+                                            disabled=""
+                                            id="root_nestedObjectOptional_deepObjectOptional_deepTest"
+                                            name="root_nestedObjectOptional_deepObjectOptional_deepTest"
+                                            placeholder=""
+                                            readonly=""
+                                            type="text"
+                                            value=""
+                                          />
+                                        </div>
+                                      </div>
+                                    </fieldset>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </fieldset>
+                        </div>
+                      </div>
+                      <div>
+                        <div
+                          class="rjsf-field rjsf-field-object"
+                        >
+                          <fieldset
+                            aria-labelledby="fieldset:::r70:::legend"
+                            class="fieldset__root emotion-0"
+                            data-part="root"
+                            data-scope="fieldset"
+                          >
+                            <div
+                              class="fieldset__content emotion-1"
+                            >
+                              <div
+                                class="emotion-2"
+                                id="root_nestedObjectOptional_deepObject__title"
+                              >
+                                <h5
+                                  class="chakra-heading emotion-3"
+                                >
+                                  deepObject
+                                </h5>
+                                <span
+                                  aria-orientation="horizontal"
+                                  class="chakra-separator emotion-4"
+                                  role="separator"
+                                />
+                              </div>
+                              <div
+                                class="emotion-5"
+                              >
+                                <div />
+                                <div>
+                                  <div
+                                    class="rjsf-field rjsf-field-string"
+                                  >
+                                    <fieldset
+                                      aria-labelledby="fieldset:::r71:::legend"
+                                      class="fieldset__root emotion-0"
+                                      data-part="root"
+                                      data-scope="fieldset"
+                                    >
+                                      <div
+                                        class="fieldset__content emotion-1"
+                                      >
+                                        <div
+                                          class="chakra-field__root emotion-14"
+                                          data-disabled=""
+                                          data-part="root"
+                                          data-readonly=""
+                                          data-scope="field"
+                                          id="field:::r72:"
+                                          role="group"
+                                        >
+                                          <label
+                                            class="chakra-field__label emotion-15"
+                                            data-disabled=""
+                                            data-part="label"
+                                            data-readonly=""
+                                            data-scope="field"
+                                            for=":r72:"
+                                            id="field:::r72:::label"
+                                          >
+                                            deepTest
+                                          </label>
+                                          <input
                                             aria-describedby="root_nestedObjectOptional_deepObject_deepTest__error root_nestedObjectOptional_deepObject_deepTest__description root_nestedObjectOptional_deepObject_deepTest__help"
                                             class="chakra-input emotion-16"
                                             data-part="input"
@@ -19766,7 +19766,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r70:::legend"
+                            aria-labelledby="fieldset:::r73:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19841,7 +19841,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r71:::legend"
+                            aria-labelledby="fieldset:::r74:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19916,7 +19916,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r72:::legend"
+                            aria-labelledby="fieldset:::r75:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19996,7 +19996,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r73:::legend"
+                  aria-labelledby="fieldset:::r76:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -20071,7 +20071,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r74:::legend"
+                  aria-labelledby="fieldset:::r77:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -20103,7 +20103,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r75:::legend"
+                            aria-labelledby="fieldset:::r78:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -20117,7 +20117,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r76:"
+                                id="field:::r79:"
                                 role="group"
                               >
                                 <label
@@ -20126,8 +20126,8 @@ exports[`single fields > optional data controls > does not show optional control
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  for=":r76:"
-                                  id="field:::r76:::label"
+                                  for=":r79:"
+                                  id="field:::r79:::label"
                                 >
                                   test
                                 </label>
@@ -20160,7 +20160,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r77:::legend"
+                  aria-labelledby="fieldset:::r7a:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -20235,7 +20235,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r78:::legend"
+                  aria-labelledby="fieldset:::r7b:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -20258,7 +20258,7 @@ exports[`single fields > optional data controls > does not show optional control
                             data-part="root"
                             data-readonly=""
                             data-scope="field"
-                            id="field:::r79:"
+                            id="field:::r7c:"
                             role="group"
                           >
                             <label
@@ -20267,8 +20267,8 @@ exports[`single fields > optional data controls > does not show optional control
                               data-part="label"
                               data-readonly=""
                               data-scope="field"
-                              for=":r79:"
-                              id="field:::r79:::label"
+                              for=":r7c:"
+                              id="field:::r7c:::label"
                             >
                               optionalObjectWithOneofs
                             </label>
@@ -20283,9 +20283,9 @@ exports[`single fields > optional data controls > does not show optional control
                             >
                               <select
                                 aria-hidden="true"
-                                aria-labelledby="field:::r79:::label"
+                                aria-labelledby="field:::r7c:::label"
                                 disabled=""
-                                id=":r79:"
+                                id=":r7c:"
                                 name="root_optionalObjectWithOneofs__oneof_select"
                                 style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                 tabindex="-1"
@@ -20330,7 +20330,7 @@ exports[`single fields > optional data controls > does not show optional control
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-invalid="false"
-                                    aria-labelledby="field:::r79:::label"
+                                    aria-labelledby="field:::r7c:::label"
                                     aria-required="false"
                                     class="chakra-select__trigger emotion-105"
                                     data-disabled=""
@@ -20388,7 +20388,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                               >
                                 <div
-                                  aria-labelledby="field:::r79:::label"
+                                  aria-labelledby="field:::r7c:::label"
                                   class="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -20503,7 +20503,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7b:::legend"
+                            aria-labelledby="fieldset:::r7e:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -20535,7 +20535,7 @@ exports[`single fields > optional data controls > does not show optional control
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r7c:::legend"
+                                      aria-labelledby="fieldset:::r7f:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -20549,7 +20549,7 @@ exports[`single fields > optional data controls > does not show optional control
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r7d:"
+                                          id="field:::r7g:"
                                           role="group"
                                         >
                                           <label
@@ -20558,8 +20558,8 @@ exports[`single fields > optional data controls > does not show optional control
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            for=":r7d:"
-                                            id="field:::r7d:::label"
+                                            for=":r7g:"
+                                            id="field:::r7g:::label"
                                           >
                                             name
                                           </label>
@@ -20597,7 +20597,7 @@ exports[`single fields > optional data controls > does not show optional control
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7e:::legend"
+                  aria-labelledby="fieldset:::r7h:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -20620,7 +20620,7 @@ exports[`single fields > optional data controls > does not show optional control
                             data-part="root"
                             data-readonly=""
                             data-scope="field"
-                            id="field:::r7f:"
+                            id="field:::r7i:"
                             role="group"
                           >
                             <label
@@ -20629,8 +20629,8 @@ exports[`single fields > optional data controls > does not show optional control
                               data-part="label"
                               data-readonly=""
                               data-scope="field"
-                              for=":r7f:"
-                              id="field:::r7f:::label"
+                              for=":r7i:"
+                              id="field:::r7i:::label"
                             >
                               optionalArrayWithAnyofs
                             </label>
@@ -20645,9 +20645,9 @@ exports[`single fields > optional data controls > does not show optional control
                             >
                               <select
                                 aria-hidden="true"
-                                aria-labelledby="field:::r7f:::label"
+                                aria-labelledby="field:::r7i:::label"
                                 disabled=""
-                                id=":r7f:"
+                                id=":r7i:"
                                 name="root_optionalArrayWithAnyofs__anyof_select"
                                 style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                                 tabindex="-1"
@@ -20692,7 +20692,7 @@ exports[`single fields > optional data controls > does not show optional control
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-invalid="false"
-                                    aria-labelledby="field:::r7f:::label"
+                                    aria-labelledby="field:::r7i:::label"
                                     aria-required="false"
                                     class="chakra-select__trigger emotion-105"
                                     data-disabled=""
@@ -20750,7 +20750,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
                               >
                                 <div
-                                  aria-labelledby="field:::r7f:::label"
+                                  aria-labelledby="field:::r7i:::label"
                                   class="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -20865,7 +20865,7 @@ exports[`single fields > optional data controls > does not show optional control
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7h:::legend"
+                            aria-labelledby="fieldset:::r7k:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21557,7 +21557,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r60:::legend"
+        aria-labelledby="fieldset:::r63:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -21588,7 +21588,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r61:::legend"
+                  aria-labelledby="fieldset:::r64:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -21657,7 +21657,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r62:::legend"
+                            aria-labelledby="fieldset:::r65:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21669,15 +21669,15 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                 class="chakra-field__root emotion-17"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r63:"
+                                id="field:::r66:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-18"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r63:"
-                                  id="field:::r63:::label"
+                                  for=":r66:"
+                                  id="field:::r66:::label"
                                 >
                                   test
                                 </label>
@@ -21702,7 +21702,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r64:::legend"
+                            aria-labelledby="fieldset:::r67:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21772,7 +21772,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r65:::legend"
+                            aria-labelledby="fieldset:::r68:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21803,7 +21803,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r66:::legend"
+                                      aria-labelledby="fieldset:::r69:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -21815,15 +21815,15 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                           class="chakra-field__root emotion-17"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r67:"
+                                          id="field:::r6a:"
                                           role="group"
                                         >
                                           <label
                                             class="chakra-field__label emotion-18"
                                             data-part="label"
                                             data-scope="field"
-                                            for=":r67:"
-                                            id="field:::r67:::label"
+                                            for=":r6a:"
+                                            id="field:::r6a:::label"
                                           >
                                             deepTest
                                           </label>
@@ -21853,7 +21853,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r68:::legend"
+                            aria-labelledby="fieldset:::r6b:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21927,7 +21927,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r69:::legend"
+                            aria-labelledby="fieldset:::r6c:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22001,7 +22001,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6a:::legend"
+                            aria-labelledby="fieldset:::r6d:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22080,7 +22080,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6b:::legend"
+                  aria-labelledby="fieldset:::r6e:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -22156,7 +22156,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r6c:::legend"
+                                  aria-labelledby="fieldset:::r6f:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -22168,7 +22168,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                       class="chakra-field__root emotion-17"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::r6d:"
+                                      id="field:::r6g:"
                                       role="group"
                                     >
                                       <label
@@ -22176,8 +22176,8 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        for=":r6d:"
-                                        id="field:::r6d:::label"
+                                        for=":r6g:"
+                                        id="field:::r6g:::label"
                                       >
                                         nestedArrayOptional-1
                                         <span
@@ -22290,7 +22290,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6e:::legend"
+                  aria-labelledby="fieldset:::r6h:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -22321,7 +22321,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6f:::legend"
+                            aria-labelledby="fieldset:::r6i:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22333,15 +22333,15 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                 class="chakra-field__root emotion-17"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r6g:"
+                                id="field:::r6j:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-18"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r6g:"
-                                  id="field:::r6g:::label"
+                                  for=":r6j:"
+                                  id="field:::r6j:::label"
                                 >
                                   test
                                 </label>
@@ -22371,7 +22371,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6h:::legend"
+                  aria-labelledby="fieldset:::r6k:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -22445,7 +22445,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6i:::legend"
+                  aria-labelledby="fieldset:::r6l:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -22466,7 +22466,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6j:::legend"
+                            aria-labelledby="fieldset:::r6m:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22541,7 +22541,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6k:::legend"
+                  aria-labelledby="fieldset:::r6n:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -22562,7 +22562,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6l:::legend"
+                            aria-labelledby="fieldset:::r6o:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23143,7 +23143,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r7t:::legend"
+        aria-labelledby="fieldset:::r80:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -23175,7 +23175,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7u:::legend"
+                  aria-labelledby="fieldset:::r81:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23207,7 +23207,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7v:::legend"
+                            aria-labelledby="fieldset:::r82:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23221,7 +23221,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r80:"
+                                id="field:::r83:"
                                 role="group"
                               >
                                 <label
@@ -23230,8 +23230,8 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  for=":r80:"
-                                  id="field:::r80:::label"
+                                  for=":r83:"
+                                  id="field:::r83:::label"
                                 >
                                   test
                                 </label>
@@ -23259,7 +23259,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r81:::legend"
+                            aria-labelledby="fieldset:::r84:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23302,7 +23302,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r82:::legend"
+                            aria-labelledby="fieldset:::r85:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23334,7 +23334,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                     class="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r83:::legend"
+                                      aria-labelledby="fieldset:::r86:::legend"
                                       class="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -23348,7 +23348,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r84:"
+                                          id="field:::r87:"
                                           role="group"
                                         >
                                           <label
@@ -23357,8 +23357,8 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            for=":r84:"
-                                            id="field:::r84:::label"
+                                            for=":r87:"
+                                            id="field:::r87:::label"
                                           >
                                             deepTest
                                           </label>
@@ -23391,7 +23391,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r85:::legend"
+                            aria-labelledby="fieldset:::r88:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23466,7 +23466,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r86:::legend"
+                            aria-labelledby="fieldset:::r89:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23511,7 +23511,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r87:::legend"
+                            aria-labelledby="fieldset:::r8a:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23591,7 +23591,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r88:::legend"
+                  aria-labelledby="fieldset:::r8b:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23629,7 +23629,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                 class="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r89:::legend"
+                                  aria-labelledby="fieldset:::r8c:::legend"
                                   class="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -23643,7 +23643,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                       data-part="root"
                                       data-readonly=""
                                       data-scope="field"
-                                      id="field:::r8a:"
+                                      id="field:::r8d:"
                                       role="group"
                                     >
                                       <label
@@ -23653,8 +23653,8 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                         data-readonly=""
                                         data-required=""
                                         data-scope="field"
-                                        for=":r8a:"
-                                        id="field:::r8a:::label"
+                                        for=":r8d:"
+                                        id="field:::r8d:::label"
                                       >
                                         nestedArrayOptional-1
                                         <span
@@ -23772,7 +23772,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8b:::legend"
+                  aria-labelledby="fieldset:::r8e:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23804,7 +23804,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8c:::legend"
+                            aria-labelledby="fieldset:::r8f:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23818,7 +23818,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r8d:"
+                                id="field:::r8g:"
                                 role="group"
                               >
                                 <label
@@ -23827,8 +23827,8 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  for=":r8d:"
-                                  id="field:::r8d:::label"
+                                  for=":r8g:"
+                                  id="field:::r8g:::label"
                                 >
                                   test
                                 </label>
@@ -23861,7 +23861,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8e:::legend"
+                  aria-labelledby="fieldset:::r8h:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23936,7 +23936,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8f:::legend"
+                  aria-labelledby="fieldset:::r8i:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23957,7 +23957,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8g:::legend"
+                            aria-labelledby="fieldset:::r8j:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24005,7 +24005,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8h:::legend"
+                  aria-labelledby="fieldset:::r8k:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24026,7 +24026,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8i:::legend"
+                            aria-labelledby="fieldset:::r8l:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24519,7 +24519,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r5l:::legend"
+        aria-labelledby="fieldset:::r5o:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -24550,7 +24550,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5m:::legend"
+                  aria-labelledby="fieldset:::r5p:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24620,7 +24620,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5n:::legend"
+                  aria-labelledby="fieldset:::r5q:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24694,7 +24694,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5o:::legend"
+                  aria-labelledby="fieldset:::r5r:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24725,7 +24725,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5p:::legend"
+                            aria-labelledby="fieldset:::r5s:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24737,15 +24737,15 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                                 class="chakra-field__root emotion-32"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r5q:"
+                                id="field:::r5t:"
                                 role="group"
                               >
                                 <label
                                   class="chakra-field__label emotion-33"
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r5q:"
-                                  id="field:::r5q:::label"
+                                  for=":r5t:"
+                                  id="field:::r5t:::label"
                                 >
                                   test
                                 </label>
@@ -24775,7 +24775,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5r:::legend"
+                  aria-labelledby="fieldset:::r5u:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24849,7 +24849,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5s:::legend"
+                  aria-labelledby="fieldset:::r5v:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24870,7 +24870,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5t:::legend"
+                            aria-labelledby="fieldset:::r60:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24945,7 +24945,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5u:::legend"
+                  aria-labelledby="fieldset:::r61:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24966,7 +24966,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5v:::legend"
+                            aria-labelledby="fieldset:::r62:::legend"
                             class="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -25378,7 +25378,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r7i:::legend"
+        aria-labelledby="fieldset:::r7l:::legend"
         class="fieldset__root emotion-0"
         data-disabled=""
         data-part="root"
@@ -25412,7 +25412,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7j:::legend"
+                  aria-labelledby="fieldset:::r7m:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25457,7 +25457,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7k:::legend"
+                  aria-labelledby="fieldset:::r7n:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25504,7 +25504,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7l:::legend"
+                  aria-labelledby="fieldset:::r7o:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25538,7 +25538,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           class="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7m:::legend"
+                            aria-labelledby="fieldset:::r7p:::legend"
                             class="fieldset__root emotion-0"
                             data-disabled=""
                             data-part="root"
@@ -25553,7 +25553,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                                 data-disabled=""
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r7n:"
+                                id="field:::r7q:"
                                 role="group"
                               >
                                 <label
@@ -25561,8 +25561,8 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                                   data-disabled=""
                                   data-part="label"
                                   data-scope="field"
-                                  for=":r7n:"
-                                  id="field:::r7n:::label"
+                                  for=":r7q:"
+                                  id="field:::r7q:::label"
                                 >
                                   test
                                 </label>
@@ -25593,7 +25593,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7o:::legend"
+                  aria-labelledby="fieldset:::r7r:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25670,7 +25670,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7p:::legend"
+                  aria-labelledby="fieldset:::r7s:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25693,7 +25693,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           class="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7q:::legend"
+                            aria-labelledby="fieldset:::r7t:::legend"
                             class="fieldset__root emotion-0"
                             data-disabled=""
                             data-part="root"
@@ -25743,7 +25743,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 class="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7r:::legend"
+                  aria-labelledby="fieldset:::r7u:::legend"
                   class="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -25766,7 +25766,7 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           class="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7s:::legend"
+                            aria-labelledby="fieldset:::r7v:::legend"
                             class="fieldset__root emotion-0"
                             data-disabled=""
                             data-part="root"
@@ -26344,7 +26344,7 @@ exports[`single fields > radio field 1`] = `
       class="rjsf-field rjsf-field-boolean"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3n:::legend"
+        aria-labelledby="fieldset:::r3q:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -26356,19 +26356,19 @@ exports[`single fields > radio field 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r3o:"
+            id="field:::r3r:"
             role="group"
           >
             <div
               aria-describedby="root__error root__description root__help"
-              aria-labelledby="fieldset:::r3n:::legend"
+              aria-labelledby="fieldset:::r3q:::legend"
               aria-orientation="vertical"
               class="chakra-radio-group__root"
               data-orientation="vertical"
               data-part="root"
               data-scope="radio-group"
               dir="ltr"
-              id="radio-group::r3p:"
+              id="radio-group::r3s:"
               role="radiogroup"
               style="position: relative;"
             >
@@ -26383,13 +26383,13 @@ exports[`single fields > radio field 1`] = `
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r3p::radio:input:0"
+                  for="radio-group::r3s::radio:input:0"
                   id="root-0"
                 >
                   <input
-                    aria-labelledby="radio-group::r3p::radio:label:0"
-                    data-ownedby="radio-group::r3p:"
-                    id="radio-group::r3p::radio:input:0"
+                    aria-labelledby="radio-group::r3s::radio:label:0"
+                    data-ownedby="radio-group::r3s:"
+                    id="radio-group::r3s::radio:input:0"
                     name="root"
                     style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -26404,7 +26404,7 @@ exports[`single fields > radio field 1`] = `
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r3p::radio:control:0"
+                    id="radio-group::r3s::radio:control:0"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -26414,7 +26414,7 @@ exports[`single fields > radio field 1`] = `
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r3p::radio:label:0"
+                    id="radio-group::r3s::radio:label:0"
                   >
                     Yes
                   </span>
@@ -26427,13 +26427,13 @@ exports[`single fields > radio field 1`] = `
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  for="radio-group::r3p::radio:input:1"
+                  for="radio-group::r3s::radio:input:1"
                   id="root-1"
                 >
                   <input
-                    aria-labelledby="radio-group::r3p::radio:label:1"
-                    data-ownedby="radio-group::r3p:"
-                    id="radio-group::r3p::radio:input:1"
+                    aria-labelledby="radio-group::r3s::radio:label:1"
+                    data-ownedby="radio-group::r3s:"
+                    id="radio-group::r3s::radio:input:1"
                     name="root"
                     style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
                     type="radio"
@@ -26448,7 +26448,7 @@ exports[`single fields > radio field 1`] = `
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r3p::radio:control:1"
+                    id="radio-group::r3s::radio:control:1"
                   />
                   <span
                     class="chakra-radio-group__itemText"
@@ -26458,7 +26458,7 @@ exports[`single fields > radio field 1`] = `
                     data-ssr=""
                     data-state="unchecked"
                     dir="ltr"
-                    id="radio-group::r3p::radio:label:1"
+                    id="radio-group::r3s::radio:label:1"
                   >
                     No
                   </span>
@@ -27159,7 +27159,7 @@ exports[`single fields > schema examples 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4h:::legend"
+        aria-labelledby="fieldset:::r4k:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -27171,7 +27171,7 @@ exports[`single fields > schema examples 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r4i:"
+            id="field:::r4l:"
             role="group"
           >
             <input
@@ -27424,7 +27424,7 @@ exports[`single fields > schema examples with mixed types (string examples and n
       class="rjsf-field rjsf-field-integer"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4j:::legend"
+        aria-labelledby="fieldset:::r4m:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -27436,7 +27436,7 @@ exports[`single fields > schema examples with mixed types (string examples and n
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r4k:"
+            id="field:::r4n:"
             role="group"
           >
             <input
@@ -35563,6 +35563,667 @@ exports[`single fields > select widget with selected oneOf option description 1`
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description and hidden label 1`] = `
+<DocumentFragment>
+  @layer recipes {
+  .emotion-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+  }
+
+  .emotion-0>:not(style, [hidden])~:not(style, [hidden]) {
+    --space-y-reverse: 0;
+    margin-top: calc(var(--chakra-spacing-4) * calc(1 - var(--space-y-reverse)));
+    margin-bottom: calc(var(--chakra-spacing-4) * var(--space-y-reverse));
+  }
+}
+
+@layer recipes {
+  .emotion-1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+    gap: var(--chakra-spacing-4);
+  }
+}
+
+.emotion-2 {
+  margin-bottom: var(--chakra-spacing-1);
+  position: relative;
+}
+
+@layer recipes {
+  .emotion-2 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    width: 100%;
+    position: relative;
+    gap: var(--chakra-spacing-1\\.5);
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+@layer recipes {
+  .emotion-3 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    gap: var(--chakra-spacing-1\\.5);
+    width: var(--chakra-sizes-full);
+    --select-trigger-height: var(--chakra-sizes-10);
+    --select-trigger-padding-x: var(--chakra-spacing-3);
+  }
+}
+
+@layer recipes {
+  .emotion-4 {
+    position: relative;
+  }
+}
+
+@layer recipes {
+  .emotion-6 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: justify;
+    -webkit-justify-content: space-between;
+    justify-content: space-between;
+    width: var(--chakra-sizes-full);
+    min-height: var(--select-trigger-height);
+    --input-height: var(--select-trigger-height);
+    padding-inline: var(--select-trigger-padding-x);
+    border-radius: var(--chakra-radii-l2);
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    text-align: start;
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+    gap: var(--chakra-spacing-2);
+    background: var(--chakra-colors-transparent);
+    --bg-currentcolor: var(--chakra-colors-transparent);
+    border-width: 1px;
+    border-color: var(--chakra-colors-border);
+  }
+
+  .emotion-6:is(:focus-visible, [data-focus-visible]) {
+    outline-offset: 0px;
+    outline-width: var(--focus-ring-width, 1px);
+    outline-color: var(--focus-ring-color);
+    outline-style: var(--focus-ring-style, solid);
+    border-color: var(--focus-ring-color);
+  }
+
+  .emotion-6:is(:placeholder-shown, [data-placeholder-shown]) {
+    --mix-color: color-mix(in srgb, var(--chakra-colors-fg-muted) 80%, transparent);
+    color: var(--mix-color, var(--chakra-colors-fg-muted));
+  }
+
+  .emotion-6:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-6:is([data-invalid], [aria-invalid=true], [data-state=invalid]) {
+    border-color: var(--chakra-colors-border-error);
+  }
+
+  .emotion-6:is([aria-expanded=true], [data-expanded], [data-state=expanded]) {
+    border-color: var(--chakra-colors-border-emphasized);
+  }
+}
+
+@layer recipes {
+  .emotion-7 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    text-wrap: wrap;
+    max-width: 80%;
+  }
+}
+
+@layer recipes {
+  .emotion-8 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    gap: var(--chakra-spacing-1);
+    position: absolute;
+    inset-inline-end: 0;
+    top: 0;
+    bottom: 0;
+    padding-inline: var(--select-trigger-padding-x);
+    pointer-events: none;
+  }
+}
+
+@layer recipes {
+  .emotion-9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    color: var(--chakra-colors-fg-muted);
+  }
+
+  .emotion-9:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    color: var(--chakra-colors-fg-subtle);
+  }
+
+  .emotion-9:is([data-invalid], [aria-invalid=true], [data-state=invalid]) {
+    color: var(--chakra-colors-fg-error);
+  }
+
+  .emotion-9 :where(svg) {
+    width: var(--chakra-sizes-4);
+    height: var(--chakra-sizes-4);
+  }
+}
+
+.emotion-10 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.emotion-11 {
+  min-width: 100%!important;
+  z-index: 2!important;
+  top: calc(100% + 5px)!important;
+}
+
+@layer recipes {
+  .emotion-12 {
+    background: var(--chakra-colors-bg-panel);
+    --bg-currentcolor: var(--chakra-colors-bg-panel);
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    --select-z-index: var(--chakra-z-index-popover);
+    z-index: calc(var(--select-z-index) + var(--layer-index, 0));
+    border-radius: var(--chakra-radii-l2);
+    outline: 0;
+    max-height: var(--chakra-sizes-96);
+    overflow-y: auto;
+    box-shadow: var(--chakra-shadows-md);
+    padding: var(--chakra-spacing-1);
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+  }
+
+  .emotion-12:is([open], [data-open], [data-state=open]) {
+    transform-origin: var(--transform-origin);
+    -webkit-animation-duration: var(--chakra-durations-fast);
+    animation-duration: var(--chakra-durations-fast);
+  }
+
+  .emotion-12:is([open], [data-open], [data-state=open])[data-placement^=top] {
+    -webkit-animation-name: slide-from-bottom,fade-in;
+    animation-name: slide-from-bottom,fade-in;
+  }
+
+  .emotion-12:is([open], [data-open], [data-state=open])[data-placement^=bottom] {
+    -webkit-animation-name: slide-from-top,fade-in;
+    animation-name: slide-from-top,fade-in;
+  }
+
+  .emotion-12:is([open], [data-open], [data-state=open])[data-placement^=left] {
+    -webkit-animation-name: slide-from-right,fade-in;
+    animation-name: slide-from-right,fade-in;
+  }
+
+  .emotion-12:is([open], [data-open], [data-state=open])[data-placement^=right] {
+    -webkit-animation-name: slide-from-left,fade-in;
+    animation-name: slide-from-left,fade-in;
+  }
+
+  .emotion-12:is([closed], [data-closed], [data-state=closed]) {
+    transform-origin: var(--transform-origin);
+    -webkit-animation-duration: var(--chakra-durations-fastest);
+    animation-duration: var(--chakra-durations-fastest);
+  }
+
+  .emotion-12:is([closed], [data-closed], [data-state=closed])[data-placement^=top] {
+    -webkit-animation-name: slide-to-bottom,fade-out;
+    animation-name: slide-to-bottom,fade-out;
+  }
+
+  .emotion-12:is([closed], [data-closed], [data-state=closed])[data-placement^=bottom] {
+    -webkit-animation-name: slide-to-top,fade-out;
+    animation-name: slide-to-top,fade-out;
+  }
+
+  .emotion-12:is([closed], [data-closed], [data-state=closed])[data-placement^=left] {
+    -webkit-animation-name: slide-to-right,fade-out;
+    animation-name: slide-to-right,fade-out;
+  }
+
+  .emotion-12:is([closed], [data-closed], [data-state=closed])[data-placement^=right] {
+    -webkit-animation-name: slide-to-left,fade-out;
+    animation-name: slide-to-left,fade-out;
+  }
+}
+
+@layer recipes {
+  .emotion-13 {
+    position: relative;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    gap: var(--chakra-spacing-2);
+    cursor: var(--chakra-cursor-option);
+    -webkit-box-pack: justify;
+    -webkit-justify-content: space-between;
+    justify-content: space-between;
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+    text-align: start;
+    border-radius: var(--chakra-radii-l1);
+    padding-block: var(--chakra-spacing-1\\.5);
+    padding-inline: var(--chakra-spacing-2);
+  }
+
+  .emotion-13[data-highlighted] {
+    --mix-background: color-mix(in srgb, var(--chakra-colors-bg-emphasized) 60%, transparent);
+    background: var(--mix-background, var(--chakra-colors-bg-emphasized));
+    --bg-currentcolor: var(--mix-background, var(--chakra-colors-bg-emphasized));
+  }
+
+  .emotion-13:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+
+  .emotion-13 :where(svg) {
+    width: var(--chakra-sizes-4);
+    height: var(--chakra-sizes-4);
+  }
+}
+
+@layer recipes {
+  .emotion-14 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+  }
+}
+
+.emotion-19 {
+  margin-top: var(--chakra-spacing-3);
+}
+
+@layer recipes {
+  .emotion-20 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    position: relative;
+    border-radius: var(--chakra-radii-l2);
+    white-space: nowrap;
+    vertical-align: middle;
+    border-width: 1px;
+    border-color: var(--chakra-colors-transparent);
+    cursor: var(--chakra-cursor-button);
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    outline: 0;
+    line-height: 1.25rem;
+    isolation: isolate;
+    font-weight: var(--chakra-font-weights-medium);
+    transition-property: background-color,border-color,color,fill,stroke,opacity,box-shadow,translate,transform;
+    transition-duration: var(--chakra-durations-moderate);
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    height: var(--chakra-sizes-10);
+    min-width: var(--chakra-sizes-10);
+    font-size: var(--chakra-font-sizes-sm);
+    padding-inline: var(--chakra-spacing-4);
+    gap: var(--chakra-spacing-2);
+    background: var(--chakra-colors-color-palette-solid);
+    --bg-currentcolor: var(--chakra-colors-color-palette-solid);
+    color: var(--chakra-colors-color-palette-contrast);
+  }
+
+  .emotion-20:is(:focus-visible, [data-focus-visible]) {
+    outline-width: var(--focus-ring-width, 2px);
+    outline-offset: var(--focus-ring-offset, 2px);
+    outline-style: var(--focus-ring-style, solid);
+    outline-color: var(--focus-ring-color);
+  }
+
+  .emotion-20:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-20 :where(svg) {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    width: var(--chakra-sizes-5);
+    height: var(--chakra-sizes-5);
+  }
+
+  .emotion-20:is([aria-expanded=true], [data-expanded], [data-state=expanded]) {
+    --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+    background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+  }
+
+  @media (hover: hover) {
+    .emotion-20:is(:hover, [data-hover]):not(:disabled, [data-disabled]) {
+      --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+      background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+      --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    }
+  }
+}
+
+<form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <fieldset
+        aria-labelledby="fieldset:::r3h:::legend"
+        class="fieldset__root emotion-0"
+        data-part="root"
+        data-scope="fieldset"
+      >
+        <div
+          class="fieldset__content emotion-1"
+        >
+          <div
+            class="chakra-field__root emotion-2"
+            data-part="root"
+            data-scope="field"
+            id="field:::r3i:"
+            role="group"
+          >
+            <div
+              aria-describedby="root__error root__description root__help"
+              class="chakra-select__root emotion-3"
+              data-part="root"
+              data-scope="select"
+              dir="ltr"
+              id="select:root"
+            >
+              <select
+                aria-hidden="true"
+                aria-labelledby="field:::r3i:::label"
+                id=":r3i:"
+                name="root"
+                style="border: 0px; clip: rect(0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+                tabindex="-1"
+              >
+                <option
+                  selected=""
+                  value="0"
+                >
+                  Foo
+                </option>
+                <option
+                  value="1"
+                >
+                  Bar
+                </option>
+              </select>
+              <div
+                class="chakra-select__control emotion-4"
+                data-part="control"
+                data-scope="select"
+                data-state="closed"
+                dir="ltr"
+                id="select:root:control"
+              >
+                <div
+                  class="chakra-select__control emotion-4"
+                  data-part="control"
+                  data-scope="select"
+                  data-state="closed"
+                  dir="ltr"
+                  id="select:root:control"
+                >
+                  <button
+                    aria-controls="select:root:content"
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-invalid="false"
+                    aria-labelledby="field:::r3i:::label"
+                    aria-required="false"
+                    class="chakra-select__trigger emotion-6"
+                    data-part="trigger"
+                    data-scope="select"
+                    data-state="closed"
+                    dir="ltr"
+                    id="select:root:trigger"
+                    role="combobox"
+                    type="button"
+                  >
+                    <span
+                      class="chakra-select__valueText emotion-7"
+                      data-part="value-text"
+                      data-scope="select"
+                      dir="ltr"
+                    >
+                      Foo
+                    </span>
+                  </button>
+                  <div
+                    class="chakra-select__indicatorGroup emotion-8"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="chakra-select__indicator emotion-9"
+                      data-part="indicator"
+                      data-scope="select"
+                      data-state="closed"
+                      dir="ltr"
+                    >
+                      <svg
+                        class="emotion-10"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="m6 9 6 6 6-6"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="chakra-select__positioner emotion-11"
+                data-part="positioner"
+                data-scope="select"
+                dir="ltr"
+                id="select:root:positioner"
+                style="position: absolute; isolation: isolate; width: var(--reference-width); pointer-events: none; top: 0px; left: 0px; transform: translate3d(0, -100vh, 0); z-index: var(--z-index);"
+              >
+                <div
+                  aria-labelledby="field:::r3i:::label"
+                  class="chakra-select__content emotion-12"
+                  data-part="content"
+                  data-scope="select"
+                  data-state="closed"
+                  dir="ltr"
+                  hidden=""
+                  id="select:root:content"
+                  role="listbox"
+                  tabindex="0"
+                >
+                  <div
+                    aria-selected="true"
+                    class="chakra-select__item emotion-13"
+                    data-part="item"
+                    data-scope="select"
+                    data-state="checked"
+                    data-value="0"
+                    dir="ltr"
+                    id="select:root:option:0"
+                    role="option"
+                  >
+                    Foo
+                    <div
+                      aria-hidden="true"
+                      class="chakra-select__itemIndicator emotion-14"
+                      data-part="item-indicator"
+                      data-scope="select"
+                      data-state="checked"
+                    >
+                      <svg
+                        class="emotion-10"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 6 9 17l-5-5"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    aria-selected="false"
+                    class="chakra-select__item emotion-13"
+                    data-part="item"
+                    data-scope="select"
+                    data-state="unchecked"
+                    data-value="1"
+                    dir="ltr"
+                    id="select:root:option:1"
+                    role="option"
+                  >
+                    Bar
+                    <div
+                      aria-hidden="true"
+                      class="chakra-select__itemIndicator emotion-14"
+                      data-part="item-indicator"
+                      data-scope="select"
+                      data-state="unchecked"
+                      hidden=""
+                    >
+                      <svg
+                        class="emotion-10"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 6 9 17l-5-5"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div
+      class="emotion-19"
+    >
+      <button
+        class="chakra-button emotion-20"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+  <span
+    hidden=""
+  />
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   @layer recipes {
@@ -35845,7 +36506,7 @@ exports[`single fields > slider field 1`] = `
       class="rjsf-field rjsf-field-integer"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3q:::legend"
+        aria-labelledby="fieldset:::r3t:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -35857,7 +36518,7 @@ exports[`single fields > slider field 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r3r:"
+            id="field:::r3u:"
             role="group"
           >
             <div
@@ -39594,7 +40255,7 @@ exports[`single fields > title field 1`] = `
       class="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4a:::legend"
+        aria-labelledby="fieldset:::r4d:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -39625,7 +40286,7 @@ exports[`single fields > title field 1`] = `
                 class="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4b:::legend"
+                  aria-labelledby="fieldset:::r4e:::legend"
                   class="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -39637,15 +40298,15 @@ exports[`single fields > title field 1`] = `
                       class="chakra-field__root emotion-8"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r4c:"
+                      id="field:::r4f:"
                       role="group"
                     >
                       <label
                         class="chakra-field__label emotion-9"
                         data-part="label"
                         data-scope="field"
-                        for=":r4c:"
-                        id="field:::r4c:::label"
+                        for=":r4f:"
+                        id="field:::r4f:::label"
                       >
                         Titre 2
                       </label>
@@ -40521,7 +41182,7 @@ exports[`single fields > using custom tagName 1`] = `
       class="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r4f:::legend"
+        aria-labelledby="fieldset:::r4i:::legend"
         class="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -40533,7 +41194,7 @@ exports[`single fields > using custom tagName 1`] = `
             class="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r4g:"
+            id="field:::r4j:"
             role="group"
           >
             <input

--- a/packages/core/src/components/widgets/SelectWidget.tsx
+++ b/packages/core/src/components/widgets/SelectWidget.tsx
@@ -78,6 +78,14 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
 
   return (
     <>
+      <SelectedOptionDescription
+        id={id}
+        multiple={multiple}
+        options={options}
+        registry={registry}
+        uiSchema={uiSchema}
+        value={value}
+      />
       {/* oxlint-disable-next-line jsx-a11y/no-autofocus */}
       <select
         id={id}
@@ -108,14 +116,6 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
             );
           })}
       </select>
-      <SelectedOptionDescription
-        id={id}
-        multiple={multiple}
-        options={options}
-        registry={registry}
-        uiSchema={uiSchema}
-        value={value}
-      />
     </>
   );
 }

--- a/packages/core/src/components/widgets/SelectWidget.tsx
+++ b/packages/core/src/components/widgets/SelectWidget.tsx
@@ -8,6 +8,7 @@ import {
   enumOptionValueEncoder,
   getOptionValueFormat,
   logUnsupportedDefaultForEnum,
+  SelectedOptionDescription,
 } from '@rjsf/utils';
 
 function getValue(event: SyntheticEvent<HTMLSelectElement>, multiple: boolean) {
@@ -40,6 +41,8 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
   onFocus,
   placeholder,
   htmlName,
+  registry,
+  uiSchema,
 }: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled, emptyValue: optEmptyVal } = options;
   const emptyValue = multiple ? [] : '';
@@ -74,36 +77,46 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
   logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, multiple);
 
   return (
-    // oxlint-disable-next-line jsx-a11y/no-autofocus
-    <select
-      id={id}
-      name={htmlName || id}
-      multiple={multiple}
-      className='form-control'
-      value={selectValue}
-      required={required}
-      disabled={disabled || readonly}
-      autoFocus={autofocus}
-      onBlur={handleBlur}
-      onFocus={handleFocus}
-      onChange={handleChange}
-      aria-describedby={ariaDescribedByIds(id)}
-    >
-      {showPlaceholderOption && <option value=''>{placeholder}</option>}
-      {Array.isArray(enumOptions) &&
-        enumOptions.map(({ value: enumValue, label: enumLabel }, i) => {
-          const isDisabled = enumDisabled && enumDisabled.includes(enumValue);
-          return (
-            <option
-              key={String(enumValue)}
-              value={enumOptionValueEncoder(enumValue, i, optionValueFormat)}
-              disabled={isDisabled}
-            >
-              {enumLabel}
-            </option>
-          );
-        })}
-    </select>
+    <>
+      {/* oxlint-disable-next-line jsx-a11y/no-autofocus */}
+      <select
+        id={id}
+        name={htmlName || id}
+        multiple={multiple}
+        className='form-control'
+        value={selectValue}
+        required={required}
+        disabled={disabled || readonly}
+        autoFocus={autofocus}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
+        onChange={handleChange}
+        aria-describedby={ariaDescribedByIds(id)}
+      >
+        {showPlaceholderOption && <option value=''>{placeholder}</option>}
+        {Array.isArray(enumOptions) &&
+          enumOptions.map(({ value: enumValue, label: enumLabel }, i) => {
+            const isDisabled = enumDisabled && enumDisabled.includes(enumValue);
+            return (
+              <option
+                key={String(enumValue)}
+                value={enumOptionValueEncoder(enumValue, i, optionValueFormat)}
+                disabled={isDisabled}
+              >
+                {enumLabel}
+              </option>
+            );
+          })}
+      </select>
+      <SelectedOptionDescription
+        id={id}
+        multiple={multiple}
+        options={options}
+        registry={registry}
+        uiSchema={uiSchema}
+        value={value}
+      />
+    </>
   );
 }
 

--- a/packages/core/test/StringField.test.tsx
+++ b/packages/core/test/StringField.test.tsx
@@ -416,6 +416,28 @@ describe('StringField', () => {
   });
 
   describe('SelectWidget', () => {
+    it('renders the selected oneOf option description', async () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: 'string',
+          oneOf: [
+            { const: 'foo', title: 'Foo', description: 'Foo description' },
+            { const: 'bar', title: 'Bar', description: 'Bar description' },
+          ],
+        },
+        formData: 'foo',
+      });
+
+      expect(node).toHaveTextContent('Foo description');
+      expect(node).not.toHaveTextContent('Bar description');
+
+      const select = node.querySelector<HTMLSelectElement>('select')!;
+      await user.selectOptions(select, select.options[2]);
+
+      expect(node).not.toHaveTextContent('Foo description');
+      expect(node).toHaveTextContent('Bar description');
+    });
+
     it('should render a string field', () => {
       const { node } = createFormComponent({
         schema: {

--- a/packages/core/test/__snapshots__/FormSnap.test.tsx.snap
+++ b/packages/core/test/__snapshots__/FormSnap.test.tsx.snap
@@ -6301,6 +6301,47 @@ exports[`single fields > select widget with selected oneOf option description 1`
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description and hidden label 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="form-group rjsf-field rjsf-field-string"
+    >
+      <select
+        aria-describedby="root__error root__description root__help"
+        class="form-control"
+        id="root"
+        name="root"
+      >
+        <option
+          value=""
+        />
+        <option
+          value="0"
+        >
+          Foo
+        </option>
+        <option
+          value="1"
+        >
+          Bar
+        </option>
+      </select>
+    </div>
+    <div>
+      <button
+        class="btn btn-info "
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <form

--- a/packages/core/test/__snapshots__/FormSnap.test.tsx.snap
+++ b/packages/core/test/__snapshots__/FormSnap.test.tsx.snap
@@ -6254,6 +6254,53 @@ exports[`single fields > select widget with description in schema and FieldTempl
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="form-group rjsf-field rjsf-field-string"
+    >
+      <div
+        class="field-description"
+        id="root__description"
+      >
+        Foo description
+      </div>
+      <select
+        aria-describedby="root__error root__description root__help"
+        class="form-control"
+        id="root"
+        name="root"
+      >
+        <option
+          value=""
+        />
+        <option
+          value="0"
+        >
+          Foo
+        </option>
+        <option
+          value="1"
+        >
+          Bar
+        </option>
+      </select>
+    </div>
+    <div>
+      <button
+        class="btn btn-info "
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <form

--- a/packages/daisyui/src/widgets/SelectWidget/SelectWidget.tsx
+++ b/packages/daisyui/src/widgets/SelectWidget/SelectWidget.tsx
@@ -7,6 +7,7 @@ import {
   enumOptionValueEncoder,
   getOptionValueFormat,
   logUnsupportedDefaultForEnum,
+  SelectedOptionDescription,
 } from '@rjsf/utils';
 
 /** The `SelectWidget` component renders a select input with DaisyUI styling
@@ -38,6 +39,8 @@ export default function SelectWidget<
   onChange,
   onBlur,
   onFocus,
+  registry,
+  uiSchema,
 }: WidgetProps<T, S, F>) {
   const { enumOptions, emptyValue: optEmptyVal } = options;
   const optionValueFormat = getOptionValueFormat(options);
@@ -178,6 +181,14 @@ export default function SelectWidget<
           })}
         </ul>
       </div>
+      <SelectedOptionDescription
+        id={id}
+        multiple={multiple}
+        options={options}
+        registry={registry}
+        uiSchema={uiSchema}
+        value={value}
+      />
     </div>
   );
 }

--- a/packages/daisyui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/daisyui/test/__snapshots__/Form.test.tsx.snap
@@ -12780,6 +12780,115 @@ exports[`single fields > select widget with description in schema and FieldTempl
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="flex-grow rjsf-field rjsf-field-string"
+    >
+      <div
+        class="field-template mb-3 rjsf-field rjsf-field-string"
+      >
+        <label
+          class="label"
+          for="root"
+        >
+          <span
+            class="label-text font-medium"
+          />
+        </label>
+        <div
+          class="form-control w-full"
+        >
+          <div
+            class="dropdown w-full"
+          >
+            <div
+              class="btn btn-outline w-full text-left flex justify-between items-center "
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="truncate"
+              >
+                Foo
+              </span>
+              <span
+                class="ml-2"
+              >
+                ▼
+              </span>
+            </div>
+            <ul
+              class="dropdown-content z-[1] bg-base-100 w-full max-h-60 overflow-auto rounded-box shadow-lg"
+              role="listbox"
+            >
+              <li
+                aria-selected="true"
+                class="px-4 py-2 hover:bg-base-200 cursor-pointer bg-primary/10"
+                data-value="0"
+                role="option"
+                tabindex="0"
+              >
+                <div
+                  class="flex items-center gap-2"
+                >
+                  <span>
+                    Foo
+                  </span>
+                </div>
+              </li>
+              <li
+                aria-selected="false"
+                class="px-4 py-2 hover:bg-base-200 cursor-pointer "
+                data-value="1"
+                role="option"
+                tabindex="0"
+              >
+                <div
+                  class="flex items-center gap-2"
+                >
+                  <span>
+                    Bar
+                  </span>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div
+            class="description-field my-4"
+            id="root__description"
+          >
+            <div
+              class="text-sm text-base-content/80"
+            >
+              Foo description
+            </div>
+          </div>
+        </div>
+        <div
+          class="rjsf-field-error-template text-red-600"
+        >
+          <ul
+            class="list-disc list-inside"
+          />
+        </div>
+      </div>
+    </div>
+    <div>
+      <button
+        class="btn btn-primary btn-primary-content "
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <form

--- a/packages/daisyui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/daisyui/test/__snapshots__/Form.test.tsx.snap
@@ -12889,6 +12889,97 @@ exports[`single fields > select widget with selected oneOf option description 1`
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description and hidden label 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="flex-grow rjsf-field rjsf-field-string"
+    >
+      <div
+        class="field-template mb-3 rjsf-field rjsf-field-string"
+      >
+        <div
+          class="form-control w-full"
+        >
+          <div
+            class="dropdown w-full"
+          >
+            <div
+              class="btn btn-outline w-full text-left flex justify-between items-center "
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="truncate"
+              >
+                Foo
+              </span>
+              <span
+                class="ml-2"
+              >
+                ▼
+              </span>
+            </div>
+            <ul
+              class="dropdown-content z-[1] bg-base-100 w-full max-h-60 overflow-auto rounded-box shadow-lg"
+              role="listbox"
+            >
+              <li
+                aria-selected="true"
+                class="px-4 py-2 hover:bg-base-200 cursor-pointer bg-primary/10"
+                data-value="0"
+                role="option"
+                tabindex="0"
+              >
+                <div
+                  class="flex items-center gap-2"
+                >
+                  <span>
+                    Foo
+                  </span>
+                </div>
+              </li>
+              <li
+                aria-selected="false"
+                class="px-4 py-2 hover:bg-base-200 cursor-pointer "
+                data-value="1"
+                role="option"
+                tabindex="0"
+              >
+                <div
+                  class="flex items-center gap-2"
+                >
+                  <span>
+                    Bar
+                  </span>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="rjsf-field-error-template text-red-600"
+        >
+          <ul
+            class="list-disc list-inside"
+          />
+        </div>
+      </div>
+    </div>
+    <div>
+      <button
+        class="btn btn-primary btn-primary-content "
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <form

--- a/packages/fluentui-rc/src/SelectWidget/SelectWidget.tsx
+++ b/packages/fluentui-rc/src/SelectWidget/SelectWidget.tsx
@@ -9,6 +9,7 @@ import {
   getOptionValueFormat,
   labelValue,
   logUnsupportedDefaultForEnum,
+  SelectedOptionDescription,
 } from '@rjsf/utils';
 
 function getValue(data: OptionOnSelectData, multiple: boolean) {
@@ -41,6 +42,8 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
   onFocus,
   schema,
   placeholder,
+  registry,
+  uiSchema,
 }: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled, emptyValue: optEmptyVal } = options;
   const optionValueFormat = getOptionValueFormat(options);
@@ -102,6 +105,14 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
             );
           })}
       </Dropdown>
+      <SelectedOptionDescription
+        id={id}
+        multiple={multiple}
+        options={options}
+        registry={registry}
+        uiSchema={uiSchema}
+        value={value}
+      />
     </Field>
   );
 }

--- a/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
@@ -1298,8 +1298,8 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                 >
                   <label
                     class="fui-Label fui-Field__label ___uxsood0_w9q9lw0 fk6fouc f19n0e5 fkhj508 f1i3iumi f6nezus f1iqmcbn fclwglc fywfov9 fyacil5"
-                    for="field-r9r__control"
-                    id="field-r9r__label"
+                    for="field-r9u__control"
+                    id="field-r9u__label"
                   >
                     color
                   </label>
@@ -1309,7 +1309,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                     <button
                       aria-describedby="root_color__error root_color__description root_color__help"
                       aria-expanded="false"
-                      aria-labelledby="field-r9r__label"
+                      aria-labelledby="field-r9u__label"
                       class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                       id="root_color"
                       name="root[color]"
@@ -2651,8 +2651,8 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                 >
                   <label
                     class="fui-Label fui-Field__label ___uxsood0_w9q9lw0 fk6fouc f19n0e5 fkhj508 f1i3iumi f6nezus f1iqmcbn fclwglc fywfov9 fyacil5"
-                    for="field-rbb__control"
-                    id="field-rbb__label"
+                    for="field-rbe__control"
+                    id="field-rbe__label"
                   >
                     color
                   </label>
@@ -2662,7 +2662,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                     <button
                       aria-describedby="root_color__error root_color__description root_color__help"
                       aria-expanded="false"
-                      aria-labelledby="field-rbb__label"
+                      aria-labelledby="field-rbe__label"
                       class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                       id="root_color"
                       name="root.color"
@@ -4983,8 +4983,8 @@ exports[`single fields > optional data controls > does not show optional control
                     >
                       <label
                         class="fui-Label fui-Field__label ___uxsood0_w9q9lw0 fk6fouc f19n0e5 fkhj508 f1i3iumi f6nezus f1iqmcbn fclwglc fywfov9 fyacil5"
-                        for="field-r4e__control"
-                        id="field-r4e__label"
+                        for="field-r4h__control"
+                        id="field-r4h__label"
                       >
                         optionalObjectWithOneofs
                       </label>
@@ -4994,7 +4994,7 @@ exports[`single fields > optional data controls > does not show optional control
                         <button
                           aria-describedby="root_optionalObjectWithOneofs__oneof_select__error root_optionalObjectWithOneofs__oneof_select__description root_optionalObjectWithOneofs__oneof_select__help"
                           aria-expanded="false"
-                          aria-labelledby="field-r4e__label"
+                          aria-labelledby="field-r4h__label"
                           class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                           id="root_optionalObjectWithOneofs__oneof_select"
                           name="root_optionalObjectWithOneofs__oneof_select"
@@ -5130,8 +5130,8 @@ exports[`single fields > optional data controls > does not show optional control
                     >
                       <label
                         class="fui-Label fui-Field__label ___uxsood0_w9q9lw0 fk6fouc f19n0e5 fkhj508 f1i3iumi f6nezus f1iqmcbn fclwglc fywfov9 fyacil5"
-                        for="field-r4k__control"
-                        id="field-r4k__label"
+                        for="field-r4n__control"
+                        id="field-r4n__label"
                       >
                         optionalArrayWithAnyofs
                       </label>
@@ -5141,7 +5141,7 @@ exports[`single fields > optional data controls > does not show optional control
                         <button
                           aria-describedby="root_optionalArrayWithAnyofs__anyof_select__error root_optionalArrayWithAnyofs__anyof_select__description root_optionalArrayWithAnyofs__anyof_select__help"
                           aria-expanded="false"
-                          aria-labelledby="field-r4k__label"
+                          aria-labelledby="field-r4n__label"
                           class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                           id="root_optionalArrayWithAnyofs__anyof_select"
                           name="root_optionalArrayWithAnyofs__anyof_select"
@@ -5899,8 +5899,8 @@ exports[`single fields > optional data controls > does not show optional control
                     >
                       <label
                         class="fui-Label fui-Field__label ___uxsood0_w9q9lw0 fk6fouc f19n0e5 fkhj508 f1i3iumi f6nezus f1iqmcbn fclwglc fywfov9 fyacil5"
-                        for="field-r70__control"
-                        id="field-r70__label"
+                        for="field-r73__control"
+                        id="field-r73__label"
                       >
                         optionalObjectWithOneofs
                       </label>
@@ -5910,7 +5910,7 @@ exports[`single fields > optional data controls > does not show optional control
                         <button
                           aria-describedby="root_optionalObjectWithOneofs__oneof_select__error root_optionalObjectWithOneofs__oneof_select__description root_optionalObjectWithOneofs__oneof_select__help"
                           aria-expanded="false"
-                          aria-labelledby="field-r70__label"
+                          aria-labelledby="field-r73__label"
                           class="fui-Dropdown__button ___b67tb00_4t2umz0 f122n59 f1c21dwh f3bhgqh f1ewtqcl f1s2aq7o f14mj54c fdrzuqr f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                           disabled=""
                           id="root_optionalObjectWithOneofs__oneof_select"
@@ -6046,8 +6046,8 @@ exports[`single fields > optional data controls > does not show optional control
                     >
                       <label
                         class="fui-Label fui-Field__label ___uxsood0_w9q9lw0 fk6fouc f19n0e5 fkhj508 f1i3iumi f6nezus f1iqmcbn fclwglc fywfov9 fyacil5"
-                        for="field-r76__control"
-                        id="field-r76__label"
+                        for="field-r79__control"
+                        id="field-r79__label"
                       >
                         optionalArrayWithAnyofs
                       </label>
@@ -6057,7 +6057,7 @@ exports[`single fields > optional data controls > does not show optional control
                         <button
                           aria-describedby="root_optionalArrayWithAnyofs__anyof_select__error root_optionalArrayWithAnyofs__anyof_select__description root_optionalArrayWithAnyofs__anyof_select__help"
                           aria-expanded="false"
-                          aria-labelledby="field-r76__label"
+                          aria-labelledby="field-r79__label"
                           class="fui-Dropdown__button ___b67tb00_4t2umz0 f122n59 f1c21dwh f3bhgqh f1ewtqcl f1s2aq7o f14mj54c fdrzuqr f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                           disabled=""
                           id="root_optionalArrayWithAnyofs__anyof_select"
@@ -10081,6 +10081,104 @@ exports[`single fields > select widget with description in schema and FieldTempl
             This is a select description
           </span>
         </p>
+      </div>
+    </div>
+    <div
+      class="___fko12g0_0000000 f1wswflg"
+    >
+      <button
+        class="fui-Button r1f29ykk ___dhqv000_ql4wmo0 ffp7eso f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1phragk f15wkkf3 f1s2uweq fr80ssc f1ukrpxl fecsdlb f1rq72xc f1ksv2xa fhvnf4x fb6swo4 f1klyf7k f232fm2 f1d6mv4x f1nz3ub2 fag2qd2 fmvhcg7 f1o3dhpw f14bpyus fqc85l4 f1h3a8gf fkiggi6 f8gmj8i f1ap8nzx f1igan7k fjag8bx f1v3eptx f1ysmecq faulsx f79t15f fbtzoaq f8qmx7k fd4bjan f17t0x8g f194v5ow f1qgg65p fk7jm04 fhgccpy f32wu9k fu5nqqq f13prjl2 f1czftr5 f1nl83rv fixhny3 feygou5"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields > select widget with selected oneOf option description 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="___r7kt3y0_0000000 fqerorx rjsf-field rjsf-field-string"
+    >
+      <div
+        class="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+      >
+        <div
+          class="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+        >
+          <label
+            class="fui-Label fui-Field__label ___uxsood0_w9q9lw0 fk6fouc f19n0e5 fkhj508 f1i3iumi f6nezus f1iqmcbn fclwglc fywfov9 fyacil5"
+            for="field-r2m__control"
+            id="field-r2m__label"
+          />
+          <div
+            class="fui-Dropdown form-control ___11d5zms_mmbwks0 ft85np5 f1ewtqcl ftuwxu6 f1exfvgq f10pi13n fmrv4ls f14a1fxs f3e99gv fhljsf7 f1gw3sf2 f13zj6fq f1mdlcz9 f1a7op3 f1gboi2j f1cjjd47 ffyw7fx f1kp91vd f1ibwz09 f1mnjydx f13evtba f1yk9hq fhwpy7i f14ee0xe f1xhbsuh fsrmcvb f1t3k7v9 fjw5xc1 f1xdyd5c fatpbeo fb7uyps fx04xgm f1c7in40 f1ibeo51 f18qfb8s f1m082s7 fxugw4r f1c1zstj fhz96rm fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi fvs00aa f1assf6x f1z0osm6 f4ruux4 f1b473iu f381qr8 f1qzcrsd ft4skwv"
+          >
+            <button
+              aria-describedby="root__error root__description root__help"
+              aria-expanded="false"
+              aria-labelledby="field-r2m__label"
+              class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
+              id="root"
+              name="root"
+              role="combobox"
+              tabindex="0"
+              type="button"
+              value="Foo"
+            >
+              Foo
+              <span
+                class="fui-Dropdown__expandIcon ___5y6ahy0_3cm10l0 f1ewtqcl fxkbij4 ftgm304 fe5j1ua f12w6cgp f8bv1bt fvc9v3g f1h9en5y"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="fui-Icon ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
+                  fill="currentColor"
+                  height="1em"
+                  viewBox="0 0 20 20"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 0 1-.78 0L4.15 8.35a.5.5 0 1 1 .7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </button>
+            <button
+              aria-label="Clear selection"
+              class="fui-Dropdown__clearButton rticfuj ___1ijk9xi_1ynmboo f1ewtqcl fxkbij4 fjseox fe5j1ua f12w6cgp f8bv1bt fvc9v3g f1h9en5y"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="fui-Icon ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
+                fill="currentColor"
+                height="1em"
+                viewBox="0 0 20 20"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+          <span
+            class="fui-Text ___6s2bv30_bwsv0h0 fk6fouc fkhj508 f1i3iumi figsok6 fpgzoln ftgm304 f6juhto f1gl81tg f2jf649 frnwi6n f18zxyen"
+            id="root__description"
+          >
+            Foo description
+          </span>
+        </div>
       </div>
     </div>
     <div

--- a/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
@@ -1298,8 +1298,8 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                 >
                   <label
                     class="fui-Label fui-Field__label ___uxsood0_w9q9lw0 fk6fouc f19n0e5 fkhj508 f1i3iumi f6nezus f1iqmcbn fclwglc fywfov9 fyacil5"
-                    for="field-r9u__control"
-                    id="field-r9u__label"
+                    for="field-ra1__control"
+                    id="field-ra1__label"
                   >
                     color
                   </label>
@@ -1309,7 +1309,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                     <button
                       aria-describedby="root_color__error root_color__description root_color__help"
                       aria-expanded="false"
-                      aria-labelledby="field-r9u__label"
+                      aria-labelledby="field-ra1__label"
                       class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                       id="root_color"
                       name="root[color]"
@@ -2651,8 +2651,8 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                 >
                   <label
                     class="fui-Label fui-Field__label ___uxsood0_w9q9lw0 fk6fouc f19n0e5 fkhj508 f1i3iumi f6nezus f1iqmcbn fclwglc fywfov9 fyacil5"
-                    for="field-rbe__control"
-                    id="field-rbe__label"
+                    for="field-rbh__control"
+                    id="field-rbh__label"
                   >
                     color
                   </label>
@@ -2662,7 +2662,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                     <button
                       aria-describedby="root_color__error root_color__description root_color__help"
                       aria-expanded="false"
-                      aria-labelledby="field-rbe__label"
+                      aria-labelledby="field-rbh__label"
                       class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                       id="root_color"
                       name="root.color"
@@ -4983,8 +4983,8 @@ exports[`single fields > optional data controls > does not show optional control
                     >
                       <label
                         class="fui-Label fui-Field__label ___uxsood0_w9q9lw0 fk6fouc f19n0e5 fkhj508 f1i3iumi f6nezus f1iqmcbn fclwglc fywfov9 fyacil5"
-                        for="field-r4h__control"
-                        id="field-r4h__label"
+                        for="field-r4k__control"
+                        id="field-r4k__label"
                       >
                         optionalObjectWithOneofs
                       </label>
@@ -4994,7 +4994,7 @@ exports[`single fields > optional data controls > does not show optional control
                         <button
                           aria-describedby="root_optionalObjectWithOneofs__oneof_select__error root_optionalObjectWithOneofs__oneof_select__description root_optionalObjectWithOneofs__oneof_select__help"
                           aria-expanded="false"
-                          aria-labelledby="field-r4h__label"
+                          aria-labelledby="field-r4k__label"
                           class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                           id="root_optionalObjectWithOneofs__oneof_select"
                           name="root_optionalObjectWithOneofs__oneof_select"
@@ -5130,8 +5130,8 @@ exports[`single fields > optional data controls > does not show optional control
                     >
                       <label
                         class="fui-Label fui-Field__label ___uxsood0_w9q9lw0 fk6fouc f19n0e5 fkhj508 f1i3iumi f6nezus f1iqmcbn fclwglc fywfov9 fyacil5"
-                        for="field-r4n__control"
-                        id="field-r4n__label"
+                        for="field-r4q__control"
+                        id="field-r4q__label"
                       >
                         optionalArrayWithAnyofs
                       </label>
@@ -5141,7 +5141,7 @@ exports[`single fields > optional data controls > does not show optional control
                         <button
                           aria-describedby="root_optionalArrayWithAnyofs__anyof_select__error root_optionalArrayWithAnyofs__anyof_select__description root_optionalArrayWithAnyofs__anyof_select__help"
                           aria-expanded="false"
-                          aria-labelledby="field-r4n__label"
+                          aria-labelledby="field-r4q__label"
                           class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                           id="root_optionalArrayWithAnyofs__anyof_select"
                           name="root_optionalArrayWithAnyofs__anyof_select"
@@ -5899,8 +5899,8 @@ exports[`single fields > optional data controls > does not show optional control
                     >
                       <label
                         class="fui-Label fui-Field__label ___uxsood0_w9q9lw0 fk6fouc f19n0e5 fkhj508 f1i3iumi f6nezus f1iqmcbn fclwglc fywfov9 fyacil5"
-                        for="field-r73__control"
-                        id="field-r73__label"
+                        for="field-r76__control"
+                        id="field-r76__label"
                       >
                         optionalObjectWithOneofs
                       </label>
@@ -5910,7 +5910,7 @@ exports[`single fields > optional data controls > does not show optional control
                         <button
                           aria-describedby="root_optionalObjectWithOneofs__oneof_select__error root_optionalObjectWithOneofs__oneof_select__description root_optionalObjectWithOneofs__oneof_select__help"
                           aria-expanded="false"
-                          aria-labelledby="field-r73__label"
+                          aria-labelledby="field-r76__label"
                           class="fui-Dropdown__button ___b67tb00_4t2umz0 f122n59 f1c21dwh f3bhgqh f1ewtqcl f1s2aq7o f14mj54c fdrzuqr f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                           disabled=""
                           id="root_optionalObjectWithOneofs__oneof_select"
@@ -6046,8 +6046,8 @@ exports[`single fields > optional data controls > does not show optional control
                     >
                       <label
                         class="fui-Label fui-Field__label ___uxsood0_w9q9lw0 fk6fouc f19n0e5 fkhj508 f1i3iumi f6nezus f1iqmcbn fclwglc fywfov9 fyacil5"
-                        for="field-r79__control"
-                        id="field-r79__label"
+                        for="field-r7c__control"
+                        id="field-r7c__label"
                       >
                         optionalArrayWithAnyofs
                       </label>
@@ -6057,7 +6057,7 @@ exports[`single fields > optional data controls > does not show optional control
                         <button
                           aria-describedby="root_optionalArrayWithAnyofs__anyof_select__error root_optionalArrayWithAnyofs__anyof_select__description root_optionalArrayWithAnyofs__anyof_select__help"
                           aria-expanded="false"
-                          aria-labelledby="field-r79__label"
+                          aria-labelledby="field-r7c__label"
                           class="fui-Dropdown__button ___b67tb00_4t2umz0 f122n59 f1c21dwh f3bhgqh f1ewtqcl f1s2aq7o f14mj54c fdrzuqr f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                           disabled=""
                           id="root_optionalArrayWithAnyofs__anyof_select"
@@ -10178,6 +10178,92 @@ exports[`single fields > select widget with selected oneOf option description 1`
           >
             Foo description
           </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="___fko12g0_0000000 f1wswflg"
+    >
+      <button
+        class="fui-Button r1f29ykk ___dhqv000_ql4wmo0 ffp7eso f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1phragk f15wkkf3 f1s2uweq fr80ssc f1ukrpxl fecsdlb f1rq72xc f1ksv2xa fhvnf4x fb6swo4 f1klyf7k f232fm2 f1d6mv4x f1nz3ub2 fag2qd2 fmvhcg7 f1o3dhpw f14bpyus fqc85l4 f1h3a8gf fkiggi6 f8gmj8i f1ap8nzx f1igan7k fjag8bx f1v3eptx f1ysmecq faulsx f79t15f fbtzoaq f8qmx7k fd4bjan f17t0x8g f194v5ow f1qgg65p fk7jm04 fhgccpy f32wu9k fu5nqqq f13prjl2 f1czftr5 f1nl83rv fixhny3 feygou5"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields > select widget with selected oneOf option description and hidden label 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="___r7kt3y0_0000000 fqerorx rjsf-field rjsf-field-string"
+    >
+      <div
+        class="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+      >
+        <div
+          class="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+        >
+          <div
+            class="fui-Dropdown form-control ___11d5zms_mmbwks0 ft85np5 f1ewtqcl ftuwxu6 f1exfvgq f10pi13n fmrv4ls f14a1fxs f3e99gv fhljsf7 f1gw3sf2 f13zj6fq f1mdlcz9 f1a7op3 f1gboi2j f1cjjd47 ffyw7fx f1kp91vd f1ibwz09 f1mnjydx f13evtba f1yk9hq fhwpy7i f14ee0xe f1xhbsuh fsrmcvb f1t3k7v9 fjw5xc1 f1xdyd5c fatpbeo fb7uyps fx04xgm f1c7in40 f1ibeo51 f18qfb8s f1m082s7 fxugw4r f1c1zstj fhz96rm fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi fvs00aa f1assf6x f1z0osm6 f4ruux4 f1b473iu f381qr8 f1qzcrsd ft4skwv"
+          >
+            <button
+              aria-describedby="root__error root__description root__help"
+              aria-expanded="false"
+              class="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
+              id="root"
+              name="root"
+              role="combobox"
+              tabindex="0"
+              type="button"
+              value="Foo"
+            >
+              Foo
+              <span
+                class="fui-Dropdown__expandIcon ___5y6ahy0_3cm10l0 f1ewtqcl fxkbij4 ftgm304 fe5j1ua f12w6cgp f8bv1bt fvc9v3g f1h9en5y"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="fui-Icon ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
+                  fill="currentColor"
+                  height="1em"
+                  viewBox="0 0 20 20"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15.85 7.65c.2.2.2.5 0 .7l-5.46 5.49a.55.55 0 0 1-.78 0L4.15 8.35a.5.5 0 1 1 .7-.7L10 12.8l5.15-5.16c.2-.2.5-.2.7 0Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </button>
+            <button
+              aria-label="Clear selection"
+              class="fui-Dropdown__clearButton rticfuj ___1ijk9xi_1ynmboo f1ewtqcl fxkbij4 fjseox fe5j1ua f12w6cgp f8bv1bt fvc9v3g f1h9en5y"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="fui-Icon ___9ctc0p0_1xvj9ao f1w7gpdv fez10in f1dd5bof"
+                fill="currentColor"
+                height="1em"
+                viewBox="0 0 20 20"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/mantine/src/widgets/SelectWidget.tsx
+++ b/packages/mantine/src/widgets/SelectWidget.tsx
@@ -10,6 +10,7 @@ import {
   getOptionValueFormat,
   labelValue,
   logUnsupportedDefaultForEnum,
+  SelectedOptionDescription,
 } from '@rjsf/utils';
 
 import { cleanupOptions } from '../utils';
@@ -105,15 +106,20 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
     ...themeProps,
   };
 
-  return multiple ? (
-    <MultiSelect
-      {...sharedProps}
-      value={enumOptionSelectedValue<S>(value, enumOptions, true, optionValueFormat, []) as string[]}
-    />
-  ) : (
-    <Select
-      {...sharedProps}
-      value={enumOptionSelectedValue<S>(value, enumOptions, false, optionValueFormat, null) as string | null}
-    />
+  return (
+    <>
+      {multiple ? (
+        <MultiSelect
+          {...sharedProps}
+          value={enumOptionSelectedValue<S>(value, enumOptions, true, optionValueFormat, []) as string[]}
+        />
+      ) : (
+        <Select
+          {...sharedProps}
+          value={enumOptionSelectedValue<S>(value, enumOptions, false, optionValueFormat, null) as string | null}
+        />
+      )}
+      <SelectedOptionDescription {...props} />
+    </>
   );
 }

--- a/packages/mantine/src/widgets/SelectWidget.tsx
+++ b/packages/mantine/src/widgets/SelectWidget.tsx
@@ -108,6 +108,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
 
   return (
     <>
+      <SelectedOptionDescription {...props} />
       {multiple ? (
         <MultiSelect
           {...sharedProps}
@@ -119,7 +120,6 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
           value={enumOptionSelectedValue<S>(value, enumOptions, false, optionValueFormat, null) as string | null}
         />
       )}
-      <SelectedOptionDescription {...props} />
     </>
   );
 }

--- a/packages/mantine/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mantine/test/__snapshots__/Form.test.tsx.snap
@@ -15399,6 +15399,13 @@ exports[`single fields > select widget with selected oneOf option description 1`
     <div
       class="rjsf-field rjsf-field-string"
     >
+      <p
+        class="mantine-focus-auto m_b6d8b162 mantine-Text-root"
+        id="root__description"
+        style="margin-top: calc(0.1875rem * var(--mantine-scale)); margin-bottom: var(--mantine-spacing-sm);"
+      >
+        Foo description
+      </p>
       <div
         class="m_46b77525 mantine-InputWrapper-root mantine-Select-root"
         data-size="sm"
@@ -15482,7 +15489,7 @@ exports[`single fields > select widget with selected oneOf option description 1`
                       data-checked="true"
                       data-combobox-active="true"
                       data-combobox-option="true"
-                      id=":rhk:"
+                      id=":rhl:"
                       role="option"
                       value="0"
                     >
@@ -15508,7 +15515,7 @@ exports[`single fields > select widget with selected oneOf option description 1`
                       aria-selected="false"
                       class="m_92253aa5 mantine-Select-option m_390b5f4"
                       data-combobox-option="true"
-                      id=":rhm:"
+                      id=":rhn:"
                       role="option"
                       value="1"
                     >
@@ -15542,13 +15549,6 @@ exports[`single fields > select widget with selected oneOf option description 1`
         type="hidden"
         value="0"
       />
-      <p
-        class="mantine-focus-auto m_b6d8b162 mantine-Text-root"
-        id="root__description"
-        style="margin-top: calc(0.1875rem * var(--mantine-scale)); margin-bottom: var(--mantine-spacing-sm);"
-      >
-        Foo description
-      </p>
     </div>
     <button
       class="mantine-focus-auto mantine-active m_77c9d27d mantine-Button-root m_87cf2631 mantine-UnstyledButton-root"

--- a/packages/mantine/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mantine/test/__snapshots__/Form.test.tsx.snap
@@ -31,10 +31,10 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1f2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1fo{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1f2"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1fo"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -68,7 +68,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1f9"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1fv"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -95,10 +95,10 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-r1fe{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                              .__m__-r1g4{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                             </style>
                             <div
-                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1fe"
+                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1g4"
                               style="margin-bottom: var(--mantine-spacing-sm);"
                             >
                               <div
@@ -321,7 +321,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1g5"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1gr"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -348,10 +348,10 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-r1ga{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                              .__m__-r1h0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                             </style>
                             <div
-                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1ga"
+                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1h0"
                               style="margin-bottom: var(--mantine-spacing-sm);"
                             >
                               <div
@@ -672,10 +672,10 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1dm{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1ec{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1dm"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ec"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -709,7 +709,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1dt"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1ej"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -882,7 +882,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1ed"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1f3"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -1151,10 +1151,10 @@ exports[`nameGenerator > bracketNameGenerator > checkboxes field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1iq{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1jg{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1iq"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1jg"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -1178,7 +1178,7 @@ exports[`nameGenerator > bracketNameGenerator > checkboxes field 1`] = `
                   role="group"
                 >
                   <div
-                    class="m_8bffd616 mantine-Flex-root __m__-r1j0"
+                    class="m_8bffd616 mantine-Flex-root __m__-r1jm"
                     style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
                   >
                     <div
@@ -1381,10 +1381,10 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1cf{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1d5{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1cf"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1d5"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -1410,10 +1410,10 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r1ck{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r1da{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1ck"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1da"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -1515,10 +1515,10 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r1d5{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r1dr{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1d5"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1dr"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -1659,10 +1659,10 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1i2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1io{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1i2"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1io"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -1686,7 +1686,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                   role="radiogroup"
                 >
                   <div
-                    class="m_8bffd616 mantine-Flex-root __m__-r1i9"
+                    class="m_8bffd616 mantine-Flex-root __m__-r1iv"
                     style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
                   >
                     <div
@@ -1840,10 +1840,10 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1h6{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1hs{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1h6"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1hs"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -1943,7 +1943,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1hp:"
+                              id=":r1if:"
                               role="option"
                               value="0"
                             >
@@ -1955,7 +1955,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1hr:"
+                              id=":r1ih:"
                               role="option"
                               value="1"
                             >
@@ -1967,7 +1967,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1ht:"
+                              id=":r1ij:"
                               role="option"
                               value="2"
                             >
@@ -2057,10 +2057,10 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1bl{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1cb{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1bl"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1cb"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -2302,10 +2302,10 @@ exports[`nameGenerator > bracketNameGenerator > textarea field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1jn{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1kd{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1jn"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1kd"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -2399,10 +2399,10 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1nf{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1o5{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1nf"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1o5"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -2436,7 +2436,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1nm"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1oc"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -2463,10 +2463,10 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-r1nr{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                              .__m__-r1oh{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                             </style>
                             <div
-                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1nr"
+                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1oh"
                               style="margin-bottom: var(--mantine-spacing-sm);"
                             >
                               <div
@@ -2689,7 +2689,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1oi"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1p8"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -2716,10 +2716,10 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-r1on{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                              .__m__-r1pd{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                             </style>
                             <div
-                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1on"
+                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1pd"
                               style="margin-bottom: var(--mantine-spacing-sm);"
                             >
                               <div
@@ -3040,10 +3040,10 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1m3{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1mp{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1m3"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1mp"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -3077,7 +3077,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1ma"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1n0"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -3250,7 +3250,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1mq"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1ng"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -3519,10 +3519,10 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1ks{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1li{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ks"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1li"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -3548,10 +3548,10 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r1l1{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r1ln{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1l1"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1ln"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -3653,10 +3653,10 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r1li{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r1m8{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1li"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1m8"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -3797,10 +3797,10 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1pj{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1q9{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1pj"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1q9"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -3900,7 +3900,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1q6:"
+                              id=":r1qs:"
                               role="option"
                               value="0"
                             >
@@ -3912,7 +3912,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1q8:"
+                              id=":r1qu:"
                               role="option"
                               value="1"
                             >
@@ -3924,7 +3924,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1qa:"
+                              id=":r1r0:"
                               role="option"
                               value="2"
                             >
@@ -4014,10 +4014,10 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1k2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1ko{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1k2"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ko"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -4274,10 +4274,10 @@ exports[`single fields > Cyclic schema 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rmc{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rn2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rmc"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rn2"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -4310,10 +4310,10 @@ exports[`single fields > Cyclic schema 1`] = `
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rmi{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rn8{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rmi"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rn8"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -4939,7 +4939,7 @@ exports[`single fields > checkboxes field 1`] = `
           role="group"
         >
           <div
-            class="m_8bffd616 mantine-Flex-root __m__-rh8"
+            class="m_8bffd616 mantine-Flex-root __m__-rhu"
             style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
           >
             <div
@@ -5605,10 +5605,10 @@ exports[`single fields > field with description 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rj4{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rjq{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rj4"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rjq"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -5712,10 +5712,10 @@ exports[`single fields > field with description in uiSchema 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rjg{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rk6{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rjg"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rk6"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -5819,10 +5819,10 @@ exports[`single fields > field with markdown description 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rjs{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rki{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rjs"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rki"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -5926,10 +5926,10 @@ exports[`single fields > field with markdown description in uiSchema 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rk8{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rku{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rk8"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rku"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -6516,10 +6516,10 @@ exports[`single fields > hidden field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-riv{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rjl{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-riv"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rjl"
           style="margin-bottom: var(--mantine-spacing-sm);"
         />
       </div>
@@ -6925,10 +6925,10 @@ exports[`single fields > optional data controls > does not show optional control
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rmu{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rnk{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rmu"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rnk"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -6954,10 +6954,10 @@ exports[`single fields > optional data controls > does not show optional control
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rn3{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rnp{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rn3"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rnp"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -7021,10 +7021,10 @@ exports[`single fields > optional data controls > does not show optional control
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rne{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-ro4{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-rne"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-ro4"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -7092,10 +7092,10 @@ exports[`single fields > optional data controls > does not show optional control
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rnp{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-rof{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-rnp"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-rof"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -7455,10 +7455,10 @@ exports[`single fields > optional data controls > does not show optional control
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rp0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rpm{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rp0"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rpm"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -7677,7 +7677,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 data-checked="true"
                                 data-combobox-active="true"
                                 data-combobox-option="true"
-                                id=":rq1:"
+                                id=":rqn:"
                                 role="option"
                                 value="0"
                               >
@@ -7703,7 +7703,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":rq3:"
+                                id=":rqp:"
                                 role="option"
                                 value="1"
                               >
@@ -7715,7 +7715,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":rq5:"
+                                id=":rqr:"
                                 role="option"
                                 value="2"
                               >
@@ -7769,10 +7769,10 @@ exports[`single fields > optional data controls > does not show optional control
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rq9{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-rqv{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-rq9"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-rqv"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     >
                       <div
@@ -7924,7 +7924,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 data-checked="true"
                                 data-combobox-active="true"
                                 data-combobox-option="true"
-                                id=":rr3:"
+                                id=":rrp:"
                                 role="option"
                                 value="0"
                               >
@@ -7950,7 +7950,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":rr5:"
+                                id=":rrr:"
                                 role="option"
                                 value="1"
                               >
@@ -7962,7 +7962,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":rr7:"
+                                id=":rrt:"
                                 role="option"
                                 value="2"
                               >
@@ -8129,10 +8129,10 @@ exports[`single fields > optional data controls > does not show optional control
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r12i{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r138{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r12i"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r138"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -8158,10 +8158,10 @@ exports[`single fields > optional data controls > does not show optional control
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r12n{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r13d{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r12n"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r13d"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -8228,10 +8228,10 @@ exports[`single fields > optional data controls > does not show optional control
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r132{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r13o{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r132"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r13o"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -8302,10 +8302,10 @@ exports[`single fields > optional data controls > does not show optional control
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r13d{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r143{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r13d"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r143"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -8676,10 +8676,10 @@ exports[`single fields > optional data controls > does not show optional control
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r14k{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r15a{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r14k"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r15a"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -8907,7 +8907,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 data-checked="true"
                                 data-combobox-active="true"
                                 data-combobox-option="true"
-                                id=":r15l:"
+                                id=":r16b:"
                                 role="option"
                                 value="0"
                               >
@@ -8933,7 +8933,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":r15n:"
+                                id=":r16d:"
                                 role="option"
                                 value="1"
                               >
@@ -8945,7 +8945,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":r15p:"
+                                id=":r16f:"
                                 role="option"
                                 value="2"
                               >
@@ -9000,10 +9000,10 @@ exports[`single fields > optional data controls > does not show optional control
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r15t{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-r16j{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-r15t"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-r16j"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     >
                       <div
@@ -9159,7 +9159,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 data-checked="true"
                                 data-combobox-active="true"
                                 data-combobox-option="true"
-                                id=":r16n:"
+                                id=":r17d:"
                                 role="option"
                                 value="0"
                               >
@@ -9185,7 +9185,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":r16p:"
+                                id=":r17f:"
                                 role="option"
                                 value="1"
                               >
@@ -9197,7 +9197,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":r16r:"
+                                id=":r17h:"
                                 role="option"
                                 value="2"
                               >
@@ -9367,10 +9367,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rtv{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rul{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rtv"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rul"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -9388,10 +9388,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-ru3{--grid-gutter:var(--mantine-spacing-md);}
+                  .__m__-rup{--grid-gutter:var(--mantine-spacing-md);}
                 </style>
                 <div
-                  class="m_410352e9 mantine-Grid-root __m__-ru3"
+                  class="m_410352e9 mantine-Grid-root __m__-rup"
                 >
                   <div
                     class="m_dee7bd2f mantine-Grid-inner"
@@ -9399,10 +9399,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-ru5{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                      .__m__-rur{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                     </style>
                     <div
-                      class="m_96bdd299 mantine-Grid-col __m__-ru5"
+                      class="m_96bdd299 mantine-Grid-col __m__-rur"
                     >
                       <h3
                         class="m_8a5d1357 mantine-Title-root"
@@ -9416,10 +9416,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-ru8{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                      .__m__-ruu{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                     </style>
                     <div
-                      class="m_96bdd299 mantine-Grid-col __m__-ru8"
+                      class="m_96bdd299 mantine-Grid-col __m__-ruu"
                     >
                       <button
                         class="mantine-focus-auto mantine-active rjsf-remove-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -9465,10 +9465,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-ruc{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rv2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-ruc"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rv2"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -9525,10 +9525,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rum{--grid-gutter:var(--mantine-spacing-md);}
+                          .__m__-rvc{--grid-gutter:var(--mantine-spacing-md);}
                         </style>
                         <div
-                          class="m_410352e9 mantine-Grid-root __m__-rum"
+                          class="m_410352e9 mantine-Grid-root __m__-rvc"
                         >
                           <div
                             class="m_dee7bd2f mantine-Grid-inner"
@@ -9536,10 +9536,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-ruo{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                              .__m__-rve{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                             </style>
                             <div
-                              class="m_96bdd299 mantine-Grid-col __m__-ruo"
+                              class="m_96bdd299 mantine-Grid-col __m__-rve"
                             >
                               <h3
                                 class="m_8a5d1357 mantine-Title-root"
@@ -9553,10 +9553,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-rur{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                              .__m__-rvh{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                             </style>
                             <div
-                              class="m_96bdd299 mantine-Grid-col __m__-rur"
+                              class="m_96bdd299 mantine-Grid-col __m__-rvh"
                             >
                               <button
                                 class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -9602,10 +9602,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-ruv{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-rvl{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-ruv"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-rvl"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         />
                       </div>
@@ -9634,10 +9634,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rv4{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-rvq{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-rv4"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-rvq"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -9771,10 +9771,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-rvl{--grid-gutter:var(--mantine-spacing-md);}
+                            .__m__-r10b{--grid-gutter:var(--mantine-spacing-md);}
                           </style>
                           <div
-                            class="m_410352e9 mantine-Grid-root __m__-rvl"
+                            class="m_410352e9 mantine-Grid-root __m__-r10b"
                           >
                             <div
                               class="m_dee7bd2f mantine-Grid-inner"
@@ -9782,10 +9782,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                               <style
                                 data-mantine-styles="inline"
                               >
-                                .__m__-rvn{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                                .__m__-r10d{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                               </style>
                               <div
-                                class="m_96bdd299 mantine-Grid-col __m__-rvn"
+                                class="m_96bdd299 mantine-Grid-col __m__-r10d"
                               >
                                 <h4
                                   class="m_8a5d1357 mantine-Title-root"
@@ -9799,10 +9799,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                               <style
                                 data-mantine-styles="inline"
                               >
-                                .__m__-rvq{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                                .__m__-r10g{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                               </style>
                               <div
-                                class="m_96bdd299 mantine-Grid-col __m__-rvq"
+                                class="m_96bdd299 mantine-Grid-col __m__-r10g"
                               >
                                 <button
                                   class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -9945,10 +9945,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                   <style
                     data-mantine-styles="inline"
                   >
-                    .__m__-r108{--grid-gutter:var(--mantine-spacing-md);}
+                    .__m__-r10u{--grid-gutter:var(--mantine-spacing-md);}
                   </style>
                   <div
-                    class="m_410352e9 mantine-Grid-root __m__-r108"
+                    class="m_410352e9 mantine-Grid-root __m__-r10u"
                   >
                     <div
                       class="m_dee7bd2f mantine-Grid-inner"
@@ -9956,10 +9956,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-r10a{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                        .__m__-r110{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                       </style>
                       <div
-                        class="m_96bdd299 mantine-Grid-col __m__-r10a"
+                        class="m_96bdd299 mantine-Grid-col __m__-r110"
                       >
                         <h4
                           class="m_8a5d1357 mantine-Title-root"
@@ -9973,10 +9973,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-r10d{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                        .__m__-r113{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                       </style>
                       <div
-                        class="m_96bdd299 mantine-Grid-col __m__-r10d"
+                        class="m_96bdd299 mantine-Grid-col __m__-r113"
                       >
                         <button
                           class="mantine-focus-auto mantine-active rjsf-remove-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -10028,7 +10028,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r10j"
+                      class="m_8bffd616 mantine-Flex-root __m__-r119"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -10194,10 +10194,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r114{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r11q{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r114"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r11q"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -10336,10 +10336,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r11m{--grid-gutter:var(--mantine-spacing-md);}
+                      .__m__-r12c{--grid-gutter:var(--mantine-spacing-md);}
                     </style>
                     <div
-                      class="m_410352e9 mantine-Grid-root __m__-r11m"
+                      class="m_410352e9 mantine-Grid-root __m__-r12c"
                     >
                       <div
                         class="m_dee7bd2f mantine-Grid-inner"
@@ -10347,10 +10347,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r11o{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                          .__m__-r12e{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                         </style>
                         <div
-                          class="m_96bdd299 mantine-Grid-col __m__-r11o"
+                          class="m_96bdd299 mantine-Grid-col __m__-r12e"
                         >
                           <h3
                             class="m_8a5d1357 mantine-Title-root"
@@ -10364,10 +10364,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r11r{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                          .__m__-r12h{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                         </style>
                         <div
-                          class="m_96bdd299 mantine-Grid-col __m__-r11r"
+                          class="m_96bdd299 mantine-Grid-col __m__-r12h"
                         >
                           <button
                             class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -10413,10 +10413,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r11v{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-r12l{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-r11v"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-r12l"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     />
                   </div>
@@ -10448,10 +10448,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-r124{--grid-gutter:var(--mantine-spacing-md);}
+                        .__m__-r12q{--grid-gutter:var(--mantine-spacing-md);}
                       </style>
                       <div
-                        class="m_410352e9 mantine-Grid-root __m__-r124"
+                        class="m_410352e9 mantine-Grid-root __m__-r12q"
                       >
                         <div
                           class="m_dee7bd2f mantine-Grid-inner"
@@ -10459,10 +10459,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-r126{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                            .__m__-r12s{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                           </style>
                           <div
-                            class="m_96bdd299 mantine-Grid-col __m__-r126"
+                            class="m_96bdd299 mantine-Grid-col __m__-r12s"
                           >
                             <h4
                               class="m_8a5d1357 mantine-Title-root"
@@ -10476,10 +10476,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-r129{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                            .__m__-r12v{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                           </style>
                           <div
-                            class="m_96bdd299 mantine-Grid-col __m__-r129"
+                            class="m_96bdd299 mantine-Grid-col __m__-r12v"
                           >
                             <button
                               class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -10593,10 +10593,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r18j{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r199{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r18j"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r199"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -10622,10 +10622,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r18o{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r19e{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r18o"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r19e"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -10693,10 +10693,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r193{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r19p{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r193"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r19p"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <em
@@ -10731,10 +10731,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r198{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r19u{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r198"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r19u"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -11000,7 +11000,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1a7"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1at"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -11173,10 +11173,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r1ao{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r1be{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1ao"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1be"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -11328,10 +11328,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r1bb{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-r1c1{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-r1bb"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-r1c1"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     >
                       <em
@@ -11451,10 +11451,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rrj{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rs9{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rrj"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rs9"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -11472,10 +11472,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rrn{--grid-gutter:var(--mantine-spacing-md);}
+                  .__m__-rsd{--grid-gutter:var(--mantine-spacing-md);}
                 </style>
                 <div
-                  class="m_410352e9 mantine-Grid-root __m__-rrn"
+                  class="m_410352e9 mantine-Grid-root __m__-rsd"
                 >
                   <div
                     class="m_dee7bd2f mantine-Grid-inner"
@@ -11483,10 +11483,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rrp{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                      .__m__-rsf{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                     </style>
                     <div
-                      class="m_96bdd299 mantine-Grid-col __m__-rrp"
+                      class="m_96bdd299 mantine-Grid-col __m__-rsf"
                     >
                       <h3
                         class="m_8a5d1357 mantine-Title-root"
@@ -11500,10 +11500,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rrs{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                      .__m__-rsi{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                     </style>
                     <div
-                      class="m_96bdd299 mantine-Grid-col __m__-rrs"
+                      class="m_96bdd299 mantine-Grid-col __m__-rsi"
                     >
                       <button
                         class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -11549,10 +11549,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rs0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rsm{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rs0"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rsm"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 />
               </div>
@@ -11575,10 +11575,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                   <style
                     data-mantine-styles="inline"
                   >
-                    .__m__-rs4{--grid-gutter:var(--mantine-spacing-md);}
+                    .__m__-rsq{--grid-gutter:var(--mantine-spacing-md);}
                   </style>
                   <div
-                    class="m_410352e9 mantine-Grid-root __m__-rs4"
+                    class="m_410352e9 mantine-Grid-root __m__-rsq"
                   >
                     <div
                       class="m_dee7bd2f mantine-Grid-inner"
@@ -11586,10 +11586,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-rs6{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                        .__m__-rss{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                       </style>
                       <div
-                        class="m_96bdd299 mantine-Grid-col __m__-rs6"
+                        class="m_96bdd299 mantine-Grid-col __m__-rss"
                       >
                         <h4
                           class="m_8a5d1357 mantine-Title-root"
@@ -11603,10 +11603,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-rs9{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                        .__m__-rsv{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                       </style>
                       <div
-                        class="m_96bdd299 mantine-Grid-col __m__-rs9"
+                        class="m_96bdd299 mantine-Grid-col __m__-rsv"
                       >
                         <button
                           class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -11679,10 +11679,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rsh{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rt7{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rsh"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rt7"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -11821,10 +11821,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rt3{--grid-gutter:var(--mantine-spacing-md);}
+                      .__m__-rtp{--grid-gutter:var(--mantine-spacing-md);}
                     </style>
                     <div
-                      class="m_410352e9 mantine-Grid-root __m__-rt3"
+                      class="m_410352e9 mantine-Grid-root __m__-rtp"
                     >
                       <div
                         class="m_dee7bd2f mantine-Grid-inner"
@@ -11832,10 +11832,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rt5{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                          .__m__-rtr{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                         </style>
                         <div
-                          class="m_96bdd299 mantine-Grid-col __m__-rt5"
+                          class="m_96bdd299 mantine-Grid-col __m__-rtr"
                         >
                           <h3
                             class="m_8a5d1357 mantine-Title-root"
@@ -11849,10 +11849,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rt8{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                          .__m__-rtu{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                         </style>
                         <div
-                          class="m_96bdd299 mantine-Grid-col __m__-rt8"
+                          class="m_96bdd299 mantine-Grid-col __m__-rtu"
                         >
                           <button
                             class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -11898,10 +11898,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rtc{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-ru2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-rtc"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-ru2"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     />
                   </div>
@@ -11933,10 +11933,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-rth{--grid-gutter:var(--mantine-spacing-md);}
+                        .__m__-ru7{--grid-gutter:var(--mantine-spacing-md);}
                       </style>
                       <div
-                        class="m_410352e9 mantine-Grid-root __m__-rth"
+                        class="m_410352e9 mantine-Grid-root __m__-ru7"
                       >
                         <div
                           class="m_dee7bd2f mantine-Grid-inner"
@@ -11944,10 +11944,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-rtj{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                            .__m__-ru9{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                           </style>
                           <div
-                            class="m_96bdd299 mantine-Grid-col __m__-rtj"
+                            class="m_96bdd299 mantine-Grid-col __m__-ru9"
                           >
                             <h4
                               class="m_8a5d1357 mantine-Title-root"
@@ -11961,10 +11961,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-rtm{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                            .__m__-ruc{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                           </style>
                           <div
-                            class="m_96bdd299 mantine-Grid-col __m__-rtm"
+                            class="m_96bdd299 mantine-Grid-col __m__-ruc"
                           >
                             <button
                               class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -12078,10 +12078,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r177{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r17t{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r177"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r17t"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -12107,10 +12107,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r17c{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r182{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r17c"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r182"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <em
@@ -12180,10 +12180,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r17l{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r18b{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r17l"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r18b"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -12335,10 +12335,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r188{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-r18u{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-r188"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-r18u"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     >
                       <em
@@ -12551,7 +12551,7 @@ exports[`single fields > radio field 1`] = `
           role="radiogroup"
         >
           <div
-            class="m_8bffd616 mantine-Flex-root __m__-ri7"
+            class="m_8bffd616 mantine-Flex-root __m__-rit"
             style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
           >
             <div
@@ -15377,6 +15377,199 @@ exports[`single fields > select widget with description in schema and FieldTempl
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description 1`] = `
+<DocumentFragment>
+  <style
+    data-mantine-styles="true"
+  >
+    
+
+
+
+
+  </style>
+  <style
+    data-mantine-styles="classes"
+  >
+    @media (max-width: 35.99375em) {.mantine-visible-from-xs {display: none !important;}}@media (min-width: 36em) {.mantine-hidden-from-xs {display: none !important;}}@media (max-width: 47.99375em) {.mantine-visible-from-sm {display: none !important;}}@media (min-width: 48em) {.mantine-hidden-from-sm {display: none !important;}}@media (max-width: 61.99375em) {.mantine-visible-from-md {display: none !important;}}@media (min-width: 62em) {.mantine-hidden-from-md {display: none !important;}}@media (max-width: 74.99375em) {.mantine-visible-from-lg {display: none !important;}}@media (min-width: 75em) {.mantine-hidden-from-lg {display: none !important;}}@media (max-width: 87.99375em) {.mantine-visible-from-xl {display: none !important;}}@media (min-width: 88em) {.mantine-hidden-from-xl {display: none !important;}}
+  </style>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="m_46b77525 mantine-InputWrapper-root mantine-Select-root"
+        data-size="sm"
+      >
+        <div
+          class="m_6c018570 mantine-Input-wrapper mantine-Select-wrapper"
+          data-size="sm"
+          data-variant="default"
+          data-with-right-section="true"
+          style="--input-height: var(--input-height-sm); --input-fz: var(--mantine-font-size-sm); --input-right-section-pointer-events: none;"
+        >
+          <input
+            aria-haspopup="listbox"
+            aria-invalid="false"
+            autocomplete="off"
+            class="m_8fb7ebe7 mantine-Input-input mantine-Select-input"
+            data-variant="default"
+            id="root"
+            placeholder=""
+            value="Foo"
+          />
+          <div
+            class="m_82577fc2 mantine-Input-section mantine-Select-section"
+            data-position="right"
+          >
+            <svg
+              class="m_2943220b mantine-ComboboxChevron-chevron"
+              data-combobox-chevron="true"
+              fill="none"
+              viewBox="0 0 15 15"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M4.93179 5.43179C4.75605 5.60753 4.75605 5.89245 4.93179 6.06819C5.10753 6.24392 5.39245 6.24392 5.56819 6.06819L7.49999 4.13638L9.43179 6.06819C9.60753 6.24392 9.89245 6.24392 10.0682 6.06819C10.2439 5.89245 10.2439 5.60753 10.0682 5.43179L7.81819 3.18179C7.73379 3.0974 7.61933 3.04999 7.49999 3.04999C7.38064 3.04999 7.26618 3.0974 7.18179 3.18179L4.93179 5.43179ZM10.0682 9.56819C10.2439 9.39245 10.2439 9.10753 10.0682 8.93179C9.89245 8.75606 9.60753 8.75606 9.43179 8.93179L7.49999 10.8636L5.56819 8.93179C5.39245 8.75606 5.10753 8.75606 4.93179 8.93179C4.75605 9.10753 4.75605 9.39245 4.93179 9.56819L7.18179 11.8182C7.35753 11.9939 7.64245 11.9939 7.81819 11.8182L10.0682 9.56819Z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        class="m_38a85659 mantine-Popover-dropdown m_88b62a41 mantine-Select-dropdown"
+        data-composed="true"
+        data-position="bottom"
+        role="presentation"
+        style="display: none; z-index: 300; top: 0px; left: 0px; --combobox-option-fz: var(--mantine-font-size-sm); --combobox-option-padding: var(--combobox-option-padding-sm);"
+      >
+        <div
+          class="m_b2821a6e mantine-Select-options"
+          id="mantine-i"
+          role="listbox"
+          style="--combobox-option-fz: var(--mantine-font-size-sm); --combobox-option-padding: var(--combobox-option-padding-sm);"
+        >
+          <div
+            class=""
+            style="display: flex; overflow: hidden; max-height: calc(13.75rem * var(--mantine-scale));"
+          >
+            <div
+              class=""
+              style="display: flex; flex-direction: column; flex: 1 1 0%; overflow: hidden; min-width: 0px; min-height: 0px;"
+            >
+              <div
+                class="m_d57069b5 mantine-ScrollArea-root"
+                data-autosize="true"
+                style="--scrollarea-scrollbar-size: var(--combobox-padding); --sa-corner-width: 0px; --sa-corner-height: 0px;"
+              >
+                <div
+                  class="m_c0783ff9 mantine-ScrollArea-viewport"
+                  data-offset-scrollbars="y"
+                  data-scrollbars="xy"
+                  style="overflow-x: scroll; overflow-y: scroll;"
+                >
+                  <div
+                    class="m_b1336c6 mantine-ScrollArea-content"
+                  >
+                    <div
+                      aria-selected="true"
+                      class="m_92253aa5 mantine-Select-option m_390b5f4"
+                      data-checked="true"
+                      data-combobox-active="true"
+                      data-combobox-option="true"
+                      id=":rhk:"
+                      role="option"
+                      value="0"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="m_8ee53fc2"
+                        fill="none"
+                        viewBox="0 0 10 7"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M4 4.586L1.707 2.293A1 1 0 1 0 .293 3.707l3 3a.997.997 0 0 0 1.414 0l5-5A1 1 0 1 0 8.293.293L4 4.586z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                      <span>
+                        Foo
+                      </span>
+                    </div>
+                    <div
+                      aria-selected="false"
+                      class="m_92253aa5 mantine-Select-option m_390b5f4"
+                      data-combobox-option="true"
+                      id=":rhm:"
+                      role="option"
+                      value="1"
+                    >
+                      <span>
+                        Bar
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="m_c44ba933 mantine-ScrollArea-scrollbar"
+                  data-mantine-scrollbar="true"
+                  data-orientation="horizontal"
+                  data-state="hidden"
+                  style="position: absolute; --sa-thumb-width: 18px;"
+                />
+                <div
+                  class="m_c44ba933 mantine-ScrollArea-scrollbar"
+                  data-mantine-scrollbar="true"
+                  data-orientation="vertical"
+                  data-state="hidden"
+                  style="position: absolute; --sa-thumb-height: 18px;"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <input
+        name="root"
+        type="hidden"
+        value="0"
+      />
+      <p
+        class="mantine-focus-auto m_b6d8b162 mantine-Text-root"
+        id="root__description"
+        style="margin-top: calc(0.1875rem * var(--mantine-scale)); margin-bottom: var(--mantine-spacing-sm);"
+      >
+        Foo description
+      </p>
+    </div>
+    <button
+      class="mantine-focus-auto mantine-active m_77c9d27d mantine-Button-root m_87cf2631 mantine-UnstyledButton-root"
+      data-variant="filled"
+      style="--button-bg: var(--mantine-color-blue-filled); --button-hover: var(--mantine-color-blue-filled-hover); --button-color: var(--mantine-color-white); --button-bd: calc(0.0625rem * var(--mantine-scale)) solid transparent;"
+      type="submit"
+    >
+      <span
+        class="m_80f1301b mantine-Button-inner"
+      >
+        <span
+          class="m_811560b9 mantine-Button-label"
+        >
+          Submit
+        </span>
+      </span>
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <style
@@ -16443,10 +16636,10 @@ exports[`single fields > title field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rkl{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rlb{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rkl"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rlb"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div

--- a/packages/mantine/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mantine/test/__snapshots__/Form.test.tsx.snap
@@ -31,10 +31,10 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1fo{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1gd{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1fo"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1gd"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -68,7 +68,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1fv"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1gk"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -95,10 +95,10 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-r1g4{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                              .__m__-r1gp{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                             </style>
                             <div
-                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1g4"
+                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1gp"
                               style="margin-bottom: var(--mantine-spacing-sm);"
                             >
                               <div
@@ -321,7 +321,7 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1gr"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1hg"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -348,10 +348,10 @@ exports[`nameGenerator > bracketNameGenerator > array of objects 1`] = `
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-r1h0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                              .__m__-r1hl{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                             </style>
                             <div
-                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1h0"
+                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1hl"
                               style="margin-bottom: var(--mantine-spacing-sm);"
                             >
                               <div
@@ -672,10 +672,10 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1ec{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1f1{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ec"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1f1"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -709,7 +709,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1ej"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1f8"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -882,7 +882,7 @@ exports[`nameGenerator > bracketNameGenerator > array of strings 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1f3"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1fo"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -1151,10 +1151,10 @@ exports[`nameGenerator > bracketNameGenerator > checkboxes field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1jg{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1k5{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1jg"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1k5"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -1178,7 +1178,7 @@ exports[`nameGenerator > bracketNameGenerator > checkboxes field 1`] = `
                   role="group"
                 >
                   <div
-                    class="m_8bffd616 mantine-Flex-root __m__-r1jm"
+                    class="m_8bffd616 mantine-Flex-root __m__-r1kb"
                     style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
                   >
                     <div
@@ -1381,10 +1381,10 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1d5{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1dq{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1d5"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1dq"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -1410,10 +1410,10 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r1da{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r1dv{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1da"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1dv"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -1515,10 +1515,10 @@ exports[`nameGenerator > bracketNameGenerator > nested object 1`] = `
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r1dr{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r1eg{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1dr"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1eg"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -1659,10 +1659,10 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1io{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1jd{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1io"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1jd"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -1686,7 +1686,7 @@ exports[`nameGenerator > bracketNameGenerator > radio field 1`] = `
                   role="radiogroup"
                 >
                   <div
-                    class="m_8bffd616 mantine-Flex-root __m__-r1iv"
+                    class="m_8bffd616 mantine-Flex-root __m__-r1jk"
                     style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
                   >
                     <div
@@ -1840,10 +1840,10 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1hs{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1ih{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1hs"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ih"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -1943,7 +1943,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1if:"
+                              id=":r1j4:"
                               role="option"
                               value="0"
                             >
@@ -1955,7 +1955,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1ih:"
+                              id=":r1j6:"
                               role="option"
                               value="1"
                             >
@@ -1967,7 +1967,7 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1ij:"
+                              id=":r1j8:"
                               role="option"
                               value="2"
                             >
@@ -2057,10 +2057,10 @@ exports[`nameGenerator > bracketNameGenerator > simple fields 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1cb{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1d0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1cb"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1d0"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -2302,10 +2302,10 @@ exports[`nameGenerator > bracketNameGenerator > textarea field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1kd{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1l2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1kd"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1l2"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -2399,10 +2399,10 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1o5{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1oq{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1o5"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1oq"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -2436,7 +2436,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1oc"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1p1"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -2463,10 +2463,10 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-r1oh{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                              .__m__-r1p6{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                             </style>
                             <div
-                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1oh"
+                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1p6"
                               style="margin-bottom: var(--mantine-spacing-sm);"
                             >
                               <div
@@ -2689,7 +2689,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1p8"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1pt"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -2716,10 +2716,10 @@ exports[`nameGenerator > dotNotationNameGenerator > array of objects 1`] = `
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-r1pd{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                              .__m__-r1q2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                             </style>
                             <div
-                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1pd"
+                              class="m_2415a157 mantine-SimpleGrid-root __m__-r1q2"
                               style="margin-bottom: var(--mantine-spacing-sm);"
                             >
                               <div
@@ -3040,10 +3040,10 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1mp{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1ne{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1mp"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ne"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -3077,7 +3077,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1n0"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1nl"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -3250,7 +3250,7 @@ exports[`nameGenerator > dotNotationNameGenerator > array of strings 1`] = `
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1ng"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1o5"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -3519,10 +3519,10 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1li{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1m7{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1li"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1m7"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -3548,10 +3548,10 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r1ln{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r1mc{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1ln"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1mc"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -3653,10 +3653,10 @@ exports[`nameGenerator > dotNotationNameGenerator > nested object 1`] = `
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r1m8{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r1mt{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1m8"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1mt"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -3797,10 +3797,10 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1q9{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1qu{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1q9"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1qu"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -3900,7 +3900,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1qs:"
+                              id=":r1rh:"
                               role="option"
                               value="0"
                             >
@@ -3912,7 +3912,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1qu:"
+                              id=":r1rj:"
                               role="option"
                               value="1"
                             >
@@ -3924,7 +3924,7 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                               aria-selected="false"
                               class="m_92253aa5 mantine-Select-option m_390b5f4"
                               data-combobox-option="true"
-                              id=":r1r0:"
+                              id=":r1rl:"
                               role="option"
                               value="2"
                             >
@@ -4014,10 +4014,10 @@ exports[`nameGenerator > dotNotationNameGenerator > simple fields 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r1ko{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r1ld{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ko"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ld"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -4274,10 +4274,10 @@ exports[`single fields > Cyclic schema 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rn2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rnn{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rn2"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rnn"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -4310,10 +4310,10 @@ exports[`single fields > Cyclic schema 1`] = `
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rn8{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rnt{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rn8"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rnt"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -4939,7 +4939,7 @@ exports[`single fields > checkboxes field 1`] = `
           role="group"
         >
           <div
-            class="m_8bffd616 mantine-Flex-root __m__-rhu"
+            class="m_8bffd616 mantine-Flex-root __m__-rij"
             style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
           >
             <div
@@ -5605,10 +5605,10 @@ exports[`single fields > field with description 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rjq{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rkf{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rjq"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rkf"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -5712,10 +5712,10 @@ exports[`single fields > field with description in uiSchema 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rk6{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rkr{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rk6"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rkr"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -5819,10 +5819,10 @@ exports[`single fields > field with markdown description 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rki{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rl7{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rki"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rl7"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -5926,10 +5926,10 @@ exports[`single fields > field with markdown description in uiSchema 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rku{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rlj{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rku"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rlj"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -6516,10 +6516,10 @@ exports[`single fields > hidden field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rjl{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rka{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rjl"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rka"
           style="margin-bottom: var(--mantine-spacing-sm);"
         />
       </div>
@@ -6925,10 +6925,10 @@ exports[`single fields > optional data controls > does not show optional control
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rnk{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-ro9{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rnk"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-ro9"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -6954,10 +6954,10 @@ exports[`single fields > optional data controls > does not show optional control
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rnp{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-roe{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rnp"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-roe"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -7021,10 +7021,10 @@ exports[`single fields > optional data controls > does not show optional control
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-ro4{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-rop{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-ro4"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-rop"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -7092,10 +7092,10 @@ exports[`single fields > optional data controls > does not show optional control
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rof{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-rp4{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-rof"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-rp4"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -7455,10 +7455,10 @@ exports[`single fields > optional data controls > does not show optional control
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rpm{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rqb{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rpm"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rqb"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -7677,7 +7677,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 data-checked="true"
                                 data-combobox-active="true"
                                 data-combobox-option="true"
-                                id=":rqn:"
+                                id=":rrc:"
                                 role="option"
                                 value="0"
                               >
@@ -7703,7 +7703,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":rqp:"
+                                id=":rre:"
                                 role="option"
                                 value="1"
                               >
@@ -7715,7 +7715,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":rqr:"
+                                id=":rrg:"
                                 role="option"
                                 value="2"
                               >
@@ -7769,10 +7769,10 @@ exports[`single fields > optional data controls > does not show optional control
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rqv{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-rrk{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-rqv"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-rrk"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     >
                       <div
@@ -7924,7 +7924,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 data-checked="true"
                                 data-combobox-active="true"
                                 data-combobox-option="true"
-                                id=":rrp:"
+                                id=":rse:"
                                 role="option"
                                 value="0"
                               >
@@ -7950,7 +7950,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":rrr:"
+                                id=":rsg:"
                                 role="option"
                                 value="1"
                               >
@@ -7962,7 +7962,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":rrt:"
+                                id=":rsi:"
                                 role="option"
                                 value="2"
                               >
@@ -8129,10 +8129,10 @@ exports[`single fields > optional data controls > does not show optional control
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r138{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r13t{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r138"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r13t"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -8158,10 +8158,10 @@ exports[`single fields > optional data controls > does not show optional control
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r13d{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r142{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r13d"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r142"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -8228,10 +8228,10 @@ exports[`single fields > optional data controls > does not show optional control
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r13o{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r14d{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r13o"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r14d"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -8302,10 +8302,10 @@ exports[`single fields > optional data controls > does not show optional control
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r143{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r14o{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r143"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r14o"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -8676,10 +8676,10 @@ exports[`single fields > optional data controls > does not show optional control
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r15a{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r15v{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r15a"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r15v"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -8907,7 +8907,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 data-checked="true"
                                 data-combobox-active="true"
                                 data-combobox-option="true"
-                                id=":r16b:"
+                                id=":r170:"
                                 role="option"
                                 value="0"
                               >
@@ -8933,7 +8933,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":r16d:"
+                                id=":r172:"
                                 role="option"
                                 value="1"
                               >
@@ -8945,7 +8945,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":r16f:"
+                                id=":r174:"
                                 role="option"
                                 value="2"
                               >
@@ -9000,10 +9000,10 @@ exports[`single fields > optional data controls > does not show optional control
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r16j{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-r178{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-r16j"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-r178"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     >
                       <div
@@ -9159,7 +9159,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 data-checked="true"
                                 data-combobox-active="true"
                                 data-combobox-option="true"
-                                id=":r17d:"
+                                id=":r182:"
                                 role="option"
                                 value="0"
                               >
@@ -9185,7 +9185,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":r17f:"
+                                id=":r184:"
                                 role="option"
                                 value="1"
                               >
@@ -9197,7 +9197,7 @@ exports[`single fields > optional data controls > does not show optional control
                                 aria-selected="false"
                                 class="m_92253aa5 mantine-Select-option m_390b5f4"
                                 data-combobox-option="true"
-                                id=":r17h:"
+                                id=":r186:"
                                 role="option"
                                 value="2"
                               >
@@ -9367,10 +9367,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rul{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rva{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rul"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rva"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -9388,10 +9388,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rup{--grid-gutter:var(--mantine-spacing-md);}
+                  .__m__-rve{--grid-gutter:var(--mantine-spacing-md);}
                 </style>
                 <div
-                  class="m_410352e9 mantine-Grid-root __m__-rup"
+                  class="m_410352e9 mantine-Grid-root __m__-rve"
                 >
                   <div
                     class="m_dee7bd2f mantine-Grid-inner"
@@ -9399,10 +9399,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rur{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                      .__m__-rvg{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                     </style>
                     <div
-                      class="m_96bdd299 mantine-Grid-col __m__-rur"
+                      class="m_96bdd299 mantine-Grid-col __m__-rvg"
                     >
                       <h3
                         class="m_8a5d1357 mantine-Title-root"
@@ -9416,10 +9416,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-ruu{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                      .__m__-rvj{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                     </style>
                     <div
-                      class="m_96bdd299 mantine-Grid-col __m__-ruu"
+                      class="m_96bdd299 mantine-Grid-col __m__-rvj"
                     >
                       <button
                         class="mantine-focus-auto mantine-active rjsf-remove-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -9465,10 +9465,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rv2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rvn{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rv2"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rvn"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -9525,10 +9525,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rvc{--grid-gutter:var(--mantine-spacing-md);}
+                          .__m__-r101{--grid-gutter:var(--mantine-spacing-md);}
                         </style>
                         <div
-                          class="m_410352e9 mantine-Grid-root __m__-rvc"
+                          class="m_410352e9 mantine-Grid-root __m__-r101"
                         >
                           <div
                             class="m_dee7bd2f mantine-Grid-inner"
@@ -9536,10 +9536,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-rve{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                              .__m__-r103{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                             </style>
                             <div
-                              class="m_96bdd299 mantine-Grid-col __m__-rve"
+                              class="m_96bdd299 mantine-Grid-col __m__-r103"
                             >
                               <h3
                                 class="m_8a5d1357 mantine-Title-root"
@@ -9553,10 +9553,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                             <style
                               data-mantine-styles="inline"
                             >
-                              .__m__-rvh{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                              .__m__-r106{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                             </style>
                             <div
-                              class="m_96bdd299 mantine-Grid-col __m__-rvh"
+                              class="m_96bdd299 mantine-Grid-col __m__-r106"
                             >
                               <button
                                 class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -9602,10 +9602,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rvl{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r10a{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-rvl"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r10a"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         />
                       </div>
@@ -9634,10 +9634,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rvq{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r10f{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-rvq"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r10f"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -9771,10 +9771,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-r10b{--grid-gutter:var(--mantine-spacing-md);}
+                            .__m__-r110{--grid-gutter:var(--mantine-spacing-md);}
                           </style>
                           <div
-                            class="m_410352e9 mantine-Grid-root __m__-r10b"
+                            class="m_410352e9 mantine-Grid-root __m__-r110"
                           >
                             <div
                               class="m_dee7bd2f mantine-Grid-inner"
@@ -9782,10 +9782,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                               <style
                                 data-mantine-styles="inline"
                               >
-                                .__m__-r10d{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                                .__m__-r112{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                               </style>
                               <div
-                                class="m_96bdd299 mantine-Grid-col __m__-r10d"
+                                class="m_96bdd299 mantine-Grid-col __m__-r112"
                               >
                                 <h4
                                   class="m_8a5d1357 mantine-Title-root"
@@ -9799,10 +9799,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                               <style
                                 data-mantine-styles="inline"
                               >
-                                .__m__-r10g{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                                .__m__-r115{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                               </style>
                               <div
-                                class="m_96bdd299 mantine-Grid-col __m__-r10g"
+                                class="m_96bdd299 mantine-Grid-col __m__-r115"
                               >
                                 <button
                                   class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -9945,10 +9945,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                   <style
                     data-mantine-styles="inline"
                   >
-                    .__m__-r10u{--grid-gutter:var(--mantine-spacing-md);}
+                    .__m__-r11j{--grid-gutter:var(--mantine-spacing-md);}
                   </style>
                   <div
-                    class="m_410352e9 mantine-Grid-root __m__-r10u"
+                    class="m_410352e9 mantine-Grid-root __m__-r11j"
                   >
                     <div
                       class="m_dee7bd2f mantine-Grid-inner"
@@ -9956,10 +9956,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-r110{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                        .__m__-r11l{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                       </style>
                       <div
-                        class="m_96bdd299 mantine-Grid-col __m__-r110"
+                        class="m_96bdd299 mantine-Grid-col __m__-r11l"
                       >
                         <h4
                           class="m_8a5d1357 mantine-Title-root"
@@ -9973,10 +9973,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-r113{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                        .__m__-r11o{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                       </style>
                       <div
-                        class="m_96bdd299 mantine-Grid-col __m__-r113"
+                        class="m_96bdd299 mantine-Grid-col __m__-r11o"
                       >
                         <button
                           class="mantine-focus-auto mantine-active rjsf-remove-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -10028,7 +10028,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r119"
+                      class="m_8bffd616 mantine-Flex-root __m__-r11u"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -10194,10 +10194,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r11q{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r12f{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r11q"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r12f"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -10336,10 +10336,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r12c{--grid-gutter:var(--mantine-spacing-md);}
+                      .__m__-r131{--grid-gutter:var(--mantine-spacing-md);}
                     </style>
                     <div
-                      class="m_410352e9 mantine-Grid-root __m__-r12c"
+                      class="m_410352e9 mantine-Grid-root __m__-r131"
                     >
                       <div
                         class="m_dee7bd2f mantine-Grid-inner"
@@ -10347,10 +10347,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r12e{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                          .__m__-r133{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                         </style>
                         <div
-                          class="m_96bdd299 mantine-Grid-col __m__-r12e"
+                          class="m_96bdd299 mantine-Grid-col __m__-r133"
                         >
                           <h3
                             class="m_8a5d1357 mantine-Title-root"
@@ -10364,10 +10364,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r12h{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                          .__m__-r136{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                         </style>
                         <div
-                          class="m_96bdd299 mantine-Grid-col __m__-r12h"
+                          class="m_96bdd299 mantine-Grid-col __m__-r136"
                         >
                           <button
                             class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -10413,10 +10413,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r12l{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-r13a{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-r12l"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-r13a"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     />
                   </div>
@@ -10448,10 +10448,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-r12q{--grid-gutter:var(--mantine-spacing-md);}
+                        .__m__-r13f{--grid-gutter:var(--mantine-spacing-md);}
                       </style>
                       <div
-                        class="m_410352e9 mantine-Grid-root __m__-r12q"
+                        class="m_410352e9 mantine-Grid-root __m__-r13f"
                       >
                         <div
                           class="m_dee7bd2f mantine-Grid-inner"
@@ -10459,10 +10459,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-r12s{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                            .__m__-r13h{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                           </style>
                           <div
-                            class="m_96bdd299 mantine-Grid-col __m__-r12s"
+                            class="m_96bdd299 mantine-Grid-col __m__-r13h"
                           >
                             <h4
                               class="m_8a5d1357 mantine-Title-root"
@@ -10476,10 +10476,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-r12v{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                            .__m__-r13k{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                           </style>
                           <div
-                            class="m_96bdd299 mantine-Grid-col __m__-r12v"
+                            class="m_96bdd299 mantine-Grid-col __m__-r13k"
                           >
                             <button
                               class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -10593,10 +10593,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r199{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r19u{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r199"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r19u"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -10622,10 +10622,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r19e{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r1a3{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r19e"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1a3"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -10693,10 +10693,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r19p{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r1ae{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r19p"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1ae"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <em
@@ -10731,10 +10731,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-r19u{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                          .__m__-r1aj{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                         </style>
                         <div
-                          class="m_2415a157 mantine-SimpleGrid-root __m__-r19u"
+                          class="m_2415a157 mantine-SimpleGrid-root __m__-r1aj"
                           style="margin-bottom: var(--mantine-spacing-sm);"
                         >
                           <div
@@ -11000,7 +11000,7 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     style="margin-bottom: var(--mantine-spacing-xs);"
                   >
                     <div
-                      class="m_8bffd616 mantine-Flex-root __m__-r1at"
+                      class="m_8bffd616 mantine-Flex-root __m__-r1bi"
                       style="gap: var(--mantine-spacing-xs); align-items: end; justify-content: center;"
                     >
                       <div
@@ -11173,10 +11173,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r1be{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r1c3{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1be"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r1c3"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -11328,10 +11328,10 @@ exports[`single fields > optional data controls > shows "add" and "remove" optio
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r1c1{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-r1cm{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-r1c1"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-r1cm"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     >
                       <em
@@ -11451,10 +11451,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rs9{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rsu{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rs9"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rsu"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -11472,10 +11472,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rsd{--grid-gutter:var(--mantine-spacing-md);}
+                  .__m__-rt2{--grid-gutter:var(--mantine-spacing-md);}
                 </style>
                 <div
-                  class="m_410352e9 mantine-Grid-root __m__-rsd"
+                  class="m_410352e9 mantine-Grid-root __m__-rt2"
                 >
                   <div
                     class="m_dee7bd2f mantine-Grid-inner"
@@ -11483,10 +11483,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rsf{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                      .__m__-rt4{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                     </style>
                     <div
-                      class="m_96bdd299 mantine-Grid-col __m__-rsf"
+                      class="m_96bdd299 mantine-Grid-col __m__-rt4"
                     >
                       <h3
                         class="m_8a5d1357 mantine-Title-root"
@@ -11500,10 +11500,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rsi{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                      .__m__-rt7{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                     </style>
                     <div
-                      class="m_96bdd299 mantine-Grid-col __m__-rsi"
+                      class="m_96bdd299 mantine-Grid-col __m__-rt7"
                     >
                       <button
                         class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -11549,10 +11549,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rsm{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rtb{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rsm"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rtb"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 />
               </div>
@@ -11575,10 +11575,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                   <style
                     data-mantine-styles="inline"
                   >
-                    .__m__-rsq{--grid-gutter:var(--mantine-spacing-md);}
+                    .__m__-rtf{--grid-gutter:var(--mantine-spacing-md);}
                   </style>
                   <div
-                    class="m_410352e9 mantine-Grid-root __m__-rsq"
+                    class="m_410352e9 mantine-Grid-root __m__-rtf"
                   >
                     <div
                       class="m_dee7bd2f mantine-Grid-inner"
@@ -11586,10 +11586,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-rss{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                        .__m__-rth{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                       </style>
                       <div
-                        class="m_96bdd299 mantine-Grid-col __m__-rss"
+                        class="m_96bdd299 mantine-Grid-col __m__-rth"
                       >
                         <h4
                           class="m_8a5d1357 mantine-Title-root"
@@ -11603,10 +11603,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-rsv{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                        .__m__-rtk{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                       </style>
                       <div
-                        class="m_96bdd299 mantine-Grid-col __m__-rsv"
+                        class="m_96bdd299 mantine-Grid-col __m__-rtk"
                       >
                         <button
                           class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -11679,10 +11679,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-rt7{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-rts{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-rt7"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-rts"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -11821,10 +11821,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-rtp{--grid-gutter:var(--mantine-spacing-md);}
+                      .__m__-rue{--grid-gutter:var(--mantine-spacing-md);}
                     </style>
                     <div
-                      class="m_410352e9 mantine-Grid-root __m__-rtp"
+                      class="m_410352e9 mantine-Grid-root __m__-rue"
                     >
                       <div
                         class="m_dee7bd2f mantine-Grid-inner"
@@ -11832,10 +11832,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rtr{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                          .__m__-rug{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                         </style>
                         <div
-                          class="m_96bdd299 mantine-Grid-col __m__-rtr"
+                          class="m_96bdd299 mantine-Grid-col __m__-rug"
                         >
                           <h3
                             class="m_8a5d1357 mantine-Title-root"
@@ -11849,10 +11849,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                         <style
                           data-mantine-styles="inline"
                         >
-                          .__m__-rtu{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                          .__m__-ruj{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                         </style>
                         <div
-                          class="m_96bdd299 mantine-Grid-col __m__-rtu"
+                          class="m_96bdd299 mantine-Grid-col __m__-ruj"
                         >
                           <button
                             class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -11898,10 +11898,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-ru2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-run{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-ru2"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-run"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     />
                   </div>
@@ -11933,10 +11933,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                       <style
                         data-mantine-styles="inline"
                       >
-                        .__m__-ru7{--grid-gutter:var(--mantine-spacing-md);}
+                        .__m__-rus{--grid-gutter:var(--mantine-spacing-md);}
                       </style>
                       <div
-                        class="m_410352e9 mantine-Grid-root __m__-ru7"
+                        class="m_410352e9 mantine-Grid-root __m__-rus"
                       >
                         <div
                           class="m_dee7bd2f mantine-Grid-inner"
@@ -11944,10 +11944,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-ru9{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
+                            .__m__-ruu{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}
                           </style>
                           <div
-                            class="m_96bdd299 mantine-Grid-col __m__-ru9"
+                            class="m_96bdd299 mantine-Grid-col __m__-ruu"
                           >
                             <h4
                               class="m_8a5d1357 mantine-Title-root"
@@ -11961,10 +11961,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                           <style
                             data-mantine-styles="inline"
                           >
-                            .__m__-ruc{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
+                            .__m__-rv1{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}
                           </style>
                           <div
-                            class="m_96bdd299 mantine-Grid-col __m__-ruc"
+                            class="m_96bdd299 mantine-Grid-col __m__-rv1"
                           >
                             <button
                               class="mantine-focus-auto mantine-active rjsf-add-optional-data m_8d3f4000 mantine-ActionIcon-root m_87cf2631 mantine-UnstyledButton-root"
@@ -12078,10 +12078,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
         <style
           data-mantine-styles="inline"
         >
-          .__m__-r17t{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-r18i{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-r17t"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-r18i"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div
@@ -12107,10 +12107,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r182{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r18n{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r182"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r18n"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <em
@@ -12180,10 +12180,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                 <style
                   data-mantine-styles="inline"
                 >
-                  .__m__-r18b{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                  .__m__-r190{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                 </style>
                 <div
-                  class="m_2415a157 mantine-SimpleGrid-root __m__-r18b"
+                  class="m_2415a157 mantine-SimpleGrid-root __m__-r190"
                   style="margin-bottom: var(--mantine-spacing-sm);"
                 >
                   <div
@@ -12335,10 +12335,10 @@ exports[`single fields > optional data controls > shows "add" optional controls 
                     <style
                       data-mantine-styles="inline"
                     >
-                      .__m__-r18u{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+                      .__m__-r19j{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
                     </style>
                     <div
-                      class="m_2415a157 mantine-SimpleGrid-root __m__-r18u"
+                      class="m_2415a157 mantine-SimpleGrid-root __m__-r19j"
                       style="margin-bottom: var(--mantine-spacing-sm);"
                     >
                       <em
@@ -12551,7 +12551,7 @@ exports[`single fields > radio field 1`] = `
           role="radiogroup"
         >
           <div
-            class="m_8bffd616 mantine-Flex-root __m__-rit"
+            class="m_8bffd616 mantine-Flex-root __m__-rji"
             style="gap: var(--mantine-spacing-xs); flex-wrap: wrap; flex-direction: column; margin-top: var(--mantine-spacing-xs);"
           >
             <div
@@ -15570,6 +15570,192 @@ exports[`single fields > select widget with selected oneOf option description 1`
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description and hidden label 1`] = `
+<DocumentFragment>
+  <style
+    data-mantine-styles="true"
+  >
+    
+
+
+
+
+  </style>
+  <style
+    data-mantine-styles="classes"
+  >
+    @media (max-width: 35.99375em) {.mantine-visible-from-xs {display: none !important;}}@media (min-width: 36em) {.mantine-hidden-from-xs {display: none !important;}}@media (max-width: 47.99375em) {.mantine-visible-from-sm {display: none !important;}}@media (min-width: 48em) {.mantine-hidden-from-sm {display: none !important;}}@media (max-width: 61.99375em) {.mantine-visible-from-md {display: none !important;}}@media (min-width: 62em) {.mantine-hidden-from-md {display: none !important;}}@media (max-width: 74.99375em) {.mantine-visible-from-lg {display: none !important;}}@media (min-width: 75em) {.mantine-hidden-from-lg {display: none !important;}}@media (max-width: 87.99375em) {.mantine-visible-from-xl {display: none !important;}}@media (min-width: 88em) {.mantine-hidden-from-xl {display: none !important;}}
+  </style>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="m_46b77525 mantine-InputWrapper-root mantine-Select-root"
+        data-size="sm"
+      >
+        <div
+          class="m_6c018570 mantine-Input-wrapper mantine-Select-wrapper"
+          data-size="sm"
+          data-variant="default"
+          data-with-right-section="true"
+          style="--input-height: var(--input-height-sm); --input-fz: var(--mantine-font-size-sm); --input-right-section-pointer-events: none;"
+        >
+          <input
+            aria-haspopup="listbox"
+            aria-invalid="false"
+            autocomplete="off"
+            class="m_8fb7ebe7 mantine-Input-input mantine-Select-input"
+            data-variant="default"
+            id="root"
+            placeholder=""
+            value="Foo"
+          />
+          <div
+            class="m_82577fc2 mantine-Input-section mantine-Select-section"
+            data-position="right"
+          >
+            <svg
+              class="m_2943220b mantine-ComboboxChevron-chevron"
+              data-combobox-chevron="true"
+              fill="none"
+              viewBox="0 0 15 15"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M4.93179 5.43179C4.75605 5.60753 4.75605 5.89245 4.93179 6.06819C5.10753 6.24392 5.39245 6.24392 5.56819 6.06819L7.49999 4.13638L9.43179 6.06819C9.60753 6.24392 9.89245 6.24392 10.0682 6.06819C10.2439 5.89245 10.2439 5.60753 10.0682 5.43179L7.81819 3.18179C7.73379 3.0974 7.61933 3.04999 7.49999 3.04999C7.38064 3.04999 7.26618 3.0974 7.18179 3.18179L4.93179 5.43179ZM10.0682 9.56819C10.2439 9.39245 10.2439 9.10753 10.0682 8.93179C9.89245 8.75606 9.60753 8.75606 9.43179 8.93179L7.49999 10.8636L5.56819 8.93179C5.39245 8.75606 5.10753 8.75606 4.93179 8.93179C4.75605 9.10753 4.75605 9.39245 4.93179 9.56819L7.18179 11.8182C7.35753 11.9939 7.64245 11.9939 7.81819 11.8182L10.0682 9.56819Z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        class="m_38a85659 mantine-Popover-dropdown m_88b62a41 mantine-Select-dropdown"
+        data-composed="true"
+        data-position="bottom"
+        role="presentation"
+        style="display: none; z-index: 300; top: 0px; left: 0px; --combobox-option-fz: var(--mantine-font-size-sm); --combobox-option-padding: var(--combobox-option-padding-sm);"
+      >
+        <div
+          class="m_b2821a6e mantine-Select-options"
+          id="mantine-i"
+          role="listbox"
+          style="--combobox-option-fz: var(--mantine-font-size-sm); --combobox-option-padding: var(--combobox-option-padding-sm);"
+        >
+          <div
+            class=""
+            style="display: flex; overflow: hidden; max-height: calc(13.75rem * var(--mantine-scale));"
+          >
+            <div
+              class=""
+              style="display: flex; flex-direction: column; flex: 1 1 0%; overflow: hidden; min-width: 0px; min-height: 0px;"
+            >
+              <div
+                class="m_d57069b5 mantine-ScrollArea-root"
+                data-autosize="true"
+                style="--scrollarea-scrollbar-size: var(--combobox-padding); --sa-corner-width: 0px; --sa-corner-height: 0px;"
+              >
+                <div
+                  class="m_c0783ff9 mantine-ScrollArea-viewport"
+                  data-offset-scrollbars="y"
+                  data-scrollbars="xy"
+                  style="overflow-x: scroll; overflow-y: scroll;"
+                >
+                  <div
+                    class="m_b1336c6 mantine-ScrollArea-content"
+                  >
+                    <div
+                      aria-selected="true"
+                      class="m_92253aa5 mantine-Select-option m_390b5f4"
+                      data-checked="true"
+                      data-combobox-active="true"
+                      data-combobox-option="true"
+                      id=":ria:"
+                      role="option"
+                      value="0"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="m_8ee53fc2"
+                        fill="none"
+                        viewBox="0 0 10 7"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M4 4.586L1.707 2.293A1 1 0 1 0 .293 3.707l3 3a.997.997 0 0 0 1.414 0l5-5A1 1 0 1 0 8.293.293L4 4.586z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                      <span>
+                        Foo
+                      </span>
+                    </div>
+                    <div
+                      aria-selected="false"
+                      class="m_92253aa5 mantine-Select-option m_390b5f4"
+                      data-combobox-option="true"
+                      id=":ric:"
+                      role="option"
+                      value="1"
+                    >
+                      <span>
+                        Bar
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="m_c44ba933 mantine-ScrollArea-scrollbar"
+                  data-mantine-scrollbar="true"
+                  data-orientation="horizontal"
+                  data-state="hidden"
+                  style="position: absolute; --sa-thumb-width: 18px;"
+                />
+                <div
+                  class="m_c44ba933 mantine-ScrollArea-scrollbar"
+                  data-mantine-scrollbar="true"
+                  data-orientation="vertical"
+                  data-state="hidden"
+                  style="position: absolute; --sa-thumb-height: 18px;"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <input
+        name="root"
+        type="hidden"
+        value="0"
+      />
+    </div>
+    <button
+      class="mantine-focus-auto mantine-active m_77c9d27d mantine-Button-root m_87cf2631 mantine-UnstyledButton-root"
+      data-variant="filled"
+      style="--button-bg: var(--mantine-color-blue-filled); --button-hover: var(--mantine-color-blue-filled-hover); --button-color: var(--mantine-color-white); --button-bd: calc(0.0625rem * var(--mantine-scale)) solid transparent;"
+      type="submit"
+    >
+      <span
+        class="m_80f1301b mantine-Button-inner"
+      >
+        <span
+          class="m_811560b9 mantine-Button-label"
+        >
+          Submit
+        </span>
+      </span>
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <style
@@ -16636,10 +16822,10 @@ exports[`single fields > title field 1`] = `
         <style
           data-mantine-styles="inline"
         >
-          .__m__-rlb{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
+          .__m__-rm0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}
         </style>
         <div
-          class="m_2415a157 mantine-SimpleGrid-root __m__-rlb"
+          class="m_2415a157 mantine-SimpleGrid-root __m__-rm0"
           style="margin-bottom: var(--mantine-spacing-sm);"
         >
           <div

--- a/packages/mui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/mui/src/SelectWidget/SelectWidget.tsx
@@ -13,6 +13,7 @@ import {
   getOptionValueFormat,
   labelValue,
   logUnsupportedDefaultForEnum,
+  SelectedOptionDescription,
 } from '@rjsf/utils';
 
 import { getMuiProps } from '../util';
@@ -83,49 +84,52 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
   logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, isMultiple);
 
   return (
-    <TextField
-      id={id}
-      name={htmlName || id}
-      label={labelValue(label || undefined, hideLabel, undefined)}
-      value={enumOptionSelectedValue<S>(value, enumOptions, isMultiple, optionValueFormat, emptyValue)}
-      required={required}
-      disabled={disabled || readonly}
-      autoFocus={autofocus}
-      autoComplete={autocomplete}
-      placeholder={placeholder}
-      error={rawErrors.length > 0}
-      onChange={handleChange}
-      onBlur={handleBlur}
-      onFocus={handleFocus}
-      {...({ ...otherMuiProps, ...textFieldRemainingProps } as TextFieldProps)}
-      select // Apply this and the following props after the potential overrides defined in textFieldProps
-      slotProps={{
-        ...muiSlotProps,
-        inputLabel: {
-          ...muiSlotProps?.inputLabel,
-          shrink: !isEmpty,
-        },
-        select: {
-          ...muiSlotProps?.select,
-          multiple,
-        },
-      }}
-      aria-describedby={ariaDescribedByIds(id)}
-    >
-      {showPlaceholderOption && <MenuItem value=''>{placeholder}</MenuItem>}
-      {Array.isArray(enumOptions) &&
-        enumOptions.map(({ value: enumValue, label: enumLabel }, i: number) => {
-          const isDisabled: boolean = Array.isArray(enumDisabled) && enumDisabled.includes(enumValue);
-          return (
-            <MenuItem
-              key={String(enumValue)}
-              value={enumOptionValueEncoder(enumValue, i, optionValueFormat)}
-              disabled={isDisabled}
-            >
-              {enumLabel}
-            </MenuItem>
-          );
-        })}
-    </TextField>
+    <>
+      <TextField
+        id={id}
+        name={htmlName || id}
+        label={labelValue(label || undefined, hideLabel, undefined)}
+        value={enumOptionSelectedValue<S>(value, enumOptions, isMultiple, optionValueFormat, emptyValue)}
+        required={required}
+        disabled={disabled || readonly}
+        autoFocus={autofocus}
+        autoComplete={autocomplete}
+        placeholder={placeholder}
+        error={rawErrors.length > 0}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
+        {...({ ...otherMuiProps, ...textFieldRemainingProps } as TextFieldProps)}
+        select // Apply this and the following props after the potential overrides defined in textFieldProps
+        slotProps={{
+          ...muiSlotProps,
+          inputLabel: {
+            ...muiSlotProps?.inputLabel,
+            shrink: !isEmpty,
+          },
+          select: {
+            ...muiSlotProps?.select,
+            multiple,
+          },
+        }}
+        aria-describedby={ariaDescribedByIds(id)}
+      >
+        {showPlaceholderOption && <MenuItem value=''>{placeholder}</MenuItem>}
+        {Array.isArray(enumOptions) &&
+          enumOptions.map(({ value: enumValue, label: enumLabel }, i: number) => {
+            const isDisabled: boolean = Array.isArray(enumDisabled) && enumDisabled.includes(enumValue);
+            return (
+              <MenuItem
+                key={String(enumValue)}
+                value={enumOptionValueEncoder(enumValue, i, optionValueFormat)}
+                disabled={isDisabled}
+              >
+                {enumLabel}
+              </MenuItem>
+            );
+          })}
+      </TextField>
+      <SelectedOptionDescription {...props} />
+    </>
   );
 }

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -5245,7 +5245,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
                       aria-hidden="true"
                       aria-invalid="false"
                       class="MuiSelect-nativeInput emotion-8"
-                      id=":r6s:"
+                      id=":r70:"
                       name="root[color]"
                       placeholder=""
                       tabindex="-1"
@@ -10767,7 +10767,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
                       aria-hidden="true"
                       aria-invalid="false"
                       class="MuiSelect-nativeInput emotion-8"
-                      id=":r81:"
+                      id=":r85:"
                       name="root.color"
                       placeholder=""
                       tabindex="-1"
@@ -22816,7 +22816,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-128:focus::-ms-input
                           aria-hidden="true"
                           aria-invalid="false"
                           class="MuiSelect-nativeInput emotion-129"
-                          id=":r41:"
+                          id=":r45:"
                           name="root_optionalObjectWithOneofs__oneof_select"
                           tabindex="-1"
                           value="0"
@@ -22971,7 +22971,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-128:focus::-ms-input
                           aria-hidden="true"
                           aria-invalid="false"
                           class="MuiSelect-nativeInput emotion-129"
-                          id=":r45:"
+                          id=":r49:"
                           name="root_optionalArrayWithAnyofs__anyof_select"
                           tabindex="-1"
                           value="0"
@@ -24709,7 +24709,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-128:focus::-ms-input
                           aria-invalid="false"
                           class="MuiSelect-nativeInput emotion-129"
                           disabled=""
-                          id=":r5a:"
+                          id=":r5e:"
                           name="root_optionalObjectWithOneofs__oneof_select"
                           tabindex="-1"
                           value="0"
@@ -24865,7 +24865,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-128:focus::-ms-input
                           aria-invalid="false"
                           class="MuiSelect-nativeInput emotion-129"
                           disabled=""
-                          id=":r5e:"
+                          id=":r5i:"
                           name="root_optionalArrayWithAnyofs__anyof_select"
                           tabindex="-1"
                           value="0"
@@ -39307,6 +39307,515 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-4:focus::-ms-input-p
     >
       <button
         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-sizeMedium MuiButton-colorPrimary emotion-12"
+        tabindex="0"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields > select widget with selected oneOf option description 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.emotion-1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+}
+
+.emotion-2 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+}
+
+.emotion-2.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-2:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-2:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-2.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-width: 2px;
+}
+
+.emotion-2.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+}
+
+.emotion-2.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-2.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-3 {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  border-radius: 0;
+  cursor: pointer;
+  border-radius: 4px;
+  font: inherit;
+  letter-spacing: inherit;
+  color: currentColor;
+  padding: 4px 0 5px;
+  border: 0;
+  box-sizing: content-box;
+  background: none;
+  height: 1.4375em;
+  margin: 0;
+  -webkit-tap-highlight-color: transparent;
+  display: block;
+  min-width: 0;
+  width: 100%;
+  -webkit-animation-name: mui-auto-fill-cancel;
+  animation-name: mui-auto-fill-cancel;
+  -webkit-animation-duration: 10ms;
+  animation-duration: 10ms;
+  padding: 16.5px 14px;
+}
+
+.emotion-3:focus {
+  border-radius: 0;
+}
+
+.emotion-3.Mui-disabled {
+  cursor: default;
+}
+
+.emotion-3[multiple] {
+  height: auto;
+}
+
+.emotion-3:not([multiple]) option,
+.emotion-3:not([multiple]) optgroup {
+  background-color: #fff;
+}
+
+.emotion-3:focus {
+  border-radius: 4px;
+}
+
+.emotion-3.emotion-3.emotion-3 {
+  padding-right: 32px;
+}
+
+.emotion-3.MuiSelect-select {
+  height: auto;
+  min-height: 1.4375em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.emotion-3::-webkit-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3::-moz-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3::-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3:focus {
+  outline: 0;
+}
+
+.emotion-3:invalid {
+  box-shadow: none;
+}
+
+.emotion-3::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-webkit-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-moz-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-ms-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-webkit-input-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-moz-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-placeholder {
+  opacity: 0.42;
+}
+
+.emotion-3.Mui-disabled {
+  opacity: 1;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-3:-webkit-autofill {
+  -webkit-animation-duration: 5000s;
+  animation-duration: 5000s;
+  -webkit-animation-name: mui-auto-fill;
+  animation-name: mui-auto-fill;
+}
+
+.emotion-3:-webkit-autofill {
+  border-radius: inherit;
+}
+
+.emotion-4 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.emotion-5 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  fill: currentColor;
+  font-size: 1.5rem;
+  position: absolute;
+  right: 0;
+  top: calc(50% - .5em);
+  pointer-events: none;
+  color: rgba(0, 0, 0, 0.54);
+  right: 7px;
+}
+
+.emotion-5.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-6 {
+  text-align: left;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  top: -5px;
+  left: 0;
+  margin: 0;
+  padding: 0 8px;
+  pointer-events: none;
+  border-radius: inherit;
+  border-style: solid;
+  border-width: 1px;
+  overflow: hidden;
+  min-width: 0%;
+  border-color: rgba(0, 0, 0, 0.23);
+}
+
+.emotion-7 {
+  float: unset;
+  width: auto;
+  overflow: hidden;
+  padding: 0;
+  line-height: 11px;
+  -webkit-transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+}
+
+.emotion-8 {
+  margin: 0;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.57;
+  letter-spacing: 0.00714em;
+  margin-top: 5px;
+}
+
+.emotion-9 {
+  margin-top: 24px;
+}
+
+.emotion-10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border: 0;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: var(--variant-containedColor);
+  background-color: var(--variant-containedBg);
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  --variant-textColor: #1976d2;
+  --variant-outlinedColor: #1976d2;
+  --variant-outlinedBorder: rgba(25, 118, 210, 0.5);
+  --variant-containedColor: #fff;
+  --variant-containedBg: #1976d2;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-10::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-10.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-10 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-10:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-10.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-10:hover {
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-10:hover {
+    box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  }
+}
+
+.emotion-10:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-10.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-10.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+@media (hover: hover) {
+  .emotion-10:hover {
+    --variant-containedBg: #1565c0;
+    --variant-textBg: rgba(25, 118, 210, 0.04);
+    --variant-outlinedBorder: #1976d2;
+    --variant-outlinedBg: rgba(25, 118, 210, 0.04);
+  }
+}
+
+.emotion-10.MuiButton-loading {
+  color: transparent;
+}
+
+<form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+      >
+        <div
+          aria-describedby="root__error root__description root__help"
+          class="MuiFormControl-root MuiTextField-root emotion-1"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root emotion-2"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input emotion-3"
+              id="root"
+              role="combobox"
+              tabindex="0"
+            >
+              Foo
+            </div>
+            <input
+              aria-hidden="true"
+              aria-invalid="false"
+              class="MuiSelect-nativeInput emotion-4"
+              id=":r2t:"
+              name="root"
+              placeholder=""
+              tabindex="-1"
+              value="0"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon emotion-5"
+              data-testid="ArrowDropDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline emotion-6"
+            >
+              <legend
+                class="emotion-7"
+              >
+                <span
+                  aria-hidden="true"
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle2 emotion-8"
+          id="root__description"
+        >
+          Foo description
+        </h6>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root emotion-9"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-sizeMedium MuiButton-colorPrimary emotion-10"
         tabindex="0"
         type="submit"
       >

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -5245,7 +5245,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
                       aria-hidden="true"
                       aria-invalid="false"
                       class="MuiSelect-nativeInput emotion-8"
-                      id=":r70:"
+                      id=":r74:"
                       name="root[color]"
                       placeholder=""
                       tabindex="-1"
@@ -10767,7 +10767,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
                       aria-hidden="true"
                       aria-invalid="false"
                       class="MuiSelect-nativeInput emotion-8"
-                      id=":r85:"
+                      id=":r89:"
                       name="root.color"
                       placeholder=""
                       tabindex="-1"
@@ -22816,7 +22816,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-128:focus::-ms-input
                           aria-hidden="true"
                           aria-invalid="false"
                           class="MuiSelect-nativeInput emotion-129"
-                          id=":r45:"
+                          id=":r49:"
                           name="root_optionalObjectWithOneofs__oneof_select"
                           tabindex="-1"
                           value="0"
@@ -22971,7 +22971,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-128:focus::-ms-input
                           aria-hidden="true"
                           aria-invalid="false"
                           class="MuiSelect-nativeInput emotion-129"
-                          id=":r49:"
+                          id=":r4d:"
                           name="root_optionalArrayWithAnyofs__anyof_select"
                           tabindex="-1"
                           value="0"
@@ -24709,7 +24709,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-128:focus::-ms-input
                           aria-invalid="false"
                           class="MuiSelect-nativeInput emotion-129"
                           disabled=""
-                          id=":r5e:"
+                          id=":r5i:"
                           name="root_optionalObjectWithOneofs__oneof_select"
                           tabindex="-1"
                           value="0"
@@ -24865,7 +24865,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-128:focus::-ms-input
                           aria-invalid="false"
                           class="MuiSelect-nativeInput emotion-129"
                           disabled=""
-                          id=":r5i:"
+                          id=":r5m:"
                           name="root_optionalArrayWithAnyofs__anyof_select"
                           tabindex="-1"
                           value="0"
@@ -39816,6 +39816,499 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
     >
       <button
         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-sizeMedium MuiButton-colorPrimary emotion-10"
+        tabindex="0"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields > select widget with selected oneOf option description and hidden label 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.emotion-1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+}
+
+.emotion-2 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+}
+
+.emotion-2.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-2:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-2:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-2.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-width: 2px;
+}
+
+.emotion-2.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+}
+
+.emotion-2.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-2.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-3 {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  border-radius: 0;
+  cursor: pointer;
+  border-radius: 4px;
+  font: inherit;
+  letter-spacing: inherit;
+  color: currentColor;
+  padding: 4px 0 5px;
+  border: 0;
+  box-sizing: content-box;
+  background: none;
+  height: 1.4375em;
+  margin: 0;
+  -webkit-tap-highlight-color: transparent;
+  display: block;
+  min-width: 0;
+  width: 100%;
+  -webkit-animation-name: mui-auto-fill-cancel;
+  animation-name: mui-auto-fill-cancel;
+  -webkit-animation-duration: 10ms;
+  animation-duration: 10ms;
+  padding: 16.5px 14px;
+}
+
+.emotion-3:focus {
+  border-radius: 0;
+}
+
+.emotion-3.Mui-disabled {
+  cursor: default;
+}
+
+.emotion-3[multiple] {
+  height: auto;
+}
+
+.emotion-3:not([multiple]) option,
+.emotion-3:not([multiple]) optgroup {
+  background-color: #fff;
+}
+
+.emotion-3:focus {
+  border-radius: 4px;
+}
+
+.emotion-3.emotion-3.emotion-3 {
+  padding-right: 32px;
+}
+
+.emotion-3.MuiSelect-select {
+  height: auto;
+  min-height: 1.4375em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.emotion-3::-webkit-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3::-moz-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3::-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3:focus {
+  outline: 0;
+}
+
+.emotion-3:invalid {
+  box-shadow: none;
+}
+
+.emotion-3::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-webkit-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-moz-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-ms-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-webkit-input-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-moz-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-placeholder {
+  opacity: 0.42;
+}
+
+.emotion-3.Mui-disabled {
+  opacity: 1;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-3:-webkit-autofill {
+  -webkit-animation-duration: 5000s;
+  animation-duration: 5000s;
+  -webkit-animation-name: mui-auto-fill;
+  animation-name: mui-auto-fill;
+}
+
+.emotion-3:-webkit-autofill {
+  border-radius: inherit;
+}
+
+.emotion-4 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.emotion-5 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  fill: currentColor;
+  font-size: 1.5rem;
+  position: absolute;
+  right: 0;
+  top: calc(50% - .5em);
+  pointer-events: none;
+  color: rgba(0, 0, 0, 0.54);
+  right: 7px;
+}
+
+.emotion-5.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-6 {
+  text-align: left;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  top: -5px;
+  left: 0;
+  margin: 0;
+  padding: 0 8px;
+  pointer-events: none;
+  border-radius: inherit;
+  border-style: solid;
+  border-width: 1px;
+  overflow: hidden;
+  min-width: 0%;
+  border-color: rgba(0, 0, 0, 0.23);
+}
+
+.emotion-7 {
+  float: unset;
+  width: auto;
+  overflow: hidden;
+  padding: 0;
+  line-height: 11px;
+  -webkit-transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+}
+
+.emotion-8 {
+  margin-top: 24px;
+}
+
+.emotion-9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border: 0;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: var(--variant-containedColor);
+  background-color: var(--variant-containedBg);
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  --variant-textColor: #1976d2;
+  --variant-outlinedColor: #1976d2;
+  --variant-outlinedBorder: rgba(25, 118, 210, 0.5);
+  --variant-containedColor: #fff;
+  --variant-containedBg: #1976d2;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-9::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-9.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-9 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-9:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-9.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-9:hover {
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-9:hover {
+    box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  }
+}
+
+.emotion-9:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-9.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-9.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+@media (hover: hover) {
+  .emotion-9:hover {
+    --variant-containedBg: #1565c0;
+    --variant-textBg: rgba(25, 118, 210, 0.04);
+    --variant-outlinedBorder: #1976d2;
+    --variant-outlinedBg: rgba(25, 118, 210, 0.04);
+  }
+}
+
+.emotion-9.MuiButton-loading {
+  color: transparent;
+}
+
+<form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+      >
+        <div
+          aria-describedby="root__error root__description root__help"
+          class="MuiFormControl-root MuiTextField-root emotion-1"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root emotion-2"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input emotion-3"
+              id="root"
+              role="combobox"
+              tabindex="0"
+            >
+              Foo
+            </div>
+            <input
+              aria-hidden="true"
+              aria-invalid="false"
+              class="MuiSelect-nativeInput emotion-4"
+              id=":r31:"
+              name="root"
+              placeholder=""
+              tabindex="-1"
+              value="0"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon emotion-5"
+              data-testid="ArrowDropDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline emotion-6"
+            >
+              <legend
+                class="emotion-7"
+              >
+                <span
+                  aria-hidden="true"
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root emotion-8"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-sizeMedium MuiButton-colorPrimary emotion-9"
         tabindex="0"
         type="submit"
       >

--- a/packages/primereact/src/SelectWidget/SelectWidget.tsx
+++ b/packages/primereact/src/SelectWidget/SelectWidget.tsx
@@ -7,6 +7,7 @@ import {
   enumOptionValueEncoder,
   getOptionValueFormat,
   logUnsupportedDefaultForEnum,
+  SelectedOptionDescription,
 } from '@rjsf/utils';
 import { Dropdown } from 'primereact/dropdown';
 import { MultiSelect } from 'primereact/multiselect';
@@ -21,7 +22,12 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
 ) {
   const { multiple = false } = props;
 
-  return multiple ? <MultiSelectWidget {...props} /> : <SingleSelectWidget {...props} />;
+  return (
+    <>
+      {multiple ? <MultiSelectWidget {...props} /> : <SingleSelectWidget {...props} />}
+      <SelectedOptionDescription {...props} />
+    </>
+  );
 }
 
 function SingleSelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>({

--- a/packages/primereact/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/primereact/test/__snapshots__/Form.test.tsx.snap
@@ -9476,6 +9476,49 @@ exports[`single fields > select widget with description in schema and FieldTempl
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;"
+      >
+        <select
+          aria-describedby="root__error root__description root__help"
+          id="root"
+          name="root"
+          options="[object Object],[object Object]"
+          placeholder=""
+        />
+        <span
+          id="root__description"
+        >
+          Foo description
+        </span>
+      </div>
+    </div>
+    <button
+      aria-label="Submit"
+      class="p-button p-component"
+      data-pc-name="button"
+      data-pc-section="root"
+      type="submit"
+    >
+      <span
+        class="p-button-label p-c"
+        data-pc-section="label"
+      >
+        Submit
+      </span>
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <form

--- a/packages/primereact/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/primereact/test/__snapshots__/Form.test.tsx.snap
@@ -9519,6 +9519,44 @@ exports[`single fields > select widget with selected oneOf option description 1`
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description and hidden label 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;"
+      >
+        <select
+          aria-describedby="root__error root__description root__help"
+          id="root"
+          name="root"
+          options="[object Object],[object Object]"
+          placeholder=""
+        />
+      </div>
+    </div>
+    <button
+      aria-label="Submit"
+      class="p-button p-component"
+      data-pc-name="button"
+      data-pc-section="root"
+      type="submit"
+    >
+      <span
+        class="p-button-label p-c"
+        data-pc-section="label"
+      >
+        Submit
+      </span>
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <form

--- a/packages/react-bootstrap/src/SelectWidget/SelectWidget.tsx
+++ b/packages/react-bootstrap/src/SelectWidget/SelectWidget.tsx
@@ -7,6 +7,7 @@ import {
   enumOptionValueEncoder,
   getOptionValueFormat,
   logUnsupportedDefaultForEnum,
+  SelectedOptionDescription,
 } from '@rjsf/utils';
 import FormSelect from 'react-bootstrap/FormSelect';
 
@@ -30,6 +31,8 @@ export default function SelectWidget<
   onFocus,
   placeholder,
   rawErrors = [],
+  registry,
+  uiSchema,
 }: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled, emptyValue: optEmptyValue } = options;
 
@@ -50,49 +53,59 @@ export default function SelectWidget<
   logUnsupportedDefaultForEnum<S>(id, schema, enumOptions, multiple);
 
   return (
-    <FormSelect
-      id={id}
-      name={htmlName || id}
-      value={selectValue}
-      required={required}
-      multiple={multiple}
-      disabled={disabled || readonly}
-      autoFocus={autofocus}
-      className={rawErrors.length > 0 ? 'is-invalid' : ''}
-      onBlur={
-        onBlur &&
-        ((event: FocusEvent) => {
+    <>
+      <FormSelect
+        id={id}
+        name={htmlName || id}
+        value={selectValue}
+        required={required}
+        multiple={multiple}
+        disabled={disabled || readonly}
+        autoFocus={autofocus}
+        className={rawErrors.length > 0 ? 'is-invalid' : ''}
+        onBlur={
+          onBlur &&
+          ((event: FocusEvent) => {
+            const newValue = getValue(event, multiple);
+            onBlur(id, enumOptionValueDecoder<S>(newValue, enumOptions, optionValueFormat, optEmptyValue));
+          })
+        }
+        onFocus={
+          onFocus &&
+          ((event: FocusEvent) => {
+            const newValue = getValue(event, multiple);
+            onFocus(id, enumOptionValueDecoder<S>(newValue, enumOptions, optionValueFormat, optEmptyValue));
+          })
+        }
+        onChange={(event: ChangeEvent) => {
           const newValue = getValue(event, multiple);
-          onBlur(id, enumOptionValueDecoder<S>(newValue, enumOptions, optionValueFormat, optEmptyValue));
-        })
-      }
-      onFocus={
-        onFocus &&
-        ((event: FocusEvent) => {
-          const newValue = getValue(event, multiple);
-          onFocus(id, enumOptionValueDecoder<S>(newValue, enumOptions, optionValueFormat, optEmptyValue));
-        })
-      }
-      onChange={(event: ChangeEvent) => {
-        const newValue = getValue(event, multiple);
-        onChange(enumOptionValueDecoder<S>(newValue, enumOptions, optionValueFormat, optEmptyValue));
-      }}
-      aria-describedby={ariaDescribedByIds(id)}
-    >
-      {showPlaceholderOption && <option value=''>{placeholder}</option>}
-      {enumOptions?.map(({ value: enumValue, label: enumLabel }: any, i: number) => {
-        const isDisabled = Array.isArray(enumDisabled) && enumDisabled.includes(enumValue);
-        return (
-          <option
-            key={String(enumValue)}
-            id={enumLabel}
-            value={enumOptionValueEncoder(enumValue, i, optionValueFormat)}
-            disabled={isDisabled}
-          >
-            {enumLabel}
-          </option>
-        );
-      })}
-    </FormSelect>
+          onChange(enumOptionValueDecoder<S>(newValue, enumOptions, optionValueFormat, optEmptyValue));
+        }}
+        aria-describedby={ariaDescribedByIds(id)}
+      >
+        {showPlaceholderOption && <option value=''>{placeholder}</option>}
+        {enumOptions?.map(({ value: enumValue, label: enumLabel }: any, i: number) => {
+          const isDisabled = Array.isArray(enumDisabled) && enumDisabled.includes(enumValue);
+          return (
+            <option
+              key={String(enumValue)}
+              id={enumLabel}
+              value={enumOptionValueEncoder(enumValue, i, optionValueFormat)}
+              disabled={isDisabled}
+            >
+              {enumLabel}
+            </option>
+          );
+        })}
+      </FormSelect>
+      <SelectedOptionDescription
+        id={id}
+        multiple={multiple}
+        options={options}
+        registry={registry}
+        uiSchema={uiSchema}
+        value={value}
+      />
+    </>
   );
 }

--- a/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
@@ -9819,6 +9819,63 @@ exports[`single fields > select widget with description in schema and FieldTempl
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div>
+        <label
+          class="form-label"
+          for="root"
+        />
+        <select
+          aria-describedby="root__error root__description root__help"
+          class="form-select"
+          id="root"
+          name="root"
+        >
+          <option
+            value=""
+          />
+          <option
+            id="Foo"
+            value="0"
+          >
+            Foo
+          </option>
+          <option
+            id="Bar"
+            value="1"
+          >
+            Bar
+          </option>
+        </select>
+        <div>
+          <div
+            class="mb-3"
+            id="root__description"
+          >
+            Foo description
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <button
+        class="btn btn-primary"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <form

--- a/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
@@ -9876,6 +9876,51 @@ exports[`single fields > select widget with selected oneOf option description 1`
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description and hidden label 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div>
+        <select
+          aria-describedby="root__error root__description root__help"
+          class="form-select"
+          id="root"
+          name="root"
+        >
+          <option
+            value=""
+          />
+          <option
+            id="Foo"
+            value="0"
+          >
+            Foo
+          </option>
+          <option
+            id="Bar"
+            value="1"
+          >
+            Bar
+          </option>
+        </select>
+      </div>
+    </div>
+    <div>
+      <button
+        class="btn btn-primary"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <form

--- a/packages/semantic-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/semantic-ui/src/SelectWidget/SelectWidget.tsx
@@ -16,6 +16,7 @@ import {
   getOptionValueFormat,
   labelValue,
   logUnsupportedDefaultForEnum,
+  SelectedOptionDescription,
 } from '@rjsf/utils';
 import map from 'lodash/map';
 import type { DropdownProps, DropdownItemProps } from 'semantic-ui-react';
@@ -111,25 +112,28 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
   const handleFocus = (_: FocusEvent<HTMLElement>, { target }: DropdownProps) =>
     onFocus(id, enumOptionValueDecoder<S>(target?.value, enumOptions, optionValueFormat, optEmptyVal));
   return (
-    <Form.Dropdown
-      key={id}
-      id={id}
-      name={htmlName || id}
-      label={labelValue(label || undefined, hideLabel, false)}
-      multiple={typeof multiple === 'undefined' ? false : multiple}
-      value={enumOptionSelectedValue<S>(value, enumOptions, !!multiple, optionValueFormat, emptyValue)}
-      error={rawErrors.length > 0}
-      disabled={disabled}
-      placeholder={placeholder}
-      {...semanticProps}
-      required={required}
-      autoFocus={autofocus}
-      readOnly={readonly}
-      options={dropdownOptions}
-      onChange={handleChange}
-      onBlur={handleBlur}
-      onFocus={handleFocus}
-      aria-describedby={ariaDescribedByIds(id)}
-    />
+    <>
+      <Form.Dropdown
+        key={id}
+        id={id}
+        name={htmlName || id}
+        label={labelValue(label || undefined, hideLabel, false)}
+        multiple={typeof multiple === 'undefined' ? false : multiple}
+        value={enumOptionSelectedValue<S>(value, enumOptions, !!multiple, optionValueFormat, emptyValue)}
+        error={rawErrors.length > 0}
+        disabled={disabled}
+        placeholder={placeholder}
+        {...semanticProps}
+        required={required}
+        autoFocus={autofocus}
+        readOnly={readonly}
+        options={dropdownOptions}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
+        aria-describedby={ariaDescribedByIds(id)}
+      />
+      <SelectedOptionDescription {...props} />
+    </>
   );
 }

--- a/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
@@ -8018,6 +8018,107 @@ exports[`single fields > select widget with description in schema and FieldTempl
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description 1`] = `
+<DocumentFragment>
+  <form
+    class="ui form rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="grouped equal width fields"
+      >
+        <div
+          class="field"
+        >
+          <div
+            aria-describedby="root__error root__description root__help"
+            aria-disabled="false"
+            aria-expanded="false"
+            aria-multiselectable="false"
+            class="ui fluid selection scrolling dropdown"
+            id="root"
+            inverted="false"
+            name="root"
+            role="listbox"
+            tabindex="0"
+          >
+            <div
+              aria-atomic="true"
+              aria-live="polite"
+              class="divider text"
+              role="alert"
+            >
+              Foo
+            </div>
+            <i
+              aria-hidden="true"
+              class="dropdown icon"
+            />
+            <div
+              class="menu transition"
+            >
+              <div
+                aria-checked="false"
+                aria-selected="false"
+                class="item"
+                role="option"
+                style="pointer-events: all;"
+              >
+                <span
+                  class="text"
+                />
+              </div>
+              <div
+                aria-checked="true"
+                aria-disabled="false"
+                aria-selected="true"
+                class="active selected item"
+                role="option"
+                style="pointer-events: all;"
+              >
+                <span
+                  class="text"
+                >
+                  Foo
+                </span>
+              </div>
+              <div
+                aria-checked="false"
+                aria-disabled="false"
+                aria-selected="false"
+                class="item"
+                role="option"
+                style="pointer-events: all;"
+              >
+                <span
+                  class="text"
+                >
+                  Bar
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p
+          class="sui-description"
+          id="root__description"
+        >
+          Foo description
+        </p>
+      </div>
+    </div>
+    <button
+      class="ui primary button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <form

--- a/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
@@ -8119,6 +8119,101 @@ exports[`single fields > select widget with selected oneOf option description 1`
 </DocumentFragment>
 `;
 
+exports[`single fields > select widget with selected oneOf option description and hidden label 1`] = `
+<DocumentFragment>
+  <form
+    class="ui form rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="grouped equal width fields"
+      >
+        <div
+          class="field"
+        >
+          <div
+            aria-describedby="root__error root__description root__help"
+            aria-disabled="false"
+            aria-expanded="false"
+            aria-multiselectable="false"
+            class="ui fluid selection scrolling dropdown"
+            id="root"
+            inverted="false"
+            name="root"
+            role="listbox"
+            tabindex="0"
+          >
+            <div
+              aria-atomic="true"
+              aria-live="polite"
+              class="divider text"
+              role="alert"
+            >
+              Foo
+            </div>
+            <i
+              aria-hidden="true"
+              class="dropdown icon"
+            />
+            <div
+              class="menu transition"
+            >
+              <div
+                aria-checked="false"
+                aria-selected="false"
+                class="item"
+                role="option"
+                style="pointer-events: all;"
+              >
+                <span
+                  class="text"
+                />
+              </div>
+              <div
+                aria-checked="true"
+                aria-disabled="false"
+                aria-selected="true"
+                class="active selected item"
+                role="option"
+                style="pointer-events: all;"
+              >
+                <span
+                  class="text"
+                >
+                  Foo
+                </span>
+              </div>
+              <div
+                aria-checked="false"
+                aria-disabled="false"
+                aria-selected="false"
+                class="item"
+                role="option"
+                style="pointer-events: all;"
+              >
+                <span
+                  class="text"
+                >
+                  Bar
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <button
+      class="ui primary button"
+      type="submit"
+    >
+      Submit
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
 exports[`single fields > slider field 1`] = `
 <DocumentFragment>
   <form

--- a/packages/shadcn/src/SelectWidget/SelectWidget.tsx
+++ b/packages/shadcn/src/SelectWidget/SelectWidget.tsx
@@ -6,6 +6,7 @@ import {
   enumOptionValueEncoder,
   getOptionValueFormat,
   logUnsupportedDefaultForEnum,
+  SelectedOptionDescription,
 } from '@rjsf/utils';
 
 import { FancyMultiSelect } from '../components/ui/fancy-multi-select';
@@ -37,6 +38,8 @@ export default function SelectWidget<
   placeholder,
   rawErrors = [],
   className,
+  registry,
+  uiSchema,
 }: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled, emptyValue: optEmptyValue } = options;
   const optionValueFormat = getOptionValueFormat(options);
@@ -93,6 +96,14 @@ export default function SelectWidget<
           onBlur={handleFancyBlur}
         />
       )}
+      <SelectedOptionDescription
+        id={id}
+        multiple={multiple}
+        options={options}
+        registry={registry}
+        uiSchema={uiSchema}
+        value={value}
+      />
     </div>
   );
 }

--- a/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
@@ -1545,8 +1545,8 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                     >
                       <label
                         cmdk-label=""
-                        for="radix-:r1g:"
-                        id="radix-:r1f:"
+                        for="radix-:r1j:"
+                        id="radix-:r1i:"
                         style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
                       />
                       <button
@@ -3085,8 +3085,8 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                     >
                       <label
                         cmdk-label=""
-                        for="radix-:r1l:"
-                        id="radix-:r1k:"
+                        for="radix-:r1o:"
+                        id="radix-:r1n:"
                         style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
                       />
                       <button
@@ -5866,8 +5866,8 @@ exports[`single fields > optional data controls > does not show optional control
                         >
                           <label
                             cmdk-label=""
-                            for="radix-:r14:"
-                            id="radix-:r13:"
+                            for="radix-:r17:"
+                            id="radix-:r16:"
                             style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
                           />
                           <button
@@ -6012,8 +6012,8 @@ exports[`single fields > optional data controls > does not show optional control
                         >
                           <label
                             cmdk-label=""
-                            for="radix-:r17:"
-                            id="radix-:r16:"
+                            for="radix-:r1a:"
+                            id="radix-:r19:"
                             style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
                           />
                           <button
@@ -6950,8 +6950,8 @@ exports[`single fields > optional data controls > does not show optional control
                         >
                           <label
                             cmdk-label=""
-                            for="radix-:r1a:"
-                            id="radix-:r19:"
+                            for="radix-:r1d:"
+                            id="radix-:r1c:"
                             style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
                           />
                           <button
@@ -7097,8 +7097,8 @@ exports[`single fields > optional data controls > does not show optional control
                         >
                           <label
                             cmdk-label=""
-                            for="radix-:r1d:"
-                            id="radix-:r1c:"
+                            for="radix-:r1g:"
+                            id="radix-:r1f:"
                             style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
                           />
                           <button
@@ -11890,6 +11890,95 @@ exports[`single fields > select widget with description in schema and FieldTempl
             </div>
           </div>
         </span>
+      </div>
+    </div>
+    <div>
+      <button
+        class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3 my-2"
+        data-slot="button"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields > select widget with selected oneOf option description 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="flex flex-col gap-2"
+      >
+        <label
+          class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          for="root"
+        />
+        <div
+          class="p-0.5"
+        >
+          <div
+            aria-describedby="root__error root__description root__help"
+            aria-disabled="false"
+            class="text-popover-foreground flex h-full w-full flex-col rounded-md overflow-visible bg-transparent"
+            cmdk-root=""
+            data-slot="command"
+            tabindex="-1"
+          >
+            <label
+              cmdk-label=""
+              for="radix-:r12:"
+              id="radix-:r11:"
+              style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
+            />
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              class="flex h-9 w-full items-center justify-between gap-2 whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+              type="button"
+            >
+              <span
+                class="flex-1 line-clamp-1"
+              >
+                Foo
+              </span>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-down h-4 w-4 opacity-50"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m6 9 6 6 6-6"
+                />
+              </svg>
+            </button>
+            <div
+              class="relative"
+            />
+          </div>
+          <div>
+            <div
+              class="text-sm text-muted-foreground"
+              id="root__description"
+            >
+              Foo description
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div>

--- a/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
@@ -1545,8 +1545,8 @@ exports[`nameGenerator > bracketNameGenerator > select field with enum 1`] = `
                     >
                       <label
                         cmdk-label=""
-                        for="radix-:r1j:"
-                        id="radix-:r1i:"
+                        for="radix-:r1m:"
+                        id="radix-:r1l:"
                         style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
                       />
                       <button
@@ -3085,8 +3085,8 @@ exports[`nameGenerator > dotNotationNameGenerator > select field with enum 1`] =
                     >
                       <label
                         cmdk-label=""
-                        for="radix-:r1o:"
-                        id="radix-:r1n:"
+                        for="radix-:r1r:"
+                        id="radix-:r1q:"
                         style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
                       />
                       <button
@@ -5866,8 +5866,8 @@ exports[`single fields > optional data controls > does not show optional control
                         >
                           <label
                             cmdk-label=""
-                            for="radix-:r17:"
-                            id="radix-:r16:"
+                            for="radix-:r1a:"
+                            id="radix-:r19:"
                             style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
                           />
                           <button
@@ -6012,8 +6012,8 @@ exports[`single fields > optional data controls > does not show optional control
                         >
                           <label
                             cmdk-label=""
-                            for="radix-:r1a:"
-                            id="radix-:r19:"
+                            for="radix-:r1d:"
+                            id="radix-:r1c:"
                             style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
                           />
                           <button
@@ -6950,8 +6950,8 @@ exports[`single fields > optional data controls > does not show optional control
                         >
                           <label
                             cmdk-label=""
-                            for="radix-:r1d:"
-                            id="radix-:r1c:"
+                            for="radix-:r1g:"
+                            id="radix-:r1f:"
                             style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
                           />
                           <button
@@ -7097,8 +7097,8 @@ exports[`single fields > optional data controls > does not show optional control
                         >
                           <label
                             cmdk-label=""
-                            for="radix-:r1g:"
-                            id="radix-:r1f:"
+                            for="radix-:r1j:"
+                            id="radix-:r1i:"
                             style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
                           />
                           <button
@@ -11977,6 +11977,83 @@ exports[`single fields > select widget with selected oneOf option description 1`
             >
               Foo description
             </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <button
+        class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3 my-2"
+        data-slot="button"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`single fields > select widget with selected oneOf option description and hidden label 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="rjsf-field rjsf-field-string"
+    >
+      <div
+        class="flex flex-col gap-2"
+      >
+        <div
+          class="p-0.5"
+        >
+          <div
+            aria-describedby="root__error root__description root__help"
+            aria-disabled="false"
+            class="text-popover-foreground flex h-full w-full flex-col rounded-md overflow-visible bg-transparent"
+            cmdk-root=""
+            data-slot="command"
+            tabindex="-1"
+          >
+            <label
+              cmdk-label=""
+              for="radix-:r15:"
+              id="radix-:r14:"
+              style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
+            />
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              class="flex h-9 w-full items-center justify-between gap-2 whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+              type="button"
+            >
+              <span
+                class="flex-1 line-clamp-1"
+              >
+                Foo
+              </span>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-down h-4 w-4 opacity-50"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m6 9 6 6 6-6"
+                />
+              </svg>
+            </button>
+            <div
+              class="relative"
+            />
           </div>
         </div>
       </div>

--- a/packages/snapshot-tests/src/formTests.tsx
+++ b/packages/snapshot-tests/src/formTests.tsx
@@ -489,6 +489,17 @@ export function formTests(Form: ComponentType<FormProps>) {
       const { asFragment } = render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />);
       expect(asFragment()).toMatchSnapshot();
     });
+    test('select widget with selected oneOf option description', async () => {
+      const schema: RJSFSchema = {
+        type: 'string',
+        oneOf: [
+          { const: 'foo', title: 'Foo', description: 'Foo description' },
+          { const: 'bar', title: 'Bar', description: 'Bar description' },
+        ],
+      };
+      const { asFragment } = render(<Form schema={schema} formData='foo' validator={validator} />);
+      expect(asFragment()).toMatchSnapshot();
+    });
     test('checkboxes field', async () => {
       const schema: RJSFSchema = {
         type: 'array',

--- a/packages/snapshot-tests/src/formTests.tsx
+++ b/packages/snapshot-tests/src/formTests.tsx
@@ -500,6 +500,22 @@ export function formTests(Form: ComponentType<FormProps>) {
       const { asFragment } = render(<Form schema={schema} formData='foo' validator={validator} />);
       expect(asFragment()).toMatchSnapshot();
     });
+    test('select widget with selected oneOf option description and hidden label', async () => {
+      const schema: RJSFSchema = {
+        type: 'string',
+        oneOf: [
+          { const: 'foo', title: 'Foo', description: 'Foo description' },
+          { const: 'bar', title: 'Bar', description: 'Bar description' },
+        ],
+      };
+      const uiSchema: UiSchema = {
+        'ui:options': {
+          label: false,
+        },
+      };
+      const { asFragment } = render(<Form schema={schema} formData='foo' uiSchema={uiSchema} validator={validator} />);
+      expect(asFragment()).toMatchSnapshot();
+    });
     test('checkboxes field', async () => {
       const schema: RJSFSchema = {
         type: 'array',

--- a/packages/utils/src/SelectedOptionDescription.tsx
+++ b/packages/utils/src/SelectedOptionDescription.tsx
@@ -1,5 +1,6 @@
 import enumOptionsIsSelected from './enumOptionsIsSelected';
 import getTemplate from './getTemplate';
+import getUiOptions from './getUiOptions';
 import { descriptionId } from './idGenerators';
 import type { FormContextType, RJSFSchema, StrictRJSFSchema, WidgetProps } from './types';
 
@@ -7,15 +8,20 @@ type SelectedOptionDescriptionProps<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
-> = Pick<WidgetProps<T, S, F>, 'id' | 'multiple' | 'options' | 'registry' | 'uiSchema' | 'value'>;
+> = Pick<WidgetProps<T, S, F>, 'id' | 'multiple' | 'options' | 'registry' | 'uiSchema' | 'value' | 'hideLabel'>;
 
 /** Renders the description associated with the selected oneOf or anyOf option in a single-select widget. */
 export default function SelectedOptionDescription<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
->({ id, multiple, options, registry, uiSchema, value }: SelectedOptionDescriptionProps<T, S, F>) {
-  if (multiple) {
+>({ hideLabel, id, multiple, options, registry, uiSchema, value }: SelectedOptionDescriptionProps<T, S, F>) {
+  if (multiple || hideLabel) {
+    return null;
+  }
+
+  const { label = true } = getUiOptions<T, S, F>(uiSchema, registry.globalUiOptions);
+  if (!label) {
     return null;
   }
 

--- a/packages/utils/src/SelectedOptionDescription.tsx
+++ b/packages/utils/src/SelectedOptionDescription.tsx
@@ -1,0 +1,42 @@
+import enumOptionsIsSelected from './enumOptionsIsSelected';
+import getTemplate from './getTemplate';
+import { descriptionId } from './idGenerators';
+import type { FormContextType, RJSFSchema, StrictRJSFSchema, WidgetProps } from './types';
+
+type SelectedOptionDescriptionProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+> = Pick<WidgetProps<T, S, F>, 'id' | 'multiple' | 'options' | 'registry' | 'uiSchema' | 'value'>;
+
+/** Renders the description associated with the selected oneOf or anyOf option in a single-select widget. */
+export default function SelectedOptionDescription<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+>({ id, multiple, options, registry, uiSchema, value }: SelectedOptionDescriptionProps<T, S, F>) {
+  if (multiple) {
+    return null;
+  }
+
+  const option = options.enumOptions?.find(({ value: enumValue }) => enumOptionsIsSelected(enumValue, value));
+  const description = option?.schema?.description;
+  if (!description) {
+    return null;
+  }
+
+  const DescriptionFieldTemplate = getTemplate<'DescriptionFieldTemplate', T, S, F>(
+    'DescriptionFieldTemplate',
+    registry,
+    options,
+  );
+  return (
+    <DescriptionFieldTemplate
+      id={descriptionId(id)}
+      description={description}
+      schema={option.schema!}
+      uiSchema={uiSchema}
+      registry={registry}
+    />
+  );
+}

--- a/packages/utils/src/SelectedOptionDescription.tsx
+++ b/packages/utils/src/SelectedOptionDescription.tsx
@@ -4,7 +4,7 @@ import getUiOptions from './getUiOptions';
 import { descriptionId } from './idGenerators';
 import type { FormContextType, RJSFSchema, StrictRJSFSchema, WidgetProps } from './types';
 
-type SelectedOptionDescriptionProps<
+export type SelectedOptionDescriptionProps<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -68,6 +68,7 @@ import replaceStringParameters from './replaceStringParameters';
 import resolveUiSchema from './resolveUiSchema';
 import schemaRequiresTrueValue from './schemaRequiresTrueValue';
 import SelectedOptionDescription from './SelectedOptionDescription';
+import type { SelectedOptionDescriptionProps } from './SelectedOptionDescription';
 import shallowEquals from './shallowEquals';
 import type { ComponentUpdateStrategy } from './shouldRender';
 import shouldRender from './shouldRender';
@@ -100,6 +101,7 @@ export type {
   DateElementProp,
   DateElementProps,
   FileInfoType,
+  SelectedOptionDescriptionProps,
   UseAltDateWidgetResult,
   UseFileWidgetPropsResult,
 };

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -67,6 +67,7 @@ import removeOptionalEmptyObjects from './removeOptionalEmptyObjects';
 import replaceStringParameters from './replaceStringParameters';
 import resolveUiSchema from './resolveUiSchema';
 import schemaRequiresTrueValue from './schemaRequiresTrueValue';
+import SelectedOptionDescription from './SelectedOptionDescription';
 import shallowEquals from './shallowEquals';
 import type { ComponentUpdateStrategy } from './shouldRender';
 import shouldRender from './shouldRender';
@@ -172,6 +173,7 @@ export {
   replaceStringParameters,
   resolveUiSchema,
   schemaRequiresTrueValue,
+  SelectedOptionDescription,
   shallowEquals,
   shouldRender,
   shouldRenderOptionalField,

--- a/packages/utils/test/SelectedOptionDescription.test.tsx
+++ b/packages/utils/test/SelectedOptionDescription.test.tsx
@@ -32,15 +32,16 @@ const baseProps: Pick<WidgetProps, 'id' | 'multiple' | 'options' | 'registry' | 
 describe('SelectedOptionDescription', () => {
   it('renders the selected option description with its schema', () => {
     const { container } = render(<SelectedOptionDescription {...baseProps} />);
+    const description = container.querySelector('#root__description');
 
-    expect(container.querySelector('#root__description')).toHaveTextContent('Foo description');
-    expect(container.querySelector('#root__description')).toHaveAttribute('data-schema-title', 'Foo');
+    expect(description?.textContent).toBe('Foo description');
+    expect(description?.getAttribute('data-schema-title')).toBe('Foo');
   });
 
   it('does not render for multiple selects', () => {
     const { container } = render(<SelectedOptionDescription {...baseProps} multiple />);
 
-    expect(container).toBeEmptyDOMElement();
+    expect(container.innerHTML).toBe('');
   });
 
   it.each([
@@ -54,6 +55,6 @@ describe('SelectedOptionDescription', () => {
   ])('does not render with %s', (_, options) => {
     const { container } = render(<SelectedOptionDescription {...baseProps} options={options} />);
 
-    expect(container).toBeEmptyDOMElement();
+    expect(container.innerHTML).toBe('');
   });
 });

--- a/packages/utils/test/SelectedOptionDescription.test.tsx
+++ b/packages/utils/test/SelectedOptionDescription.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 
-import type { DescriptionFieldProps, Registry, RJSFSchema, WidgetProps } from '../src';
+import type { DescriptionFieldProps, Registry, RJSFSchema, SelectedOptionDescriptionProps } from '../src';
 import { SelectedOptionDescription } from '../src';
 
 function DescriptionFieldTemplate({ id, description, schema }: DescriptionFieldProps) {
@@ -15,7 +15,7 @@ const registry = {
   templates: { DescriptionFieldTemplate },
 } as unknown as Registry;
 
-const baseProps: Pick<WidgetProps, 'id' | 'multiple' | 'options' | 'registry' | 'uiSchema' | 'value'> = {
+const baseProps: SelectedOptionDescriptionProps = {
   id: 'root',
   multiple: false,
   options: {

--- a/packages/utils/test/SelectedOptionDescription.test.tsx
+++ b/packages/utils/test/SelectedOptionDescription.test.tsx
@@ -44,6 +44,22 @@ describe('SelectedOptionDescription', () => {
     expect(container.innerHTML).toBe('');
   });
 
+  it('does not render when hideLabel is true', () => {
+    const { container } = render(<SelectedOptionDescription {...{ ...baseProps, hideLabel: true }} />);
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it.each([
+    ['ui:options label', { ...baseProps, uiSchema: { 'ui:options': { label: false } } }],
+    ['ui:label', { ...baseProps, uiSchema: { 'ui:label': false } }],
+    ['global ui options label', { ...baseProps, registry: { ...registry, globalUiOptions: { label: false } } }],
+  ])('does not render when %s is false', (_, props) => {
+    const { container } = render(<SelectedOptionDescription {...props} />);
+
+    expect(container.innerHTML).toBe('');
+  });
+
   it.each([
     ['no enum options', {}],
     ['no matching option', { enumOptions: [{ value: 'bar', label: 'Bar' }] }],

--- a/packages/utils/test/SelectedOptionDescription.test.tsx
+++ b/packages/utils/test/SelectedOptionDescription.test.tsx
@@ -1,0 +1,59 @@
+import { render } from '@testing-library/react';
+
+import type { DescriptionFieldProps, Registry, RJSFSchema, WidgetProps } from '../src';
+import { SelectedOptionDescription } from '../src';
+
+function DescriptionFieldTemplate({ id, description, schema }: DescriptionFieldProps) {
+  return (
+    <div id={id} data-schema-title={schema.title}>
+      {description}
+    </div>
+  );
+}
+
+const registry = {
+  templates: { DescriptionFieldTemplate },
+} as unknown as Registry;
+
+const baseProps: Pick<WidgetProps, 'id' | 'multiple' | 'options' | 'registry' | 'uiSchema' | 'value'> = {
+  id: 'root',
+  multiple: false,
+  options: {
+    enumOptions: [
+      { value: 'foo', label: 'Foo', schema: { title: 'Foo', description: 'Foo description' } },
+      { value: 'bar', label: 'Bar', schema: { title: 'Bar', description: 'Bar description' } },
+    ],
+  },
+  registry,
+  uiSchema: {},
+  value: 'foo',
+};
+
+describe('SelectedOptionDescription', () => {
+  it('renders the selected option description with its schema', () => {
+    const { container } = render(<SelectedOptionDescription {...baseProps} />);
+
+    expect(container.querySelector('#root__description')).toHaveTextContent('Foo description');
+    expect(container.querySelector('#root__description')).toHaveAttribute('data-schema-title', 'Foo');
+  });
+
+  it('does not render for multiple selects', () => {
+    const { container } = render(<SelectedOptionDescription {...baseProps} multiple />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it.each([
+    ['no enum options', {}],
+    ['no matching option', { enumOptions: [{ value: 'bar', label: 'Bar' }] }],
+    ['an option without a schema', { enumOptions: [{ value: 'foo', label: 'Foo' }] }],
+    [
+      'an option schema without a description',
+      { enumOptions: [{ value: 'foo', label: 'Foo', schema: { title: 'Foo' } as RJSFSchema }] },
+    ],
+  ])('does not render with %s', (_, options) => {
+    const { container } = render(<SelectedOptionDescription {...baseProps} options={options} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
Select widgets did not render the description attached to the selected `oneOf` or `anyOf` enum option, so changing the dropdown left no option-specific guidance. This adds a shared selected-option description renderer and uses it in all 12 core and theme SelectWidget implementations while leaving multi-selects unchanged. Fixes #4214
