### PR TITLE
Fix 3251: retrieveSchema() dropping allOf/if-then properties when additionalProperties is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
-- Fixed `retrieveSchema()` to keep properties introduced by a matching `allOf`/`if`/`then`/`else` branch instead of silently dropping them when the outer schema has `additionalProperties: false`, fixing [#3251](https://github.com/rjsf-team/react-jsonschema-form/issues/3251)
+- Fixed `retrieveSchema()` and `omitExtraData()` to keep properties introduced by an `allOf` branch (including a matching `if`/`then`/`else` result) instead of silently dropping them when the outer schema has `additionalProperties: false`, fixing [#3251](https://github.com/rjsf-team/react-jsonschema-form/issues/3251)
 
 ## @rjsf/validator-cfworker
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 6.8.0
 
+## @rjsf/utils
+
+- Fixed `retrieveSchema()` to keep properties introduced by a matching `allOf`/`if`/`then`/`else` branch instead of silently dropping them when the outer schema has `additionalProperties: false`, fixing [#3251](https://github.com/rjsf-team/react-jsonschema-form/issues/3251)
+
 ## @rjsf/validator-cfworker
 
 - Added an eval-free, draft-2020-12 validator package backed by `@cfworker/json-schema`, including undefined form-data normalization and per-schema-id caching, fixing [#3269](https://github.com/rjsf-team/react-jsonschema-form/issues/3269) and contributing to [#4923](https://github.com/rjsf-team/react-jsonschema-form/issues/4923)

--- a/packages/utils/src/schema/omitExtraData.ts
+++ b/packages/utils/src/schema/omitExtraData.ts
@@ -20,7 +20,7 @@ import type {
 import getClosestMatchingOption from './getClosestMatchingOption';
 import isSelect from './isSelect';
 import { relaxOptionsForScoring, resolveAllReferences } from './retrieveSchema';
-import shallowAllOfMerge from './shallowAllOfMerge';
+import { mergeAllOfSchema } from './shallowAllOfMerge';
 
 /** Returns the `formData` with only the elements specified in the `fields` list
  *
@@ -101,20 +101,6 @@ export function isValueEmpty(value: unknown): boolean {
     return Object.values(value as GenericObjectType).every(isValueEmpty);
   }
   return false;
-}
-
-/** Merges an `allOf` schema into a single flat schema, delegating to `experimental_customMergeAllOf`
- * when provided or falling back to the module-level `shallowAllOfMerge` otherwise.
- *
- * @param schema - A schema containing an `allOf` array to be merged
- * @param [experimental_customMergeAllOf] - Optional custom merge function; see `Form` documentation
- * @returns - The merged schema with `allOf` resolved into a single schema object
- */
-function doMergeAllOf<S extends StrictRJSFSchema = RJSFSchema>(
-  schema: S,
-  experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>,
-): S {
-  return experimental_customMergeAllOf ? experimental_customMergeAllOf(schema) : (shallowAllOfMerge(schema) as S);
 }
 
 /** A recursive, schema-driven filter that walks `schema` and `formData` in lockstep, keeping only
@@ -447,7 +433,7 @@ export default function omitExtraData<
       return omit(findSchemaDefinition<S>(ref, rootSchema), source, target);
     }
     if (allOf) {
-      localSchema = doMergeAllOf<S>(localSchema, experimental_customMergeAllOf);
+      localSchema = mergeAllOfSchema<S>(localSchema, experimental_customMergeAllOf);
       // Schemas whose allOf entries contain if/then/else keywords may not fully merge: the merger
       // can only hoist one if/then/else triple to the parent level, so additional entries stay in
       // allOf. Process any that remain so their conditional properties are not silently dropped.

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -39,7 +39,7 @@ import type {
   ValidatorType,
 } from '../types';
 import getFirstMatchingOption from './getFirstMatchingOption';
-import shallowAllOfMerge from './shallowAllOfMerge';
+import { mergeAllOfSchema } from './shallowAllOfMerge';
 
 /** Retrieves an expanded schema that has had all of its conditions, additional properties, references and dependencies
  * resolved and merged into the `schema` given a `validator`, `rootSchema` and `rawFormData` that is used to do the
@@ -554,15 +554,6 @@ export function stubExistingAdditionalProperties<
   return schema;
 }
 
-/**
- * Internal helper that merges allOf schemas using @x0k/json-schema-merge's shallow allOf merge
- * @param schema - The schema containing an `allOf` keyword
- * @returns The schema with allOf schemas merged
- */
-function mergeAllOf<S extends StrictRJSFSchema = RJSFSchema>(schema: S): S {
-  return shallowAllOfMerge(schema) as S;
-}
-
 /** Internal handler that retrieves an expanded schema that has had all of its conditions, additional properties,
  * references and dependencies resolved and merged into the `schema` given a `validator`, `rootSchema` and `rawFormData`
  * that is used to do the potentially recursive resolution. If `expandAllBranches` is true, then all possible branches
@@ -647,24 +638,10 @@ export function retrieveSchemaInternal<
         if (withContainsSchemas.length) {
           resolvedSchema = { ...resolvedSchema, allOf: withoutContainsSchemas };
         }
-        if (experimental_customMergeAllOf) {
-          resolvedSchema = experimental_customMergeAllOf(resolvedSchema);
-        } else {
-          // JSON Schema evaluates `additionalProperties` against only its own schema's `properties`,
-          // not its allOf siblings, so a resolved `if`/`then`/`else` branch that introduces a new
-          // property would otherwise get silently dropped by the merge below whenever the outer
-          // schema has `additionalProperties: false`, fixing #3251. Widen it for the merge so the
-          // branch's property renders, then restore the original flag on the merged result so
-          // still-undeclared keys remain marked as disallowed.
-          const hadFalseAdditionalProperties = resolvedSchema.additionalProperties === false;
-          if (hadFalseAdditionalProperties) {
-            resolvedSchema = { ...resolvedSchema, additionalProperties: true };
-          }
-          resolvedSchema = mergeAllOf(resolvedSchema);
-          if (hadFalseAdditionalProperties) {
-            resolvedSchema = { ...resolvedSchema, additionalProperties: false };
-          }
-        }
+        // See `mergeAllOfSchema()` for why additionalProperties:false doesn't drop allOf/if-then
+        // properties here, fixing #3251; `resolvedSchema` is only reassigned once the merge fully
+        // succeeds, so a throw below leaves it untouched for the catch block.
+        resolvedSchema = mergeAllOfSchema(resolvedSchema, experimental_customMergeAllOf);
         // Re-apply collected Symbol properties that the merge dropped.
         for (const sym of Object.getOwnPropertySymbols(allOfSymbols)) {
           (resolvedSchema as any)[sym] = allOfSymbols[sym];

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -647,9 +647,24 @@ export function retrieveSchemaInternal<
         if (withContainsSchemas.length) {
           resolvedSchema = { ...resolvedSchema, allOf: withoutContainsSchemas };
         }
-        resolvedSchema = experimental_customMergeAllOf
-          ? experimental_customMergeAllOf(resolvedSchema)
-          : mergeAllOf(resolvedSchema);
+        if (experimental_customMergeAllOf) {
+          resolvedSchema = experimental_customMergeAllOf(resolvedSchema);
+        } else {
+          // JSON Schema evaluates `additionalProperties` against only its own schema's `properties`,
+          // not its allOf siblings, so a resolved `if`/`then`/`else` branch that introduces a new
+          // property would otherwise get silently dropped by the merge below whenever the outer
+          // schema has `additionalProperties: false`, fixing #3251. Widen it for the merge so the
+          // branch's property renders, then restore the original flag on the merged result so
+          // still-undeclared keys remain marked as disallowed.
+          const hadFalseAdditionalProperties = resolvedSchema.additionalProperties === false;
+          if (hadFalseAdditionalProperties) {
+            resolvedSchema = { ...resolvedSchema, additionalProperties: true };
+          }
+          resolvedSchema = mergeAllOf(resolvedSchema);
+          if (hadFalseAdditionalProperties) {
+            resolvedSchema = { ...resolvedSchema, additionalProperties: false };
+          }
+        }
         // Re-apply collected Symbol properties that the merge dropped.
         for (const sym of Object.getOwnPropertySymbols(allOfSymbols)) {
           (resolvedSchema as any)[sym] = allOfSymbols[sym];

--- a/packages/utils/src/schema/shallowAllOfMerge.ts
+++ b/packages/utils/src/schema/shallowAllOfMerge.ts
@@ -1,19 +1,51 @@
 import { createComparator, createMerger, createShallowAllOfMerge } from '@x0k/json-schema-merge';
 import { createDeduplicator, createIntersector } from '@x0k/json-schema-merge/lib/array';
 
+import type { Experimental_CustomMergeAllOf, RJSFSchema, StrictRJSFSchema } from '../types';
+
 const { compareSchemaDefinitions, compareSchemaValues } = createComparator();
 const { mergeArrayOfSchemaDefinitions } = createMerger({
   intersectJson: createIntersector(compareSchemaValues),
   deduplicateJsonSchemaDef: createDeduplicator(compareSchemaDefinitions),
 });
 
-/** Shared `@x0k/json-schema-merge` shallow-allOf merge function used by `retrieveSchema` and
- * `omitExtraData`. Constructed once from a single comparator/merger/intersector/deduplicator
- * pipeline so both consumers share the same configuration without duplicating setup code.
+/** Shared `@x0k/json-schema-merge` shallow-allOf merge function used by `mergeAllOfSchema`. Constructed
+ * once from a single comparator/merger/intersector/deduplicator pipeline so both consumers share the
+ * same configuration without duplicating setup code.
  *
  * Usage: pass a schema that contains an `allOf` keyword and receive the merged result.
  *
  * @example
  * const merged = shallowAllOfMerge(schema); // schema.allOf is merged into the parent schema
  */
-export default createShallowAllOfMerge(mergeArrayOfSchemaDefinitions);
+const shallowAllOfMerge = createShallowAllOfMerge(mergeArrayOfSchemaDefinitions);
+
+/** Merges a schema's `allOf` array into itself, delegating to `experimental_customMergeAllOf` when
+ * provided or to the shared `shallowAllOfMerge` otherwise. Used by both `retrieveSchema` (to decide what
+ * to render) and `omitExtraData` (to decide what submitted data to keep).
+ *
+ * `additionalProperties` only ever considers a schema's own `properties`/`patternProperties`, never its
+ * allOf siblings, so the shared merge silently drops any property introduced by an allOf branch (e.g. a
+ * resolved `if`/`then`/`else` result) whenever `schema` has `additionalProperties: false`. To keep those
+ * properties, `additionalProperties` is temporarily widened to `true` for the merge and the original
+ * value is restored on the merged result -- `resolvedSchema` is only ever assigned the fully
+ * widened-merged-restored value, never an intermediate one, so a throw from the merge leaves the
+ * caller's schema untouched instead of stuck in the widened state. The widen/restore is skipped
+ * entirely when a custom merge function is supplied, since that caller owns the merge semantics.
+ *
+ * @param schema - A schema containing an `allOf` array to be merged
+ * @param [experimental_customMergeAllOf] - Optional custom merge function; see `Form` documentation
+ * @returns - The merged schema with `allOf` resolved into a single schema object
+ */
+export function mergeAllOfSchema<S extends StrictRJSFSchema = RJSFSchema>(
+  schema: S,
+  experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>,
+): S {
+  if (experimental_customMergeAllOf) {
+    return experimental_customMergeAllOf(schema);
+  }
+  const hadFalseAdditionalProperties = schema.additionalProperties === false;
+  const schemaToMerge = hadFalseAdditionalProperties ? { ...schema, additionalProperties: true } : schema;
+  const merged = shallowAllOfMerge(schemaToMerge) as S;
+  return hadFalseAdditionalProperties ? { ...merged, additionalProperties: false } : merged;
+}

--- a/packages/utils/test/schema/omitExtraDataTest.ts
+++ b/packages/utils/test/schema/omitExtraDataTest.ts
@@ -985,6 +985,18 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
         expect(omitExtraData(testValidator, schema, schema, formData)).toEqual({ foo: 'hello', bar: 42 });
       });
 
+      it('keeps an allOf-introduced property when the outer schema has additionalProperties:false', () => {
+        // https://github.com/rjsf-team/react-jsonschema-form/issues/3251
+        const schema: RJSFSchema = {
+          type: 'object',
+          additionalProperties: false,
+          properties: { foo: { type: 'string' } },
+          allOf: [{ properties: { bar: { type: 'number' } } }],
+        };
+        const formData = { foo: 'hello', bar: 42, extra: 'drop' };
+        expect(omitExtraData(testValidator, schema, schema, formData)).toEqual({ foo: 'hello', bar: 42 });
+      });
+
       it('treats every key as optional when a property schema is boolean true (no required list)', () => {
         // boolean true is a JSON Schema shorthand for "allow anything". It carries no required list,
         // so setProperty treats all keys in the object value as optional.

--- a/packages/utils/test/schema/retrieveSchemaTest.ts
+++ b/packages/utils/test/schema/retrieveSchemaTest.ts
@@ -1054,6 +1054,24 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
           expect.any(Error),
         );
       });
+      it('should preserve additionalProperties:false when an allOf merge throws', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          additionalProperties: false,
+          properties: { abc: { type: 'string' } },
+          allOf: [{ type: 'string' }, { type: 'boolean' }],
+        };
+        const rootSchema: RJSFSchema = { definitions: {} };
+        expect(retrieveSchema(testValidator, schema, rootSchema, {})).toEqual({
+          type: 'object',
+          additionalProperties: false,
+          properties: { abc: { type: 'string' } },
+        });
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          expect.stringMatching(/could not merge subschemas in allOf/),
+          expect.any(Error),
+        );
+      });
       it('should return allOf and top level schemas when expand all', () => {
         const schema: RJSFSchema = {
           properties: { test: { type: 'string' } },

--- a/packages/utils/test/schema/retrieveSchemaTest.ts
+++ b/packages/utils/test/schema/retrieveSchemaTest.ts
@@ -991,6 +991,57 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
           ],
         });
       });
