### PR TITLE
chore: bump ata-validator to ^1.0.0 in @rjsf/validator-ata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/validator-ata
 
 - Updated `transformRJSFValidationErrors()` to detect field name for `allOf` and `if-then-else` by falling back to the root schema to find the title, fixing [#5134](https://github.com/rjsf-team/react-jsonschema-form/issues/5134)
-- Updated the `ata-validator` dependency to `^1.0.0`, its first stable release; no API changes for `@rjsf/validator-ata` consumers
+- Updated the `ata-validator` dependency to `^1.0.0`, its first stable release; no API changes for `@rjsf/validator-ata` consumers ([#5157](https://github.com/rjsf-team/react-jsonschema-form/pull/5157))
 
 ## Dev / docs / playground
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/validator-ata
 
 - Updated `transformRJSFValidationErrors()` to detect field name for `allOf` and `if-then-else` by falling back to the root schema to find the title, fixing [#5134](https://github.com/rjsf-team/react-jsonschema-form/issues/5134)
+- Updated the `ata-validator` dependency to `^1.0.0`, its first stable release; no API changes for `@rjsf/validator-ata` consumers
 
 ## Dev / docs / playground
 

--- a/packages/validator-ata/package.json
+++ b/packages/validator-ata/package.json
@@ -77,7 +77,7 @@
     ]
   },
   "dependencies": {
-    "ata-validator": "^0.21.0",
+    "ata-validator": "^1.0.0",
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -912,8 +912,8 @@ importers:
   packages/validator-ata:
     dependencies:
       ata-validator:
-        specifier: ^0.21.0
-        version: 0.21.0(yaml@2.9.0)
+        specifier: ^1.0.0
+        version: 1.0.0(yaml@2.9.0)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -5986,9 +5986,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  ata-validator@0.21.0:
-    resolution: {integrity: sha512-cfsVpYxY2c7ZnKQg/eiImSkCFQob6OYgKeGidrBxy8/0W8GoTeiNqqFuqnTkJMDYODYaJmOCKYYWSBpuPClYIg==}
-    engines: {node: '>=18.0.0'}
+  ata-validator@1.0.0:
+    resolution: {integrity: sha512-oQBG4XDTuIasgGTyx7/C12PH1BFWeurF0uz6JRHmr0cwyO6oMRN8sllhirrSsKTkrXEyN7hpT9gQ58v62UhfTw==}
+    engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
       yaml: ^2.0.0
@@ -18165,7 +18165,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  ata-validator@0.21.0(yaml@2.9.0):
+  ata-validator@1.0.0(yaml@2.9.0):
     dependencies:
       node-addon-api: 8.8.0
       node-api-headers: 1.9.0


### PR DESCRIPTION
#### Reasons for making this change

ata-validator published 1.0.0, its first stable release. The current `^0.21.0` range does not match 1.x, so the validator would stay pinned to the 0.x line and miss stable-line updates.

No code changes are needed: the surface `@rjsf/validator-ata` uses is unchanged in 1.0. The release also ships a written stability policy covering the error codes and result shape this package relies on: https://github.com/ata-core/ata-validator/blob/master/docs/STABILITY.md

#### Checklist

- [x] Added a CHANGELOG entry under 6.6.0