### PR TITLE
Clarify playground example property names

### DIFF
--- a/packages/playground/src/samples/schemaDependencies.ts
+++ b/packages/playground/src/samples/schemaDependencies.ts
@@ -6,8 +6,8 @@ const schemaDependencies: Sample = {
     description: 'These samples are best viewed without live validation.',
     type: 'object',
     properties: {
-      simple: {
-        title: 'Simple',
+      billingDetails: {
+        title: 'Billing details',
         type: 'object',
         properties: {
           name: {
@@ -29,19 +29,19 @@ const schemaDependencies: Sample = {
           },
         },
       },
-      conditional: {
-        title: 'Conditional',
+      petOwner: {
+        title: 'Pet owner',
         $ref: '#/definitions/person',
       },
-      arrayOfConditionals: {
-        title: 'Array of conditionals',
+      petOwners: {
+        title: 'Pet owners',
         type: 'array',
         items: {
           $ref: '#/definitions/person',
         },
       },
-      fixedArrayOfConditionals: {
-        title: 'Fixed array of conditionals',
+      householdMembers: {
+        title: 'Household members',
         type: 'array',
         items: [
           {
@@ -106,24 +106,24 @@ const schemaDependencies: Sample = {
     },
   },
   uiSchema: {
-    simple: {
+    billingDetails: {
       credit_card: {
         'ui:help': 'If you enter anything here then billing_address will be dynamically added to the form.',
       },
     },
-    conditional: {
+    petOwner: {
       'Do you want to get rid of any?': {
         'ui:widget': 'radio',
       },
     },
-    arrayOfConditionals: {
+    petOwners: {
       items: {
         'Do you want to get rid of any?': {
           'ui:widget': 'radio',
         },
       },
     },
-    fixedArrayOfConditionals: {
+    householdMembers: {
       items: {
         'Do you want to get rid of any?': {
           'ui:widget': 'radio',
@@ -137,13 +137,13 @@ const schemaDependencies: Sample = {
     },
   },
   formData: {
-    simple: {
+    billingDetails: {
       name: 'Randy',
     },
-    conditional: {
+    petOwner: {
       'Do you have any pets?': 'No',
     },
-    arrayOfConditionals: [
+    petOwners: [
       {
         'Do you have any pets?': 'Yes: One',
         'How old is your pet?': 6,
@@ -153,7 +153,7 @@ const schemaDependencies: Sample = {
         'Do you want to get rid of any?': false,
       },
     ],
-    fixedArrayOfConditionals: [
+    householdMembers: [
       {
         'Do you have any pets?': 'No',
       },

--- a/packages/playground/src/samples/widgets.tsx
+++ b/packages/playground/src/samples/widgets.tsx
@@ -19,45 +19,45 @@ const widgets: Sample = {
           },
         },
       },
-      boolean: {
+      preferences: {
         type: 'object',
         title: 'Boolean field',
         properties: {
-          default: {
+          subscribeToNewsletter: {
             type: 'boolean',
-            title: 'checkbox (default)',
+            title: 'Subscribe to newsletter (checkbox, default)',
             description: 'This is the checkbox-description',
           },
-          radio: {
+          receiveProductUpdates: {
             type: 'boolean',
-            title: 'radio buttons',
+            title: 'Receive product updates (radio buttons)',
             description: 'This is the radio-description',
           },
-          select: {
+          shareUsageData: {
             type: 'boolean',
-            title: 'select box',
+            title: 'Share usage data (select box)',
             description: 'This is the select-description',
           },
         },
       },
-      string: {
+      contactDetails: {
         type: 'object',
         title: 'String field',
         properties: {
-          default: {
+          name: {
             type: 'string',
-            title: 'text input (default)',
+            title: 'Name (text input, default)',
           },
-          textarea: {
+          address: {
             type: 'string',
-            title: 'textarea',
+            title: 'Address (textarea)',
           },
-          placeholder: {
+          occupation: {
             type: 'string',
           },
-          color: {
+          favoriteColor: {
             type: 'string',
-            title: 'color picker',
+            title: 'Favorite color (color picker)',
             default: '#151ce6',
           },
         },
@@ -171,10 +171,10 @@ const widgets: Sample = {
     },
   },
   uiSchema: {
-    boolean: {
+    preferences: {
       'ui:widget': 'toggle',
     },
-    string: {
+    contactDetails: {
       'ui:widget': 'textarea',
     },
     customWidgets: {
@@ -289,14 +289,14 @@ const widgets: Sample = {
       email: 'chuck@norris.net',
       uri: 'http://chucknorris.com/',
     },
-    boolean: {
-      default: true,
-      radio: true,
-      select: true,
+    preferences: {
+      subscribeToNewsletter: true,
+      receiveProductUpdates: true,
+      shareUsageData: true,
     },
-    string: {
-      default: 'Hello...',
-      textarea: '... World',
+    contactDetails: {
+      name: 'Chuck Norris',
+      address: 'Roundhouse Lane',
     },
     customWidgets: {
       rating: 3,


### PR DESCRIPTION
### Reasons for making this change

The playground still used schema type names and example-category names as property keys. That made the editable schemas look as though names such as `boolean`, `string`, and `conditional` were JSON Schema keywords rather than ordinary user-defined properties.

This change:

- gives the Widgets sample domain-oriented keys such as `preferences` and `contactDetails`
- gives the Schema Dependencies sample keys such as `billingDetails`, `petOwner`, and `householdMembers`
- updates each sample's schema, UI schema, and form data together so behavior remains unchanged

Fixes #2403.

Implementation and validation assistance was provided by OpenAI Codex.

### Validation

- `pnpm --filter @rjsf/playground run cs-check`
- `pnpm --filter @rjsf/playground run lint`
- `pnpm test`
- `pnpm run build`
- production playground preview served locally and compiled sample keys verified

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added (no Markdown changed; the production playground build and preview were verified)
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