+      it('should merge properties from an if/then branch even when additionalProperties is false', () => {
+        // https://github.com/rjsf-team/react-jsonschema-form/issues/3251
+        const makeSchema = (): RJSFSchema => ({
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            abc: { type: 'string', enum: ['value1', 'value2'], default: 'value1' },
+          },
+          allOf: [
+            {
+              if: { properties: { abc: { enum: ['value1'] } } },
+              then: { properties: { def: { type: 'string' } }, required: ['def'] },
+            },
+            {
+              if: { properties: { abc: { enum: ['value2'] } } },
+              then: { properties: { ghj: { type: 'string' } }, required: ['ghj'] },
+            },
+          ],
+        });
+        const rootSchema: RJSFSchema = { definitions: {} };
+        testValidator.setReturnValues({
+          isValid: [
+            true, // First condition abc === value1 pass
+            false, // Second condition abc === value2 fail
+          ],
+        });
+        expect(retrieveSchema(testValidator, makeSchema(), rootSchema, { abc: 'value1' })).toEqual({
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            abc: { type: 'string', enum: ['value1', 'value2'], default: 'value1' },
+            def: { type: 'string' },
+          },
+          required: ['def'],
+        });
+        testValidator.setReturnValues({
+          isValid: [
+            false, // First condition abc === value1 fail
+            true, // Second condition abc === value2 pass
+          ],
+        });
+        expect(retrieveSchema(testValidator, makeSchema(), rootSchema, { abc: 'value2' })).toEqual({
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            abc: { type: 'string', enum: ['value1', 'value2'], default: 'value1' },
+            ghj: { type: 'string' },
+          },
+          required: ['ghj'],
+        });
+      });
       it('should not merge incompatible types', () => {
         const schema: RJSFSchema = {
           allOf: [{ type: 'string' }, { type: 'boolean' }],


### PR DESCRIPTION
### Reasons for making this change

Fixes #3251 as follows:

JSON Schema's `additionalProperties` only ever looks at a schema's own `properties`, never a sibling `allOf` branch's, so a resolved `if`/`then` branch that introduces a new property was silently stripped out during retrieveSchema's merge whenever the outer schema declared `additionalProperties: false` -- leaving it required but never rendered. Widen `additionalProperties` to `true` for just that merge call and restore it afterward so the branch's property renders while unrelated keys are still treated as disallowed, fixing #3251.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
