### PR TITLE
Require ata-validator 1.3.0 in @rjsf/validator-ata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 6.8.0
 
+## @rjsf/validator-ata
+
+- Raised the `ata-validator` requirement to `^1.3.0`, which fixes a `$ref` that could not be resolved being treated as vacuous rather than reported as an error ([#5181](https://github.com/rjsf-team/react-jsonschema-form/pull/5181))
+
 ## @rjsf/validator-cfworker
 
 - Added an eval-free, draft-2020-12 validator package backed by `@cfworker/json-schema`, including undefined form-data normalization and per-schema-id caching, fixing [#3269](https://github.com/rjsf-team/react-jsonschema-form/issues/3269) and contributing to [#4923](https://github.com/rjsf-team/react-jsonschema-form/issues/4923)

--- a/packages/validator-ata/package.json
+++ b/packages/validator-ata/package.json
@@ -77,7 +77,7 @@
     ]
   },
   "dependencies": {
-    "ata-validator": "^1.1.0",
+    "ata-validator": "^1.3.0",
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -915,8 +915,8 @@ importers:
   packages/validator-ata:
     dependencies:
       ata-validator:
-        specifier: ^1.1.0
-        version: 1.1.0(yaml@2.9.0)
+        specifier: ^1.3.0
+        version: 1.3.0(yaml@2.9.0)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -1098,37 +1098,37 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@ata-validator/native-darwin-arm64@1.1.0':
-    resolution: {integrity: sha512-FLZxpdmEwyYEAFp4lp8jFfPVdPfel8JVqN2HZnebs6Mto7zoalJmb6xyPtezas8Qn4yfRtneG4P9NrhETKxASg==}
+  '@ata-validator/native-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-k6XaL2SFt4zkw3AKSC1hWSRHlJwx/oi5H1uF8Nkkd4E0qBLw6TyyX7GpNBFpxsZFPWk7gpPptNjpljNLhNqI3w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@ata-validator/native-linux-arm64-gnu@1.1.0':
-    resolution: {integrity: sha512-+znJvO60K0UKuZ8CHVvnGy9Ug0wTm4WF6LUwiDPu9PzNZYyZwVbxFWpIQqgJnnvKZSmGbpCWG2mS05UpB3FUjA==}
+  '@ata-validator/native-linux-arm64-gnu@1.3.0':
+    resolution: {integrity: sha512-ZH76XGSi6OPrioNpdfi/mYsL4DoJ0dcpLeWNj/yrbbJe/qpH4zHyxRJtbewBf2CYJbYwEfTcnayQtKs6+EcJ7A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@ata-validator/native-linux-arm64-musl@1.1.0':
-    resolution: {integrity: sha512-vN9e+0COb+LL+FJ/Wg2v8vEKyPfGOWdZSb6WR11tCrkEIanqmxxuhJWx6lnYqjpxLOxaaj2WCYQAyd0kAfh1dw==}
+  '@ata-validator/native-linux-arm64-musl@1.3.0':
+    resolution: {integrity: sha512-XMLD8VA1Oon0ZoO/Ny/hjyQbL8EKOCAMSRzDx53DONpRaOte1kVd6RPr+oBc2zmQ53PcLtwy4DbViCWy6D56Zw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@ata-validator/native-linux-x64-gnu@1.1.0':
-    resolution: {integrity: sha512-YnqE3/JY7GhfGAoigsNFkhHSL6MLTCy5ijKhp57qTBkZYCq9qVie+9yA0QRNV6333wgFXkc8s4UNc5wJv/yadQ==}
+  '@ata-validator/native-linux-x64-gnu@1.3.0':
+    resolution: {integrity: sha512-zNxLcJEPYN+KOI9GCaUjBCz5Ps0IxBcU3QzU0UOYHHspkp8paJkK/9JeYAiD7OhhOfhiKJv9nOMXHpMSO2S8OA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@ata-validator/native-linux-x64-musl@1.1.0':
-    resolution: {integrity: sha512-DHIJQtrx6WaPtUyXq/O5LqHsMY/N5dTvM4zPaKGuNEPvGOfOOd29zOsjtW6z+vkmavdiXrh5CurbjJ+EQXeEMA==}
+  '@ata-validator/native-linux-x64-musl@1.3.0':
+    resolution: {integrity: sha512-cynVNNU29Ii8fIR0/QtGbM8c6oaO2Wn7RCn9YTecLFnvQ5sxtLdUGEcY8CWf0fP89Tq4tobFhYG++g5jLumk8w==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@ata-validator/native-win32-x64@1.1.0':
-    resolution: {integrity: sha512-2mScswxrqhCOyvcHtNJMCzKZdrgeNjcBRupi9Jx2zDsQmczGeH3MhecfnU03D8qBzSMeztpbWMqYZgJN/8JWnw==}
+  '@ata-validator/native-win32-x64@1.3.0':
+    resolution: {integrity: sha512-c5TEgcSPx9++huzEsbCkdqWUFRji4rCQtJYDKO0K8GDdCfQG5K8bWKvvB6RbHoXwEWKrXYoLOGNNxv2LuTPkQA==}
     cpu: [x64]
     os: [win32]
 
@@ -6100,8 +6100,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  ata-validator@1.1.0:
-    resolution: {integrity: sha512-xfp3VJyYuDhfvdUaRnBOhRHEUQBC4brK9fwkeyfb56KUcFmUMWkwYIvOLSpG1SppzMwx13qQdq7RmkNeU9mWVg==}
+  ata-validator@1.3.0:
+    resolution: {integrity: sha512-YYhqGTSGmsUyuMa9KyTjtKotINvWNAoSsjeVajSRckb62kf9xZJeS0gKc9RiB+SBD8LEXky6RemK2UNUthSvZg==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -11389,22 +11389,22 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@ata-validator/native-darwin-arm64@1.1.0':
+  '@ata-validator/native-darwin-arm64@1.3.0':
     optional: true
 
-  '@ata-validator/native-linux-arm64-gnu@1.1.0':
+  '@ata-validator/native-linux-arm64-gnu@1.3.0':
     optional: true
 
-  '@ata-validator/native-linux-arm64-musl@1.1.0':
+  '@ata-validator/native-linux-arm64-musl@1.3.0':
     optional: true
 
-  '@ata-validator/native-linux-x64-gnu@1.1.0':
+  '@ata-validator/native-linux-x64-gnu@1.3.0':
     optional: true
 
-  '@ata-validator/native-linux-x64-musl@1.1.0':
+  '@ata-validator/native-linux-x64-musl@1.3.0':
     optional: true
 
-  '@ata-validator/native-win32-x64@1.1.0':
+  '@ata-validator/native-win32-x64@1.3.0':
     optional: true
 
   '@babel/code-frame@7.29.7':
@@ -18378,14 +18378,14 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  ata-validator@1.1.0(yaml@2.9.0):
+  ata-validator@1.3.0(yaml@2.9.0):
     optionalDependencies:
-      '@ata-validator/native-darwin-arm64': 1.1.0
-      '@ata-validator/native-linux-arm64-gnu': 1.1.0
-      '@ata-validator/native-linux-arm64-musl': 1.1.0
-      '@ata-validator/native-linux-x64-gnu': 1.1.0
-      '@ata-validator/native-linux-x64-musl': 1.1.0
-      '@ata-validator/native-win32-x64': 1.1.0
+      '@ata-validator/native-darwin-arm64': 1.3.0
+      '@ata-validator/native-linux-arm64-gnu': 1.3.0
+      '@ata-validator/native-linux-arm64-musl': 1.3.0
+      '@ata-validator/native-linux-x64-gnu': 1.3.0
+      '@ata-validator/native-linux-x64-musl': 1.3.0
+      '@ata-validator/native-win32-x64': 1.3.0
       yaml: 2.9.0
 
   atob@2.1.2: {}


### PR DESCRIPTION
Raises the `ata-validator` requirement in `@rjsf/validator-ata` from `^1.1.0` to `^1.3.0`.

### Why

1.3.0 fixes a reference that could not be resolved being treated as vacuous. The
code generator emitted no check for it at all, so a schema carrying a `$ref` that
names a `$defs` entry or an anchor which does not exist reported valid for every
input instead of raising an error:

```js
new Validator({ $ref: '#/$defs/Uesr' }).validate(anythingAtAll).valid // => true before 1.3.0
```

A cross-schema `$ref` to a schema that was never registered already errored
correctly, so the affected case is a fragment-only reference into the same
document. Form schemas lean on `$ref` and `definitions`, which is why it seems
worth requiring rather than leaving to chance.

The caret range already allowed 1.3.0 for a fresh install. Raising the floor is
what moves projects with a committed lockfile off the affected versions.

1.3.0 also fixes references that resolve relative to an enclosing base URI, which
were matched by path suffix rather than resolved against a base, and adds
`useDefaults` and `assertFormat` options. Both default to `true`, so nothing
changes for this package.

### Lockfile

The lockfile change is limited to the seven ata entries: versions and integrity
hashes, 29 insertions against 29 deletions.

Regenerating it wholesale with the pinned pnpm (10.17.1) is not what this branch
does, deliberately. That produced a much larger diff whose bulk was `libc:` being
stripped from around sixty unrelated native packages across the workspace, which
would change optional dependency selection on musl. Only the ata entries are
touched here. `pnpm install --frozen-lockfile` accepts the result.

### Checks

Package tests pass unchanged: 1273 tests across 8 files, coverage still 100% on
statements, branches, functions and lines.
