### PR TITLE
Fix 5149: populate = never omits no-minItems arrays and fills minItems arrays with null in getDefaultFormState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `omitExtraData()` to better handle `allOf`s containing multiple `if/then/else` blocks, matching fix in `SJSF`, fixing [#5142](https://github.com/rjsf-team/react-jsonschema-form/issues/5142)
 - Fixed `optionsList()` to preserve an explicitly empty string `title` on `oneOf`/`anyOf` options instead of falling back to the option's value, fixing [#4448](https://github.com/rjsf-team/react-jsonschema-form/issues/4448)
 - Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
+- Fixed `getDefaultFormState()` so that optional array defaults are not initialized when `experimental_defaultFormStateBehavior.arrayMinItems.populate = never`, fixing [#5149](https://github.com/rjsf-team/react-jsonschema-form/issues/5149)
 
 ## @rjsf/validator-ajv8
 

--- a/packages/docs/docs/migration-guides/v6.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v6.x upgrade guide.md
@@ -877,6 +877,16 @@ This change fixes [#4709](https://github.com/rjsf-team/react-jsonschema-form/iss
 
 **Impact**: If your application was incorrectly relying on undefined primitive fields becoming `{}` objects, you may need to update your form validation or data processing logic to handle proper primitive values or `undefined` instead.
 
+#### Optional array defaulting (POTENTIAL)
+
+A bug fix was implemented that changes how optional arrays are initialized during the `formData` defaulting phase.
+
+**Previous (buggy) behavior**: Optional arrays were initialized to `[]`.
+
+**New (correct) behavior**: Optional arrays are no longer initialized.
+
+**Impact**: If your application was incorrectly relying on optional arrays being initialized this way, you may need to update it to handle the corrected behavior.
+
 #### SchemaField removed Bootstrap 3 classes
 
 In fixing [#2280](https://github.com/rjsf-team/react-jsonschema-form/issues/2280), the following `Bootstrap 3` classes

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -716,7 +716,16 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
     }
   }
 
+  const defaultsLength = Array.isArray(defaults) ? defaults.length : 0;
+
   if (neverPopulate) {
+    if (shouldMergeDefaultsIntoFormData) {
+      if (schema.minItems && schema.minItems > defaultsLength) {
+        const fillerEntries = Array.from({ length: schema.minItems - defaultsLength }, () => null) as T[];
+        return (defaults ?? []).concat(fillerEntries);
+      }
+      return defaults;
+    }
     return defaults ?? emptyDefault;
   }
   if (ignoreMinItemsFlagSet && !required) {
@@ -726,7 +735,6 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
   }
 
   let arrayDefault: T[] | undefined;
-  const defaultsLength = Array.isArray(defaults) ? defaults.length : 0;
   if (
     !schema.minItems ||
     isMultiSelect<T, S, F>(validator, schema, rootSchema, experimental_customMergeAllOf) ||

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -2165,6 +2165,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           ).toEqual(expected);
         });
       });
+
       describe('an invalid array schema', () => {
         const schema: RJSFSchema = {
           type: 'array',
@@ -2346,6 +2347,90 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
               }),
             ).toBeUndefined();
           });
+        });
+      });
+
+      describe('optional array with arrayMinItems.populate = never', () => {
+        test('optional array with arrayMinItems.populate = never, no form data', () => {
+          const schema: RJSFSchema = {
+            type: 'object',
+            properties: {
+              array: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+              minItemsArray: {
+                type: 'array',
+                minItems: 1,
+                items: {
+                  type: 'string',
+                },
+              },
+            },
+          };
+          const defaultFormStateBehavior: Experimental_DefaultFormStateBehavior = {
+            arrayMinItems: { populate: 'never' },
+          };
+
+          expect(
+            getDefaultFormState(testValidator, schema, undefined, undefined, undefined, defaultFormStateBehavior),
+          ).toEqual({
+            minItemsArray: [null],
+          });
+        });
+
+        test('optional array with arrayMinItems.populate = never preserves short formData as-is', () => {
+          const schema: RJSFSchema = {
+            type: 'object',
+            properties: {
+              minItemsArray: {
+                type: 'array',
+                minItems: 2,
+                items: { type: 'string' },
+              },
+            },
+          };
+          const defaultFormStateBehavior: Experimental_DefaultFormStateBehavior = {
+            arrayMinItems: { populate: 'never' },
+          };
+          expect(
+            getDefaultFormState(
+              testValidator,
+              schema,
+              { minItemsArray: ['foo'] },
+              undefined,
+              undefined,
+              defaultFormStateBehavior,
+            ),
+          ).toEqual({ minItemsArray: ['foo'] });
+        });
+
+        test('optional array with arrayMinItems.populate = never preserves formData that already meets minItems', () => {
+          const schema: RJSFSchema = {
+            type: 'object',
+            properties: {
+              minItemsArray: {
+                type: 'array',
+                minItems: 2,
+                items: { type: 'string' },
+              },
+            },
+          };
+          const defaultFormStateBehavior: Experimental_DefaultFormStateBehavior = {
+            arrayMinItems: { populate: 'never' },
+          };
+          expect(
+            getDefaultFormState(
+              testValidator,
+              schema,
+              { minItemsArray: ['foo', 'bar'] },
+              undefined,
+              undefined,
+              defaultFormStateBehavior,
+            ),
+          ).toEqual({ minItemsArray: ['foo', 'bar'] });
         });
       });
     });


### PR DESCRIPTION
### Reasons for making this change

Fixes #5149 - When `experimental_defaultFormStateBehavior.arrayMinItems.populate` is set to `'never'`, `getDefaultFormState()` has bugs:
- Optional arrays with no `minItems` were incorrectly initialized to `[]` instead of being omitted from the result entirely.
- Arrays with `minItems` were initialized to `[]` instead of being filled with `null` entries up to their minimum count.

Fix: in `getArrayDefaults`, when both `neverPopulate` and `shouldMergeDefaultsIntoFormData` are true (the path taken by`getDefaultFormState`):
- Return `undefined` for arrays with no `minItems` and no existing formData/defaults, so `maybeAddDefaultToObject` omits the key.
- Fill arrays that have `minItems > current length` with `null` entries up to that minimum, without computing item defaults from the schema.
- Additionally documents the optional-array defaulting change in the v6.x upgrade guide.
- Updated `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
