### PR TITLE
Update sortedJSONStringify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 6.8.0
 
+## @rjsf/utils
+
+- Fixed an issue in `sortedJSONStringify` with regards to handling arrays containing `null` and `undefined` values.
+
 ## @rjsf/validator-ata
 
 - Raised the `ata-validator` requirement to `^1.3.0`, which fixes a `$ref` that could not be resolved being treated as vacuous rather than reported as an error ([#5181](https://github.com/rjsf-team/react-jsonschema-form/pull/5181))

--- a/packages/utils/src/hashForSchema.ts
+++ b/packages/utils/src/hashForSchema.ts
@@ -26,13 +26,18 @@ export function hashString(string: string): string {
  * @returns - The stringified object with keys sorted in a consistent order
  */
 export function sortedJSONStringify(object: unknown): string {
-  const allKeys = new Set<string>();
-  // solution source: https://stackoverflow.com/questions/16167581/sort-object-properties-and-json-stringify/53593328#53593328
-  JSON.stringify(object, (key, value) => {
-    allKeys.add(key);
-    return value;
-  });
-  return JSON.stringify(object, Array.from(allKeys).sort());
+  if (Array.isArray(object)) {
+    return `[${object.map(sortedJSONStringify).join(',')}]`;
+  }
+  if (object === null || typeof object !== 'object') {
+    return JSON.stringify(typeof object === 'function' ? null : object); // Normalise functions
+  }
+
+  const record = object as Record<string, unknown>;
+  const sortedValues = Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${sortedJSONStringify(record[key])}`);
+  return `{${sortedValues.join(',')}}`;
 }
 
 /** Stringifies an `object` and returns the hash of the resulting string. Sorts object fields

--- a/packages/utils/src/hashForSchema.ts
+++ b/packages/utils/src/hashForSchema.ts
@@ -20,12 +20,17 @@ export function hashString(string: string): string {
   return hash.toString(16);
 }
 
-/** Stringifies an `object`, sorts object fields in consistent order before stringifying it.
+/** Recursively serializes a value to JSON with object keys sorted alphabetically to produce
+ * a stable string representation.
  *
  * @param object - The object for which the sorted stringify is desired
  * @returns - The stringified object with keys sorted in a consistent order
  */
 export function sortedJSONStringify(object: unknown): string {
+  function shouldIncludeValue(value: unknown) {
+    return value !== undefined && typeof value !== 'function' && typeof value !== 'symbol';
+  }
+
   if (Array.isArray(object)) {
     return `[${object.map(sortedJSONStringify).join(',')}]`;
   }
@@ -36,6 +41,7 @@ export function sortedJSONStringify(object: unknown): string {
   const record = object as Record<string, unknown>;
   const sortedValues = Object.keys(record)
     .sort()
+    .filter((key) => shouldIncludeValue(record[key]))
     .map((key) => `${JSON.stringify(key)}:${sortedJSONStringify(record[key])}`);
   return `{${sortedValues.join(',')}}`;
 }

--- a/packages/utils/src/hashForSchema.ts
+++ b/packages/utils/src/hashForSchema.ts
@@ -32,7 +32,7 @@ export function sortedJSONStringify(object: unknown): string {
   }
 
   if (Array.isArray(object)) {
-    return `[${object.map(sortedJSONStringify).join(',')}]`;
+    return `[${object.map((x) => (x === undefined ? 'undefined' : sortedJSONStringify(x))).join(',')}]`;
   }
   if (object === null || typeof object !== 'object') {
     return JSON.stringify(typeof object === 'function' ? null : object); // Normalise functions

--- a/packages/utils/test/hashForSchema.test.ts
+++ b/packages/utils/test/hashForSchema.test.ts
@@ -42,6 +42,7 @@ describe('hashForSchema', () => {
 
 const TEST_ARRAY_WITH_UNDEFINED = [undefined];
 const TEST_ARRAY_WITH_NULL = [null];
+const TEST_OBJECT_WITH_IGNORED_PROPERTIES = { a: 1, b: undefined, f: () => {} };
 
 describe('sortedJSONStringify', () => {
   it('stringifies the object with keys already in order', () => {
@@ -50,8 +51,13 @@ describe('sortedJSONStringify', () => {
   it('stringifies the object putting keys in order', () => {
     expect(sortedJSONStringify(OUT_OF_ORDER_SCHEMA)).toEqual(STRINGIFIED_IN_ORDER);
   });
-  it('stringifies undefined and null items correctly', () => {
+  it('stringifies undefined and null array items correctly', () => {
     expect(sortedJSONStringify(TEST_ARRAY_WITH_NULL)).not.toEqual(sortedJSONStringify(TEST_ARRAY_WITH_UNDEFINED));
+  });
+  it('stringifies objects the same as JSON.stringify', () => {
+    expect(sortedJSONStringify(TEST_OBJECT_WITH_IGNORED_PROPERTIES)).toEqual(
+      JSON.stringify(TEST_OBJECT_WITH_IGNORED_PROPERTIES),
+    );
   });
 });
 

--- a/packages/utils/test/hashForSchema.test.ts
+++ b/packages/utils/test/hashForSchema.test.ts
@@ -40,8 +40,6 @@ describe('hashForSchema', () => {
   });
 });
 
-const TEST_ARRAY_WITH_UNDEFINED = [undefined];
-const TEST_ARRAY_WITH_NULL = [null];
 const TEST_OBJECT_WITH_IGNORED_PROPERTIES = { a: 1, b: undefined, f: () => {} };
 
 describe('sortedJSONStringify', () => {
@@ -51,13 +49,18 @@ describe('sortedJSONStringify', () => {
   it('stringifies the object putting keys in order', () => {
     expect(sortedJSONStringify(OUT_OF_ORDER_SCHEMA)).toEqual(STRINGIFIED_IN_ORDER);
   });
-  it('stringifies undefined and null array items correctly', () => {
-    expect(sortedJSONStringify(TEST_ARRAY_WITH_NULL)).not.toEqual(sortedJSONStringify(TEST_ARRAY_WITH_UNDEFINED));
-  });
   it('stringifies objects the same as JSON.stringify', () => {
     expect(sortedJSONStringify(TEST_OBJECT_WITH_IGNORED_PROPERTIES)).toEqual(
       JSON.stringify(TEST_OBJECT_WITH_IGNORED_PROPERTIES),
     );
+  });
+  it.each([
+    ['[]', []],
+    ['[undefined]', [undefined]],
+    ['[null]', [null]],
+    ['[1,undefined,2]', [1, undefined, 2]],
+  ])('stringifies %s correctly', (expected, value) => {
+    expect(sortedJSONStringify(value)).toEqual(expected);
   });
 });
 

--- a/packages/utils/test/hashForSchema.test.ts
+++ b/packages/utils/test/hashForSchema.test.ts
@@ -40,12 +40,18 @@ describe('hashForSchema', () => {
   });
 });
 
+const TEST_ARRAY_WITH_UNDEFINED = [undefined];
+const TEST_ARRAY_WITH_NULL = [null];
+
 describe('sortedJSONStringify', () => {
   it('stringifies the object with keys already in order', () => {
     expect(sortedJSONStringify(IN_ORDER_SCHEMA)).toEqual(STRINGIFIED_IN_ORDER);
   });
   it('stringifies the object putting keys in order', () => {
     expect(sortedJSONStringify(OUT_OF_ORDER_SCHEMA)).toEqual(STRINGIFIED_IN_ORDER);
+  });
+  it('stringifies undefined and null items correctly', () => {
+    expect(sortedJSONStringify(TEST_ARRAY_WITH_NULL)).not.toEqual(sortedJSONStringify(TEST_ARRAY_WITH_UNDEFINED));
   });
 });
 


### PR DESCRIPTION
Re-implement `sortedJSONStringify` to preserve difference between `null` and `undefined` array elements

### Reasons for making this change

There's an issue where array items of `null` and `undefined` are treated the same. This means that changing an item from `undefined` to `null` (or vice versa) meant the widget was not being updated (it thought no value had changed).

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
