### PR TITLE
fix(chakra-ui): wrap ChakraProvider in EnvironmentProvider for iframe…

### DIFF
--- a/packages/chakra-ui/src/ChakraFrameProvider.tsx
+++ b/packages/chakra-ui/src/ChakraFrameProvider.tsx
@@ -1,4 +1,4 @@
-import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
+import { ChakraProvider, EnvironmentProvider, defaultSystem } from '@chakra-ui/react';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import weakMemoize from '@emotion/weak-memoize';
@@ -23,12 +23,12 @@ const memoizedCreateCacheWithContainer = weakMemoize((container: HTMLElement) =>
   return newCache;
 });
 
-export const __createChakraFrameProvider =
-  (props: any) =>
-  ({ document }: any) => (
-    <div style={{ margin: 2 }}>
-      <CacheProvider value={memoizedCreateCacheWithContainer(document.head)}>
+export const __createChakraFrameProvider = (props: any) => ({ document }: any) => (
+  <div style={{ margin: 2 }}>
+    <CacheProvider value={memoizedCreateCacheWithContainer(document.head)}>
+      <EnvironmentProvider value={() => document}>
         <ChakraProvider value={defaultSystem}>{props.children}</ChakraProvider>
-      </CacheProvider>
-    </div>
-  );
+      </EnvironmentProvider>
+    </CacheProvider>
+  </div>
+);


### PR DESCRIPTION
### Reasons for making this change

Fixes #4584

Wrapped `<ChakraProvider>` in `<EnvironmentProvider value={() => document}>` inside `ChakraFrameProvider.tsx`.

When Chakra UI components are rendered inside `<DemoFrame>` (an iframe context), interactive pointer and drag events (such as slider controls) fail to register properly because Chakra's internal state machine loses track of the iframe's DOM context. Passing `EnvironmentProvider` explicitly binds Chakra to the iframe's `document` context, restoring full pointer and drag interactivity.

*Note for maintainers:* The fix was updated to match Chakra UI's frame provider context pattern. I haven't run the playground build locally yet—would appreciate verification via CI or preview builds.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated docs if needed
  - [ ] I've updated the changelog with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature