### PR TITLE
Fix CommandItem issue in fancy select components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated the single select trigger to use native button semantics with expanded and disabled state coverage, fixing [#4764](https://github.com/rjsf-team/react-jsonschema-form/issues/4764) ([#5117](https://github.com/rjsf-team/react-jsonschema-form/pull/5117))
 - Added `CyclicSchemaExpandTemplate` to the list of templates for the theme, updating snapshots accordingly
 - Fixed a small visual bug that caused hovering over items of `FancySelect` and `FancyMultiSelect` that have the same label to incorrectly highlight more than one element, fixing [#5126](https://github.com/rjsf-team/react-jsonschema-form/issues/5126)
+- Fixed `CommandItem` value handling in `FancySelect` and `FancyMultiSelect` components to ensure values are passed as strings ([#5155](https://github.com/rjsf-team/react-jsonschema-form/pull/5155))
 - Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 
 ## @rjsf/utils

--- a/packages/shadcn/src/components/ui/fancy-multi-select.tsx
+++ b/packages/shadcn/src/components/ui/fancy-multi-select.tsx
@@ -201,6 +201,7 @@ export function FancyMultiSelect({
                   <CommandItem
                     disabled={item.disabled}
                     key={`${item.value}-command-item`}
+                    value={String(item.value)}
                     onMouseDown={(e) => {
                       e.preventDefault();
                       e.stopPropagation();

--- a/packages/shadcn/src/components/ui/fancy-multi-select.tsx
+++ b/packages/shadcn/src/components/ui/fancy-multi-select.tsx
@@ -209,7 +209,6 @@ export function FancyMultiSelect({
                     aria-controls={`${item.value}-command-item`}
                     aria-labelledby={`${item.value}-command-item`}
                     id={`${item.value}-command-item`}
-                    value={item.value}
                     onSelect={() => handleSelect(item)}
                     className='cursor-pointer'
                   >

--- a/packages/shadcn/src/components/ui/fancy-select.tsx
+++ b/packages/shadcn/src/components/ui/fancy-select.tsx
@@ -138,6 +138,7 @@ export function FancySelect({
                   <CommandItem
                     ref={item.value === selected ? selectedRef : undefined}
                     key={item.value}
+                    value={String(item.value)} 
                     onMouseDown={(e) => {
                       e.preventDefault();
                       e.stopPropagation();

--- a/packages/shadcn/src/components/ui/fancy-select.tsx
+++ b/packages/shadcn/src/components/ui/fancy-select.tsx
@@ -138,12 +138,11 @@ export function FancySelect({
                   <CommandItem
                     ref={item.value === selected ? selectedRef : undefined}
                     key={item.value}
-                    value={String(item.value)} 
+                    value={String(item.value)}
                     onMouseDown={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
                     }}
-                    value={item.value}
                     onSelect={() => {
                       if (!item.disabled) {
                         onValueChange?.(item.value);


### PR DESCRIPTION
### Reasons for making this change

Fixed an issue where CommandItem was not receiving the correct value type in FancySelect and FancyMultiSelect components.

### Changes made

- Added `String(item.value)` for CommandItem value prop in `fancy-select.tsx`
- Added `String(item.value)` for CommandItem value prop in `fancy-multi-select.tsx`

### Testing

- Verified the changes locally.