### PR TITLE
Fix 4266: compute full nested defaults for additionalProperties $ref on Add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `processPendingChange` so that clearing a string field that has a schema `default` value no longer re-applies the default, fixing [#5125](https://github.com/rjsf-team/react-jsonschema-form/issues/5125)
 - Fixed a regression introduced in [#5136](https://github.com/rjsf-team/react-jsonschema-form/pull/5136) where clearing a second field caused a previously-cleared field to be re-populated with its schema default; uses `JSON.parse(JSON.stringify(...))` to strip `undefined`-valued keys from formData before AJV validation so that the [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix is preserved
 - Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
+- Fixed `ObjectField`'s "Add" button for `additionalProperties` schemas containing a `$ref` so the new item's default value is computed via `getDefaultFormState()` against the fully-resolved referenced schema (recursively populating nested defaults) instead of only reading the resolved schema's own top-level `default`, which discarded the sibling `default` and any nested property defaults, fixing [#4266](https://github.com/rjsf-team/react-jsonschema-form/issues/4266)
 
 ## @rjsf/daisyui
 
@@ -2468,7 +2469,7 @@ Move theme snapshot tests into separate package
 - However, if users of @rjsf/antd want to use v5 styling, they need to wrap your application with the `StyleProvider` from `@ant-design/cssinjs`. They need not have to install this package, its a transitive package coming from antd.
 
 ```tsx
-import { StyleProvider } from "@ant-design/cssinjs";
+import { StyleProvider } from '@ant-design/cssinjs';
 
 const Component = () => {
   return (

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -292,7 +292,7 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
           apSchema = schemaUtils.retrieveSchema({ [REF_KEY]: apSchema[REF_KEY] } as S, formData);
           type = apSchema.type;
           constValue = apSchema.const;
-          defaultValue = apSchema.default;
+          defaultValue = schemaUtils.getDefaultFormState(apSchema as S, defaultValue as T) as RJSFSchema['default'];
         }
         if (!type && (ANY_OF_KEY in apSchema || ONE_OF_KEY in apSchema)) {
           type = 'object';

--- a/packages/core/test/ObjectField.test.tsx
+++ b/packages/core/test/ObjectField.test.tsx
@@ -704,6 +704,48 @@ describe('ObjectField', () => {
       expect(node.querySelectorAll('.rjsf-field-string')).toHaveLength(1);
     });
 
+    it('should resolve if/then conditions for an existing additionalProperties entry that is a $ref (issue #4266)', () => {
+      const recursiveSchema: RJSFSchema = {
+        definitions: {
+          property: {
+            type: 'object',
+            properties: {
+              type: { type: 'string', enum: ['string', 'object'], default: 'string' },
+            },
+            required: ['type'],
+            if: { properties: { type: { const: 'object' } } },
+            then: {
+              properties: {
+                properties: { $ref: '#/definitions/properties' },
+              },
+            },
+          },
+          properties: {
+            type: 'object',
+            additionalProperties: {
+              default: { type: 'string' },
+              $ref: '#/definitions/property',
+            },
+          },
+        },
+        $ref: '#/definitions/property',
+      };
+
+      const { node } = createFormComponent({
+        schema: recursiveSchema,
+        formData: {
+          type: 'object',
+          properties: {
+            inner: { type: 'object', properties: {} },
+          },
+        },
+      });
+
+      // If the `if`/`then` condition on the $ref'd `property` definition was resolved, the nested
+      // `inner.properties` object field should be rendered.
+      expect(node.querySelector('#root_properties_inner_properties')).not.toBeNull();
+    });
+
     it('uiSchema title should not affect additionalProperties', () => {
       const { node } = createFormComponent({
         schema,
@@ -1498,6 +1540,35 @@ describe('ObjectField', () => {
       await user.click(node.querySelector('.rjsf-object-property-expand button')!);
 
       expectToHaveBeenCalledWithFormData(onChange, { newKey: 1 }, 'root');
+    });
+
+    it('should add a new item with the fully-computed nested defaults when additionalProperties is a $ref (issue #4266)', async () => {
+      // The `default` sibling next to `$ref` should seed the computed defaults rather than being
+      // discarded in favor of the referenced schema's own top-level `default` (which doesn't exist here).
+      const customSchema: RJSFSchema = {
+        ...schema,
+        definitions: {
+          namedThing: {
+            type: 'object',
+            properties: {
+              // `name` has its own nested default that must be preserved alongside the sibling default.
+              name: { type: 'string', default: 'unnamed' },
+            },
+          },
+        },
+        additionalProperties: {
+          default: { active: true },
+          $ref: '#/definitions/namedThing',
+        },
+      };
+      const { node, onChange } = createFormComponent({
+        schema: customSchema,
+        formData: {},
+      });
+
+      await user.click(node.querySelector('.rjsf-object-property-expand button')!);
+
+      expectToHaveBeenCalledWithFormData(onChange, { newKey: { name: 'unnamed', active: true } }, 'root');
     });
 
     it('should generate the specified default key and value inputs if default is provided outside of additionalProperties schema', () => {


### PR DESCRIPTION
### Reasons for making this change

Fixes #4266 as follows:

- Updated `ObjectField` to compute the default via `schemaUtils.getDefaultFormState()` against the fully-resolved referenced schema
  - Also passed the sibling default as the default so nested defaults are populated recursively instead of lost.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
