### PR TITLE
Fix 3933: remove broken schemas from AJV cache after compilation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,13 +31,17 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Support locale-specific decimal separators in `NumberField` (e.g. Polish/German comma decimal separators) without breaking non-text widgets like radio buttons and select dropdowns, fixing [#5148](https://github.com/rjsf-team/react-jsonschema-form/pull/5148)
-- Fixed `ObjectField` to preserve the insertion order of additional and pattern properties when keys are renamed to integers, fixing [#4631](https://github.com/rjsf-team/react-jsonschema-form/issues/4631) ([#5156](https://github.com/rjsf-team/react-jsonschema-form/pull/5156))
+- Fixed `ObjectField` to preserve the insertion order of additional and pattern properties when keys are renamed to integers, fixing [#4631](https://github.com/rjsf-team/react-jsonschema-form/issues/4631)
 
 ## @rjsf/utils
 
 - Added `getDecimalSeparator()` utility to detect locale-specific decimal separators and updated `asNumber()` to parse locale-specific decimal strings, partially fixing [#5148](https://github.com/rjsf-team/react-jsonschema-form/pull/5148)
 - Fixed a regression where `getDefaultFormState()` with `experimental_defaultFormStateBehavior.arrayMinItems.populate = 'never'` padded arrays with `null` entries up to `minItems`, fixing [#5163](https://github.com/rjsf-team/react-jsonschema-form/issues/5163)
   - Optional arrays with no data are now omitted (unchanged) while required arrays with no data default to `[]`, letting the validator report the `minItems` violation instead of surfacing invalid `null` items
+
+## @rjsf/validator-ajv8
+
+- Updated `AJV8Validator` to remove broken schemas from AJV cache after compilation error, fixing [#3933](https://github.com/rjsf-team/react-jsonschema-form/issues/3933)
 
 ## @rjsf/validator-ata
 

--- a/packages/validator-ajv8/src/validator.ts
+++ b/packages/validator-ajv8/src/validator.ts
@@ -108,6 +108,13 @@ export default class AJV8Validator<
       compiledValidator(formData);
     } catch (err) {
       compilationError = err as Error;
+      // AJV registers a schema in its internal cache before running meta-schema
+      // validation. When that check throws, the broken schema stays cached so
+      // subsequent compile() calls skip revalidation and return silently. Remove
+      // the entry so every call with an invalid schema consistently produces a
+      // compilation error. For schemas with $id the cache key is the id string;
+      // for anonymous schemas AJV uses the object reference as the key.
+      this.ajv.removeSchema(schema[ID_KEY] !== undefined ? schema[ID_KEY] : (schema as object));
     }
 
     let errors;
@@ -228,13 +235,16 @@ export default class AJV8Validator<
    * @param rootSchema - The root schema used to provide $ref resolutions
    */
   isValid(schema: S, formData: T | undefined, rootSchema: S) {
+    // schemaId is declared outside the try so the catch block can remove the
+    // broken schema from AJV's registry even when an error occurs during compilation.
+    let schemaId: string | undefined;
     try {
       this.handleSchemaUpdate(rootSchema);
       // then rewrite the schema ref's to point to the rootSchema
       // this accounts for the case where schema have references to models
       // that lives in the rootSchema but not in the schema in question.
       const schemaWithIdRefPrefix = withIdRefPrefix<S>(schema) as S;
-      const schemaId = schemaWithIdRefPrefix[ID_KEY] ?? hashForSchema(schemaWithIdRefPrefix);
+      schemaId = schemaWithIdRefPrefix[ID_KEY] ?? hashForSchema(schemaWithIdRefPrefix);
       let compiledValidator: ValidateFunction | undefined;
       compiledValidator = this.ajv.getSchema(schemaId);
       if (compiledValidator === undefined) {
@@ -250,6 +260,12 @@ export default class AJV8Validator<
     } catch (e) {
       // oxlint-disable-next-line no-console
       console.warn('Error encountered compiling schema:', e);
+      // Remove the broken schema from AJV's registry so a subsequent rawValidation
+      // or isValid call does not silently reuse a cached entry that bypassed
+      // meta-schema validation.
+      if (schemaId !== undefined) {
+        this.ajv.removeSchema(schemaId);
+      }
       return false;
     }
   }

--- a/packages/validator-ajv8/src/validator.ts
+++ b/packages/validator-ajv8/src/validator.ts
@@ -114,7 +114,11 @@ export default class AJV8Validator<
       // the entry so every call with an invalid schema consistently produces a
       // compilation error. For schemas with $id the cache key is the id string;
       // for anonymous schemas AJV uses the object reference as the key.
-      this.ajv.removeSchema(schema[ID_KEY] !== undefined ? schema[ID_KEY] : (schema as object));
+      // Guard with compiledValidator === undefined so that a runtime error thrown
+      // by compiledValidator(formData) does not evict a correctly-compiled schema.
+      if (compiledValidator === undefined) {
+        this.ajv.removeSchema(schema[ID_KEY] !== undefined ? schema[ID_KEY] : (schema as object));
+      }
     }
 
     let errors;
@@ -235,9 +239,10 @@ export default class AJV8Validator<
    * @param rootSchema - The root schema used to provide $ref resolutions
    */
   isValid(schema: S, formData: T | undefined, rootSchema: S) {
-    // schemaId is declared outside the try so the catch block can remove the
-    // broken schema from AJV's registry even when an error occurs during compilation.
+    // schemaId and compiled are declared outside the try so the catch block can
+    // conditionally remove the broken schema from AJV's registry.
     let schemaId: string | undefined;
+    let compiled = false;
     try {
       this.handleSchemaUpdate(rootSchema);
       // then rewrite the schema ref's to point to the rootSchema
@@ -255,6 +260,7 @@ export default class AJV8Validator<
           this.ajv.addSchema(schemaWithIdRefPrefix, schemaId).getSchema(schemaId) ||
           this.ajv.compile(schemaWithIdRefPrefix);
       }
+      compiled = true;
       const result = compiledValidator(formData);
       return result;
     } catch (e) {
@@ -262,8 +268,9 @@ export default class AJV8Validator<
       console.warn('Error encountered compiling schema:', e);
       // Remove the broken schema from AJV's registry so a subsequent rawValidation
       // or isValid call does not silently reuse a cached entry that bypassed
-      // meta-schema validation.
-      if (schemaId !== undefined) {
+      // meta-schema validation. Guard with !compiled so that a runtime error thrown
+      // by compiledValidator(formData) does not evict a correctly-compiled schema.
+      if (!compiled && schemaId !== undefined) {
         this.ajv.removeSchema(schemaId);
       }
       return false;

--- a/packages/validator-ajv8/test/validator.test.ts
+++ b/packages/validator-ajv8/test/validator.test.ts
@@ -7,6 +7,7 @@ import type {
   ValidatorType,
 } from '@rjsf/utils';
 import { ErrorSchemaBuilder } from '@rjsf/utils';
+import type Ajv from 'ajv';
 import localize from 'ajv-i18n';
 import Ajv2019 from 'ajv/dist/2019';
 import Ajv2020 from 'ajv/dist/2020';
@@ -257,6 +258,64 @@ describe('AJV8Validator', () => {
         warnSpy.mockRestore();
         expect(result1).toBe(false);
         expect(result2).toBe(false);
+      });
+
+      it('rawValidation does not evict a correctly-compiled schema when data evaluation throws', () => {
+        // A keyword whose validate() throws during data evaluation (not compilation).
+        // The schema is valid and compiles fine; the throw happens when the compiled
+        // validator runs against formData.  The fix guards removeSchema with
+        // compiledValidator === undefined so only compile-phase failures evict.
+        const v = new AJV8Validator({
+          extenderFn: (ajv: Ajv) => {
+            ajv.addKeyword({
+              keyword: 'throwOnValidate',
+              schemaType: 'boolean',
+              validate: () => {
+                throw new Error('keyword threw during data evaluation');
+              },
+            });
+            return ajv;
+          },
+        });
+        const schema = { $id: 'test-exec-throw-raw', type: 'string', throwOnValidate: true } as unknown as RJSFSchema;
+
+        // First call — compiledValidator(formData) throws, so compilationError is set.
+        const result = v.rawValidation(schema, 'hello');
+        expect(result.validationError).toBeInstanceOf(Error);
+
+        // Schema must still be cached — the execution throw must not have evicted it.
+        expect(v.ajv.getSchema('test-exec-throw-raw')).toBeDefined();
+      });
+
+      it('isValid does not evict a correctly-compiled schema when data evaluation throws', () => {
+        const v = new AJV8Validator({
+          extenderFn: (ajv: Ajv) => {
+            ajv.addKeyword({
+              keyword: 'throwOnValidate',
+              schemaType: 'boolean',
+              validate: () => {
+                throw new Error('keyword threw during data evaluation');
+              },
+            });
+            return ajv;
+          },
+        });
+        const schema = {
+          $id: 'test-exec-throw-isvalid',
+          type: 'string',
+          throwOnValidate: true,
+        } as unknown as RJSFSchema;
+        const rootSchema: RJSFSchema = {};
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(noop);
+
+        // Execution throw — isValid should return false but NOT evict the schema.
+        const result = v.isValid(schema, 'hello', rootSchema);
+        expect(result).toBe(false);
+
+        // $id is preserved by withIdRefPrefix, so schemaId === schema.$id.
+        expect(v.ajv.getSchema('test-exec-throw-isvalid')).toBeDefined();
+
+        warnSpy.mockRestore();
       });
     });
     describe('validator.validateFormData()', () => {

--- a/packages/validator-ajv8/test/validator.test.ts
+++ b/packages/validator-ajv8/test/validator.test.ts
@@ -195,6 +195,70 @@ describe('AJV8Validator', () => {
         removeSchemaSpy.mockRestore();
       });
     });
+    describe('compilation error caching (issue #3933)', () => {
+      // AJV 8 registers a schema in its internal cache *before* running meta-schema
+      // validation (validateSchema: true by default). When that validation throws (e.g.
+      // anyOf: [] violates draft-07's minItems:1 requirement), the broken schema stays
+      // cached so subsequent compile calls skip revalidation and silently return no
+      // errors. The fix removes the schema from AJV's cache whenever a compilation
+      // error occurs so every call correctly produces a validationError.
+      it('rawValidation returns a validationError on repeated calls for a schema without $id', () => {
+        const v = new AJV8Validator({});
+        // Empty anyOf violates the draft-07 meta-schema (minItems: 1).
+        // The full-schema case from issue #3933 uses no $id, so AJV caches by object ref.
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: { foo: { type: 'string', anyOf: [] } },
+        };
+
+        const result1 = v.rawValidation(schema, {});
+        expect(result1.validationError).toBeInstanceOf(Error);
+
+        const result2 = v.rawValidation(schema, {});
+        expect(result2.validationError).toBeInstanceOf(Error);
+      });
+
+      it('rawValidation returns a validationError on repeated calls for a schema with $id', () => {
+        const v = new AJV8Validator({});
+        const schema: RJSFSchema = { $id: 'test-caching-raw-$id', anyOf: [] };
+
+        const result1 = v.rawValidation(schema, {});
+        expect(result1.validationError).toBeInstanceOf(Error);
+
+        const result2 = v.rawValidation(schema, {});
+        expect(result2.validationError).toBeInstanceOf(Error);
+      });
+
+      it('rawValidation returns a validationError when the schema was previously cached by isValid', () => {
+        const v = new AJV8Validator({});
+        // isValid uses addSchema (no meta-schema validation) so the broken schema
+        // ends up in AJV's registry as a compiled always-false validator.  A
+        // subsequent rawValidation call must not silently reuse that cached entry.
+        const schema: RJSFSchema = { $id: 'test-caching-isvalid-cross', anyOf: [] };
+        const rootSchema: RJSFSchema = {};
+
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(noop);
+        v.isValid(schema, {}, rootSchema);
+        warnSpy.mockRestore();
+
+        const result = v.rawValidation(schema, {});
+        expect(result.validationError).toBeInstanceOf(Error);
+      });
+
+      it('isValid returns false consistently when a compilation error occurs', () => {
+        const v = new AJV8Validator({});
+        // null is not a valid schema – AJV will throw when it tries to compile it.
+        const schema = null as unknown as RJSFSchema;
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(noop);
+
+        const result1 = v.isValid(schema, {}, schema);
+        const result2 = v.isValid(schema, {}, schema);
+
+        warnSpy.mockRestore();
+        expect(result1).toBe(false);
+        expect(result2).toBe(false);
+      });
+    });
     describe('validator.validateFormData()', () => {
       describe('No custom validate function, single value', () => {
         let errors: RJSFValidationError[];

--- a/packages/validator-ata/test/validator.test.ts
+++ b/packages/validator-ata/test/validator.test.ts
@@ -88,6 +88,20 @@ describe('ATAValidator', () => {
       const { validationError } = v.rawValidation(null as unknown as RJSFSchema, {});
       expect(validationError).toBeInstanceOf(Error);
     });
+
+    it('returns a validationError on every call for an invalid schema (no caching of errors)', () => {
+      const v = customizeValidator();
+      // Verify that a schema that fails construction is not cached between calls –
+      // each rawValidation call with the same invalid schema must produce a
+      // validationError, not silently succeed after the first failure.
+      const schema = null as unknown as RJSFSchema;
+
+      const result1 = v.rawValidation(schema, {});
+      expect(result1.validationError).toBeInstanceOf(Error);
+
+      const result2 = v.rawValidation(schema, {});
+      expect(result2.validationError).toBeInstanceOf(Error);
+    });
   });
 
   describe('validateFormData()', () => {

--- a/packages/validator-cfworker/test/validator.test.ts
+++ b/packages/validator-cfworker/test/validator.test.ts
@@ -68,6 +68,20 @@ describe('CFWorkerValidator', () => {
     expect(validator.rawValidation(null as unknown as RJSFSchema, {}).validationError).toBeInstanceOf(Error);
   });
 
+  it('returns a validationError on every call for an invalid schema (no caching of errors)', () => {
+    const validator = customizeValidator();
+    // Verify that an invalid schema is not cached between rawValidation calls so
+    // each call consistently returns a validationError rather than silently
+    // succeeding after the first failure.
+    const schema = null as unknown as RJSFSchema;
+
+    const result1 = validator.rawValidation(schema, {});
+    expect(result1.validationError).toBeInstanceOf(Error);
+
+    const result2 = validator.rawValidation(schema, {});
+    expect(result2.validationError).toBeInstanceOf(Error);
+  });
+
   it('runs transformErrors and customValidate hooks', () => {
     const validator = customizeValidator<{ value?: string }>();
     const schema: RJSFSchema = { type: 'object', required: ['value'], properties: { value: { type: 'string' } } };


### PR DESCRIPTION
### Reasons for making this change
Fixes #3933 as follows:

AJV 8 registers a schema in its internal cache before running meta-schema validation. When that check throws (e.g. anyOf:[] violates draft-07's minItems:1 requirement), the broken schema stays cached so subsequent compile() calls skip revalidation and silently return a compiled always-false validator with no compilationError.

Fix `rawValidation` to call `ajv.removeSchema()` in the catch block, evicting the entry by $id string or by object reference for anonymous schemas. Fix isValid to declare schemaId before the try block so the catch block can also evict any schema cached via addSchema that bypassed meta-schema validation.

Add unit tests that reproduce the bug (two consecutive rawValidation calls with the same invalid schema, plus an isValid→rawValidation cross- contamination case) and verify they pass after the fix. Add parallel regression tests for validator-ata and validator-cfworker confirming those validators already handle this correctly.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
