### PR TITLE
fix(core): preserve seconds precision in TimeWidget and sync displayed value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 6.8.0
 
+## @rjsf/core
+
+- Fixed `TimeWidget` to respect schema `multipleOf` time precision, preserving second-precision values while keeping minute-precision native inputs synchronized with their displayed value ([#5174](https://github.com/rjsf-team/react-jsonschema-form/pull/5174))
+
 ## @rjsf/validator-ata
 
 - Raised the `ata-validator` requirement to `^1.3.0`, which fixes a `$ref` that could not be resolved being treated as vacuous rather than reported as an error ([#5181](https://github.com/rjsf-team/react-jsonschema-form/pull/5181))

--- a/packages/core/src/components/widgets/TimeWidget.tsx
+++ b/packages/core/src/components/widgets/TimeWidget.tsx
@@ -10,9 +10,24 @@ import { getTemplate } from '@rjsf/utils';
 export default function TimeWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: WidgetProps<T, S, F>,
 ) {
-  const { onChange, options, registry } = props;
+  const { onChange, options, registry, schema, value } = props;
   const BaseInputTemplate = getTemplate<'BaseInputTemplate', T, S, F>('BaseInputTemplate', registry, options);
-  const handleChange = useCallback((value: any) => onChange(value ? `${value}:00` : undefined), [onChange]);
+  const hasSecondPrecision =
+    typeof schema.multipleOf === 'number' && Number.isFinite(schema.multipleOf) && schema.multipleOf < 60;
+  const handleChange = useCallback(
+    (newValue: any) => {
+      if (!newValue) {
+        onChange(undefined);
+      } else if (hasSecondPrecision) {
+        onChange(newValue);
+      } else {
+        onChange(`${newValue}:00`);
+      }
+    },
+    [hasSecondPrecision, onChange],
+  );
+  const displayValue =
+    typeof value === 'string' && !hasSecondPrecision && /^\d{2}:\d{2}:00$/.test(value) ? value.slice(0, -3) : value;
 
-  return <BaseInputTemplate type='time' {...props} onChange={handleChange} />;
+  return <BaseInputTemplate type='time' {...props} value={displayValue} onChange={handleChange} />;
 }

--- a/packages/core/test/StringField.test.tsx
+++ b/packages/core/test/StringField.test.tsx
@@ -984,7 +984,60 @@ describe('StringField', () => {
       await user.click(input);
       await user.paste(newTime);
 
-      expect(input).toHaveValue(`${newTime}:00`);
+      expect(input).toHaveValue(newTime);
+    });
+
+    it('should preserve seconds precision changes in the dom', async () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'time',
+          multipleOf: 1,
+        },
+      });
+
+      const newTime = '11:10:12';
+      const input = node.querySelector<HTMLInputElement>('[type=time]')!;
+      fireEvent.change(input, { target: { value: newTime } });
+
+      expect(input).toHaveValue(newTime);
+    });
+
+    it('should render stored minute precision values without seconds', () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'time',
+        },
+        formData: '13:10:00',
+      });
+
+      expect(node.querySelector<HTMLInputElement>('[type=time]')).toHaveValue('13:10');
+    });
+
+    it('should preserve seconds in the dom when the input precision includes seconds', () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'time',
+          multipleOf: 1,
+        },
+        formData: '13:10:00',
+      });
+
+      expect(node.querySelector<HTMLInputElement>('[type=time]')).toHaveValue('13:10:00');
+    });
+
+    it('should preserve non-zero seconds in the dom', () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'time',
+        },
+        formData: '13:10:30',
+      });
+
+      expect(node.querySelector<HTMLInputElement>('[type=time]')).toHaveValue('13:10:30');
     });
 
     it('should fill field with data', async () => {


### PR DESCRIPTION
## Summary

Fix `TimeWidget` so it stays in sync with the native browser `time` input and respects schema-level time precision.

Previously, the widget always normalized browser edits by appending `:00`. That caused two problems:

1. For minute-precision inputs, the browser edited `HH:mm` while the widget re-rendered `HH:mm:ss`, creating controlled input sync issues.
2. For second-precision inputs, such as when `schema.multipleOf < 60`, the widget still appended `:00`, producing invalid values like `09:22:12:00`.

## Root Cause

`TimeWidget` normalized values on change without considering whether the schema enabled seconds precision, and it rendered stored `HH:mm:ss` values directly back into native minute-precision inputs.

## Fix

- use `schema.multipleOf` as the precision signal for `time` values
- when seconds precision is enabled (`multipleOf < 60`):
  - preserve the browser value as-is
  - do not append `:00`
  - do not strip seconds on render
- when seconds precision is not enabled:
  - preserve backward-compatible stored values as `HH:mm:ss`
  - render stored `HH:mm:00` values as `HH:mm`
  - append `:00` when the browser emits `HH:mm`

## Backward Compatibility

This change does not alter the stored representation for minute-precision values, which remains `HH:mm:ss`.

The only behavioral change is:

- native minute-precision inputs now receive `HH:mm` instead of `HH:mm:ss`
- second-precision inputs now preserve `HH:mm:ss` instead of incorrectly appending `:00`

## Testing

- `pnpm nx lint @rjsf/core`
- `pnpm test -- StringField.test.tsx -t TimeWidget`
- `pnpm nx test @rjsf/core`
