### PR TITLE
Fix 4631: preserve additional property order for numeric keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 6.7.1
+
+## @rjsf/core
+
+- Fixed `ObjectField` to preserve the insertion order of additional and pattern properties when keys are renamed to integers, fixing [#4631](https://github.com/rjsf-team/react-jsonschema-form/issues/4631) ([#5156](https://github.com/rjsf-team/react-jsonschema-form/pull/5156))
+
 # 6.7.0
 
 ## @rjsf/antd
@@ -43,7 +49,6 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed a regression introduced in [#5136](https://github.com/rjsf-team/react-jsonschema-form/pull/5136) where clearing a second field caused a previously-cleared field to be re-populated with its schema default; uses `JSON.parse(JSON.stringify(...))` to strip `undefined`-valued keys from formData before AJV validation so that the [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix is preserved
 - Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 - Fixed `ObjectField`'s "Add" button for `additionalProperties` schemas containing a `$ref` so the new item's default value is computed via `getDefaultFormState()` against the fully-resolved referenced schema (recursively populating nested defaults) instead of only reading the resolved schema's own top-level `default`, which discarded the sibling `default` and any nested property defaults, fixing [#4266](https://github.com/rjsf-team/react-jsonschema-form/issues/4266)
-- Fixed `ObjectField` to preserve the insertion order of additional and pattern properties when keys are renamed to integers, fixing [#4631](https://github.com/rjsf-team/react-jsonschema-form/issues/4631) ([#5156](https://github.com/rjsf-team/react-jsonschema-form/pull/5156))
 
 ## @rjsf/daisyui
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed a regression introduced in [#5136](https://github.com/rjsf-team/react-jsonschema-form/pull/5136) where clearing a second field caused a previously-cleared field to be re-populated with its schema default; uses `JSON.parse(JSON.stringify(...))` to strip `undefined`-valued keys from formData before AJV validation so that the [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix is preserved
 - Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 - Fixed `ObjectField`'s "Add" button for `additionalProperties` schemas containing a `$ref` so the new item's default value is computed via `getDefaultFormState()` against the fully-resolved referenced schema (recursively populating nested defaults) instead of only reading the resolved schema's own top-level `default`, which discarded the sibling `default` and any nested property defaults, fixing [#4266](https://github.com/rjsf-team/react-jsonschema-form/issues/4266)
-- Fixed `ObjectField` to preserve the insertion order of additional and pattern properties when keys are renamed to integers, fixing [#4631](https://github.com/rjsf-team/react-jsonschema-form/issues/4631)
+- Fixed `ObjectField` to preserve the insertion order of additional and pattern properties when keys are renamed to integers, fixing [#4631](https://github.com/rjsf-team/react-jsonschema-form/issues/4631) ([#5156](https://github.com/rjsf-team/react-jsonschema-form/pull/5156))
 
 ## @rjsf/daisyui
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed a regression introduced in [#5136](https://github.com/rjsf-team/react-jsonschema-form/pull/5136) where clearing a second field caused a previously-cleared field to be re-populated with its schema default; uses `JSON.parse(JSON.stringify(...))` to strip `undefined`-valued keys from formData before AJV validation so that the [#4518](https://github.com/rjsf-team/react-jsonschema-form/issues/4518) fix is preserved
 - Show selected option descriptions, fixing ([#4214](https://github.com/rjsf-team/react-jsonschema-form/issues/4214))
 - Fixed `ObjectField`'s "Add" button for `additionalProperties` schemas containing a `$ref` so the new item's default value is computed via `getDefaultFormState()` against the fully-resolved referenced schema (recursively populating nested defaults) instead of only reading the resolved schema's own top-level `default`, which discarded the sibling `default` and any nested property defaults, fixing [#4266](https://github.com/rjsf-team/react-jsonschema-form/issues/4266)
+- Fixed `ObjectField` to preserve the insertion order of additional and pattern properties when keys are renamed to integers, fixing [#4631](https://github.com/rjsf-team/react-jsonschema-form/issues/4631)
 
 ## @rjsf/daisyui
 

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -238,6 +238,7 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
   // All the children will use childFieldPathId if present in the props, falling back to the fieldPathId
   const childFieldPathId = props.childFieldPathId ?? fieldPathId;
   const lastRenamedProperty = useRef({ previousKey: '', currentKey: undefined as string | undefined });
+  const additionalPropertyOrder = useRef<string[]>([]);
 
   const templateTitle = uiOptions.title ?? schema.title ?? title ?? name;
   const description = uiOptions.description ?? schema.description;
@@ -308,6 +309,7 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
       lastRenamedProperty.current.currentKey = newKey;
       lastRenamedProperty.current.previousKey = getAvailableKey(newKey, newFormData);
     }
+    additionalPropertyOrder.current.push(newKey);
     onChange(newFormData, childFieldPathId.path);
   }, [formData, onChange, translateString, schemaUtils, childFieldPathId, getAvailableKey, schema]);
 
@@ -339,6 +341,9 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
           lastRenamedProperty.current.previousKey = oldKey;
         }
         lastRenamedProperty.current.currentKey = actualNewKey;
+        additionalPropertyOrder.current = additionalPropertyOrder.current.map((property) =>
+          property === oldKey ? actualNewKey : property,
+        );
         onChange(renamedObj, childFieldPathId.path);
       }
     },
@@ -350,6 +355,7 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
    */
   const handleRemoveProperty = useCallback(
     (key: string) => {
+      additionalPropertyOrder.current = additionalPropertyOrder.current.filter((property) => property !== key);
       onChange(ADDITIONAL_PROPERTY_KEY_REMOVE as T, [...childFieldPathId.path, key]);
     },
     [onChange, childFieldPathId],
@@ -370,7 +376,30 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
   if (!renderOptionalField || hasFormData) {
     try {
       const properties = Object.keys(schemaProperties);
-      orderedProperties = orderProperties(properties, uiOptions.order);
+      const definedProperties: string[] = [];
+      const currentAdditionalProperties: string[] = [];
+      properties.forEach((property) => {
+        const addedByAdditionalProperties = Boolean(
+          (schemaProperties[property] as RJSFMarkedSchema)?.[ADDITIONAL_PROPERTY_FLAG],
+        );
+        if (addedByAdditionalProperties) {
+          currentAdditionalProperties.push(property);
+        } else {
+          definedProperties.push(property);
+        }
+      });
+
+      const currentAdditionalPropertySet = new Set(currentAdditionalProperties);
+      const retainedAdditionalProperties = additionalPropertyOrder.current.filter((property) =>
+        currentAdditionalPropertySet.has(property),
+      );
+      const retainedAdditionalPropertySet = new Set(retainedAdditionalProperties);
+      const newAdditionalProperties = currentAdditionalProperties.filter(
+        (property) => !retainedAdditionalPropertySet.has(property),
+      );
+      additionalPropertyOrder.current = [...retainedAdditionalProperties, ...newAdditionalProperties];
+
+      orderedProperties = orderProperties([...definedProperties, ...additionalPropertyOrder.current], uiOptions.order);
     } catch (err) {
       return (
         <div>

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -244,20 +244,17 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
     [schemaUtils, rawSchema, formData],
   );
   const uiOptions = useMemo(() => getUiOptions<T, S, F>(uiSchema, globalUiOptions), [uiSchema, globalUiOptions]);
-  const { properties: schemaProperties = {} } = schema;
+  const schemaProperties = useMemo(() => schema.properties ?? {}, [schema.properties]);
   // All the children will use childFieldPathId if present in the props, falling back to the fieldPathId
   const childFieldPathId = props.childFieldPathId ?? fieldPathId;
   const lastRenamedProperty = useRef({ previousKey: '', currentKey: undefined as string | undefined });
-  const additionalPropertyOrder = useRef<string[]>([]);
-  const additionalPropertyOrderInitialized = useRef(false);
-  if (!additionalPropertyOrderInitialized.current) {
-    additionalPropertyOrder.current = getAdditionalPropertyOrder<S>(schemaProperties);
-    additionalPropertyOrderInitialized.current = true;
-  }
-  const definedPropertyOrder = useMemo(
-    () => Object.keys(schemaProperties).filter((property) => !isAdditionalPropertySchema(schemaProperties[property])),
-    [schemaProperties],
+  const [additionalPropertyOrder, setAdditionalPropertyOrder] = useState(() =>
+    getAdditionalPropertyOrder<S>(schemaProperties),
   );
+  const definedPropertyOrder = useMemo(() => {
+    const additionalPropertySet = new Set(getAdditionalPropertyOrder<S>(schemaProperties));
+    return Object.keys(schemaProperties).filter((property) => !additionalPropertySet.has(property));
+  }, [schemaProperties]);
 
   const templateTitle = uiOptions.title ?? schema.title ?? title ?? name;
   const description = uiOptions.description ?? schema.description;
@@ -328,7 +325,7 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
       lastRenamedProperty.current.currentKey = newKey;
       lastRenamedProperty.current.previousKey = getAvailableKey(newKey, newFormData);
     }
-    additionalPropertyOrder.current.push(newKey);
+    setAdditionalPropertyOrder((order) => [...order, newKey]);
     onChange(newFormData, childFieldPathId.path);
   }, [formData, onChange, translateString, schemaUtils, childFieldPathId, getAvailableKey, schema]);
 
@@ -360,9 +357,7 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
           lastRenamedProperty.current.previousKey = oldKey;
         }
         lastRenamedProperty.current.currentKey = actualNewKey;
-        additionalPropertyOrder.current = additionalPropertyOrder.current.map((property) =>
-          property === oldKey ? actualNewKey : property,
-        );
+        setAdditionalPropertyOrder((order) => order.map((property) => (property === oldKey ? actualNewKey : property)));
         onChange(renamedObj, childFieldPathId.path);
       }
     },
@@ -374,7 +369,7 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
    */
   const handleRemoveProperty = useCallback(
     (key: string) => {
-      additionalPropertyOrder.current = additionalPropertyOrder.current.filter((property) => property !== key);
+      setAdditionalPropertyOrder((order) => order.filter((property) => property !== key));
       onChange(ADDITIONAL_PROPERTY_KEY_REMOVE as T, [...childFieldPathId.path, key]);
     },
     [onChange, childFieldPathId],
@@ -394,8 +389,9 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
 
   if (!renderOptionalField || hasFormData) {
     try {
-      const currentAdditionalProperties = additionalPropertyOrder.current.filter((property) =>
-        Object.hasOwn(schemaProperties, property),
+      const definedPropertySet = new Set(definedPropertyOrder);
+      const currentAdditionalProperties = additionalPropertyOrder.filter(
+        (property) => Object.hasOwn(schemaProperties, property) && !definedPropertySet.has(property),
       );
       orderedProperties = orderProperties([...definedPropertyOrder, ...currentAdditionalProperties], uiOptions.order);
     } catch (err) {

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -72,6 +72,16 @@ function getDefaultValue<T = any, S extends StrictRJSFSchema = RJSFSchema, F ext
   }
 }
 
+function isAdditionalPropertySchema(schema: unknown) {
+  return Boolean((schema as RJSFMarkedSchema)?.[ADDITIONAL_PROPERTY_FLAG]);
+}
+
+function getAdditionalPropertyOrder<S extends StrictRJSFSchema = RJSFSchema>(
+  schemaProperties: NonNullable<S['properties']>,
+) {
+  return Object.keys(schemaProperties).filter((property) => isAdditionalPropertySchema(schemaProperties[property]));
+}
+
 /** Props for the `ObjectFieldProperty` component */
 interface ObjectFieldPropertyProps<
   T = any,
@@ -239,6 +249,15 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
   const childFieldPathId = props.childFieldPathId ?? fieldPathId;
   const lastRenamedProperty = useRef({ previousKey: '', currentKey: undefined as string | undefined });
   const additionalPropertyOrder = useRef<string[]>([]);
+  const additionalPropertyOrderInitialized = useRef(false);
+  if (!additionalPropertyOrderInitialized.current) {
+    additionalPropertyOrder.current = getAdditionalPropertyOrder<S>(schemaProperties);
+    additionalPropertyOrderInitialized.current = true;
+  }
+  const definedPropertyOrder = useMemo(
+    () => Object.keys(schemaProperties).filter((property) => !isAdditionalPropertySchema(schemaProperties[property])),
+    [schemaProperties],
+  );
 
   const templateTitle = uiOptions.title ?? schema.title ?? title ?? name;
   const description = uiOptions.description ?? schema.description;
@@ -375,31 +394,10 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
 
   if (!renderOptionalField || hasFormData) {
     try {
-      const properties = Object.keys(schemaProperties);
-      const definedProperties: string[] = [];
-      const currentAdditionalProperties: string[] = [];
-      properties.forEach((property) => {
-        const addedByAdditionalProperties = Boolean(
-          (schemaProperties[property] as RJSFMarkedSchema)?.[ADDITIONAL_PROPERTY_FLAG],
-        );
-        if (addedByAdditionalProperties) {
-          currentAdditionalProperties.push(property);
-        } else {
-          definedProperties.push(property);
-        }
-      });
-
-      const currentAdditionalPropertySet = new Set(currentAdditionalProperties);
-      const retainedAdditionalProperties = additionalPropertyOrder.current.filter((property) =>
-        currentAdditionalPropertySet.has(property),
+      const currentAdditionalProperties = additionalPropertyOrder.current.filter((property) =>
+        Object.hasOwn(schemaProperties, property),
       );
-      const retainedAdditionalPropertySet = new Set(retainedAdditionalProperties);
-      const newAdditionalProperties = currentAdditionalProperties.filter(
-        (property) => !retainedAdditionalPropertySet.has(property),
-      );
-      additionalPropertyOrder.current = [...retainedAdditionalProperties, ...newAdditionalProperties];
-
-      orderedProperties = orderProperties([...definedProperties, ...additionalPropertyOrder.current], uiOptions.order);
+      orderedProperties = orderProperties([...definedPropertyOrder, ...currentAdditionalProperties], uiOptions.order);
     } catch (err) {
       return (
         <div>
@@ -424,9 +422,7 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
     title: uiOptions.label === false ? '' : templateTitle,
     description: uiOptions.label === false ? undefined : description,
     properties: orderedProperties.map((propertyName) => {
-      const addedByAdditionalProperties = Boolean(
-        (schema.properties?.[propertyName] as RJSFMarkedSchema)?.[ADDITIONAL_PROPERTY_FLAG],
-      );
+      const addedByAdditionalProperties = isAdditionalPropertySchema(schema.properties?.[propertyName]);
       const fieldUiSchema = addedByAdditionalProperties ? uiSchema.additionalProperties : uiSchema[propertyName];
       const hidden = getUiOptions<T, S, F>(fieldUiSchema).widget === 'hidden';
       const content = (

--- a/packages/core/test/ObjectField.test.tsx
+++ b/packages/core/test/ObjectField.test.tsx
@@ -992,6 +992,28 @@ describe('ObjectField', () => {
       expectToHaveBeenCalledWithFormData(onChange, { first: 1, newSecond: 2, third: 3 }, 'root');
     });
 
+    it('should keep a numeric pattern property in place when renaming its key', async () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: 'object',
+          patternProperties: {
+            '(.*?)': { type: 'string' },
+          },
+        },
+        formData: { first: 'one', second: 'two' },
+      });
+
+      const textNode = node.querySelector('#root_second-key')!;
+      await user.clear(textNode);
+      await user.type(textNode, '1');
+      await user.tab();
+
+      const propertyKeys = [...node.querySelectorAll<HTMLInputElement>('input[id$="-key"]')].map(
+        (input) => input.value,
+      );
+      expect(propertyKeys).toEqual(['first', '1']);
+    });
+
     it('should rename nested additionalProperties key when key input is blurred', async () => {
       const nestedSchema: RJSFSchema = {
         type: 'object',

--- a/packages/core/test/ObjectField.test.tsx
+++ b/packages/core/test/ObjectField.test.tsx
@@ -1014,6 +1014,45 @@ describe('ObjectField', () => {
       expect(propertyKeys).toEqual(['first', '1']);
     });
 
+    it('should not duplicate an additional property that becomes schema-defined after rerender', () => {
+      const initialSchema: RJSFSchema = {
+        type: 'object',
+        additionalProperties: {
+          type: 'string',
+        },
+      };
+      const updatedSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          promoted: {
+            type: 'string',
+          },
+        },
+        additionalProperties: {
+          type: 'string',
+        },
+      };
+      const formData = { first: 'one', promoted: 'two' };
+      const { node, rerender } = createFormComponent({
+        schema: initialSchema,
+        formData,
+      });
+
+      rerender({
+        schema: updatedSchema,
+        formData,
+      });
+
+      const promotedInputs = node.querySelectorAll<HTMLInputElement>('input[id="root_promoted"]');
+      expect(promotedInputs).toHaveLength(1);
+      expect(promotedInputs[0]).toHaveValue('two');
+
+      const propertyKeys = [...node.querySelectorAll<HTMLInputElement>('input[id$="-key"]')].map(
+        (input) => input.value,
+      );
+      expect(propertyKeys).toEqual(['first']);
+    });
+
     it('should rename nested additionalProperties key when key input is blurred', async () => {
       const nestedSchema: RJSFSchema = {
         type: 'object',


### PR DESCRIPTION
### Reasons for making this change

Fixes #4631.

JavaScript enumerates integer-like object keys before string keys. When an `additionalProperties` or `patternProperties` key was renamed to an integer, `Object.keys(schema.properties)` moved the field to the top of the form even though the user added it later.

### Changes made

- Track the render order of additional and pattern properties inside `ObjectField`.
- Keep that order in sync when dynamic properties are added, renamed, or removed.
- Keep schema-defined fields ahead of dynamic fields while preserving explicit `ui:order` as the final override.
- Add a regression test that renames the second pattern property to `1` and verifies that it stays second.
- Add the fix to the `@rjsf/core` changelog.

### Testing

- `corepack pnpm -C packages/core exec vitest run test/ObjectField.test.tsx` (249 passed)
- `corepack pnpm -C packages/core run test` (2215 passed)
- `corepack pnpm run lint`
- `corepack pnpm run build`
- `corepack pnpm run test`
- Target-file Oxfmt and `git diff --check`

### Checklist

- [ ] **I am updating documentation**
  - [ ] I have checked the rendering of Markdown text I added
- [x] **I am adding or updating code**
  - [x] I have added and updated tests
  - [x] Documentation changes are not needed for this bug fix
  - [x] I have updated `CHANGELOG.md`
- [ ] **I am adding a new feature**
  - [ ] I have updated the playground with an example of the feature