### PR TITLE
Fix 5163: stop padding minItems arrays with null under arrayMinItems.populate = 'never'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - Added `getDecimalSeparator()` utility to detect locale-specific decimal separators and updated `asNumber()` to parse locale-specific decimal strings, partially fixing [#5148](https://github.com/rjsf-team/react-jsonschema-form/pull/5148)
+- Fixed a regression where `getDefaultFormState()` with `experimental_defaultFormStateBehavior.arrayMinItems.populate = 'never'` padded arrays with `null` entries up to `minItems`, fixing [#5163](https://github.com/rjsf-team/react-jsonschema-form/issues/5163)
+  - Optional arrays with no data are now omitted (unchanged) while required arrays with no data default to `[]`, letting the validator report the `minItems` violation instead of surfacing invalid `null` items
 
 ## @rjsf/validator-ata
 
@@ -2496,7 +2498,7 @@ Move theme snapshot tests into separate package
 - However, if users of @rjsf/antd want to use v5 styling, they need to wrap your application with the `StyleProvider` from `@ant-design/cssinjs`. They need not have to install this package, its a transitive package coming from antd.
 
 ```tsx
-import { StyleProvider } from "@ant-design/cssinjs";
+import { StyleProvider } from '@ant-design/cssinjs';
 
 const Component = () => {
   return (

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -719,11 +719,10 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
   const defaultsLength = Array.isArray(defaults) ? defaults.length : 0;
 
   if (neverPopulate) {
-    if (shouldMergeDefaultsIntoFormData) {
-      if (schema.minItems && schema.minItems > defaultsLength) {
-        const fillerEntries = Array.from({ length: schema.minItems - defaultsLength }, () => null) as T[];
-        return (defaults ?? []).concat(fillerEntries);
-      }
+    if (shouldMergeDefaultsIntoFormData && !required) {
+      // Optional arrays with no existing data should be omitted entirely rather than defaulted to `[]`.
+      // Required arrays still fall through to `defaults ?? emptyDefault` below so that `[]` is surfaced,
+      // letting the validator report `minItems` violations instead of a missing-required-property error.
       return defaults;
     }
     return defaults ?? emptyDefault;

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -2376,9 +2376,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
 
           expect(
             getDefaultFormState(testValidator, schema, undefined, undefined, undefined, defaultFormStateBehavior),
-          ).toEqual({
-            minItemsArray: [null],
-          });
+          ).toEqual({});
         });
 
         test('optional array with arrayMinItems.populate = never preserves short formData as-is', () => {
@@ -2431,6 +2429,27 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
               defaultFormStateBehavior,
             ),
           ).toEqual({ minItemsArray: ['foo', 'bar'] });
+        });
+
+        test('required array with arrayMinItems.populate = never does not pad minItems with null (issue #5163)', () => {
+          const schema: RJSFSchema = {
+            type: 'object',
+            properties: {
+              tags: {
+                type: 'array',
+                minItems: 1,
+                items: { type: 'string' },
+              },
+            },
+            required: ['tags'],
+          };
+          const defaultFormStateBehavior: Experimental_DefaultFormStateBehavior = {
+            arrayMinItems: { populate: 'never' },
+          };
+
+          expect(
+            getDefaultFormState(testValidator, schema, undefined, undefined, undefined, defaultFormStateBehavior),
+          ).toEqual({ tags: [] });
         });
       });
     });


### PR DESCRIPTION
### Reasons for making this change

Fixes #5163 as follows:

- Updated `getDefaultFormState()` to remove the null-filler for `minItems` arrays.
  - Required arrays with no data now fall through to the pre-existing `defaults ?? emptyDefault` path and default to []
  - Optional arrays (with or without minItems) continue to be omitted entirely per #5149's fix.
- Updated `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
