### PR TITLE
Require ata-validator 1.6.0 in @rjsf/validator-ata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/validator-ata
 
 - Raised the `ata-validator` requirement to `^1.3.0`, which fixes a `$ref` that could not be resolved being treated as vacuous rather than reported as an error ([#5181](https://github.com/rjsf-team/react-jsonschema-form/pull/5181))
+- Raised the `ata-validator` requirement to `^1.6.0`, so that validation runs correctly where `new Function` is refused, such as a page under a strict Content-Security-Policy ([#5184](https://github.com/rjsf-team/react-jsonschema-form/pull/5184))
 
 ## @rjsf/validator-cfworker
 

--- a/packages/validator-ata/package.json
+++ b/packages/validator-ata/package.json
@@ -77,7 +77,7 @@
     ]
   },
   "dependencies": {
-    "ata-validator": "^1.3.0",
+    "ata-validator": "^1.6.0",
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -915,8 +915,8 @@ importers:
   packages/validator-ata:
     dependencies:
       ata-validator:
-        specifier: ^1.3.0
-        version: 1.3.0(yaml@2.9.0)
+        specifier: ^1.6.0
+        version: 1.6.0(yaml@2.9.0)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -1098,37 +1098,37 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@ata-validator/native-darwin-arm64@1.3.0':
-    resolution: {integrity: sha512-k6XaL2SFt4zkw3AKSC1hWSRHlJwx/oi5H1uF8Nkkd4E0qBLw6TyyX7GpNBFpxsZFPWk7gpPptNjpljNLhNqI3w==}
+  '@ata-validator/native-darwin-arm64@1.6.0':
+    resolution: {integrity: sha512-n65/WAXwF7e6yiir1xHMavksu6z37CRcVMwZbsya1ehLdgDT1xTwXhoZhO5W92VyYOPtCCP+W+klZF0TmuoUcw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@ata-validator/native-linux-arm64-gnu@1.3.0':
-    resolution: {integrity: sha512-ZH76XGSi6OPrioNpdfi/mYsL4DoJ0dcpLeWNj/yrbbJe/qpH4zHyxRJtbewBf2CYJbYwEfTcnayQtKs6+EcJ7A==}
+  '@ata-validator/native-linux-arm64-gnu@1.6.0':
+    resolution: {integrity: sha512-vII4nY3Hy/9R4dKz9v1DzN/coD0rqQsSEYoimLpG/QsGK6Lg9dg+pN4jDirJaSJS/M7UQnQBy1MQNNBCc8VcRQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@ata-validator/native-linux-arm64-musl@1.3.0':
-    resolution: {integrity: sha512-XMLD8VA1Oon0ZoO/Ny/hjyQbL8EKOCAMSRzDx53DONpRaOte1kVd6RPr+oBc2zmQ53PcLtwy4DbViCWy6D56Zw==}
+  '@ata-validator/native-linux-arm64-musl@1.6.0':
+    resolution: {integrity: sha512-0vagQh4axlSoQxSgFdhQc+ZlHsr0rtJtg3zig+8felNuhb+BxqvUf5Qvn+Z0E2LLiVyU/IrnYxSfK2tHOv/kGw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@ata-validator/native-linux-x64-gnu@1.3.0':
-    resolution: {integrity: sha512-zNxLcJEPYN+KOI9GCaUjBCz5Ps0IxBcU3QzU0UOYHHspkp8paJkK/9JeYAiD7OhhOfhiKJv9nOMXHpMSO2S8OA==}
+  '@ata-validator/native-linux-x64-gnu@1.6.0':
+    resolution: {integrity: sha512-Qmbfh6Z1vUTSzY6xZtWll77b2GkZu13JyIMmyADX2d3wA0DfM1kfLSMHTW8wNEHpwHLit2v5WSKJ1VEHAAkrdA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@ata-validator/native-linux-x64-musl@1.3.0':
-    resolution: {integrity: sha512-cynVNNU29Ii8fIR0/QtGbM8c6oaO2Wn7RCn9YTecLFnvQ5sxtLdUGEcY8CWf0fP89Tq4tobFhYG++g5jLumk8w==}
+  '@ata-validator/native-linux-x64-musl@1.6.0':
+    resolution: {integrity: sha512-Ghh/n4XN4lAGR10dPujz9E9ZsFDqmNxlRT/1XmgJxRYDEjYzsek2+LSaeUYUHGXdDypVcd2+8ZOgjcaovsmWWQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@ata-validator/native-win32-x64@1.3.0':
-    resolution: {integrity: sha512-c5TEgcSPx9++huzEsbCkdqWUFRji4rCQtJYDKO0K8GDdCfQG5K8bWKvvB6RbHoXwEWKrXYoLOGNNxv2LuTPkQA==}
+  '@ata-validator/native-win32-x64@1.6.0':
+    resolution: {integrity: sha512-yk78kHvL/jJRSVZl3OXToz+K4ygpycEX8sr+E02OSNpR6K+9qg5EE8O+bnAQQYgeumFug7DPraEJ/fnjntUFHA==}
     cpu: [x64]
     os: [win32]
 
@@ -6100,8 +6100,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  ata-validator@1.3.0:
-    resolution: {integrity: sha512-YYhqGTSGmsUyuMa9KyTjtKotINvWNAoSsjeVajSRckb62kf9xZJeS0gKc9RiB+SBD8LEXky6RemK2UNUthSvZg==}
+  ata-validator@1.6.0:
+    resolution: {integrity: sha512-ZJ1hRDPZXhE7yg392+Dx+GVaq0qFHgIgVi5V0XFJ2Ftpvq0ke+HcCGWkuH2Vo1AZNQloyFLIOH5+o6X4pVn8Pw==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -11389,22 +11389,22 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@ata-validator/native-darwin-arm64@1.3.0':
+  '@ata-validator/native-darwin-arm64@1.6.0':
     optional: true
 
-  '@ata-validator/native-linux-arm64-gnu@1.3.0':
+  '@ata-validator/native-linux-arm64-gnu@1.6.0':
     optional: true
 
-  '@ata-validator/native-linux-arm64-musl@1.3.0':
+  '@ata-validator/native-linux-arm64-musl@1.6.0':
     optional: true
 
-  '@ata-validator/native-linux-x64-gnu@1.3.0':
+  '@ata-validator/native-linux-x64-gnu@1.6.0':
     optional: true
 
-  '@ata-validator/native-linux-x64-musl@1.3.0':
+  '@ata-validator/native-linux-x64-musl@1.6.0':
     optional: true
 
-  '@ata-validator/native-win32-x64@1.3.0':
+  '@ata-validator/native-win32-x64@1.6.0':
     optional: true
 
   '@babel/code-frame@7.29.7':
@@ -18378,14 +18378,14 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  ata-validator@1.3.0(yaml@2.9.0):
+  ata-validator@1.6.0(yaml@2.9.0):
     optionalDependencies:
-      '@ata-validator/native-darwin-arm64': 1.3.0
-      '@ata-validator/native-linux-arm64-gnu': 1.3.0
-      '@ata-validator/native-linux-arm64-musl': 1.3.0
-      '@ata-validator/native-linux-x64-gnu': 1.3.0
-      '@ata-validator/native-linux-x64-musl': 1.3.0
-      '@ata-validator/native-win32-x64': 1.3.0
+      '@ata-validator/native-darwin-arm64': 1.6.0
+      '@ata-validator/native-linux-arm64-gnu': 1.6.0
+      '@ata-validator/native-linux-arm64-musl': 1.6.0
+      '@ata-validator/native-linux-x64-gnu': 1.6.0
+      '@ata-validator/native-linux-x64-musl': 1.6.0
+      '@ata-validator/native-win32-x64': 1.6.0
       yaml: 2.9.0
 
   atob@2.1.2: {}


### PR DESCRIPTION
Raises the `ata-validator` requirement in `@rjsf/validator-ata` from `^1.3.0` to `^1.6.0`.

### Why

1.4.0 is the reason to raise the floor. Where `new Function` is refused, the
validator used to survive the refusal and go on handling schemas it got wrong,
silently. It now runs on an interpreted engine instead, scoring 1286 of 1290 on
the official Draft 2020-12 suite with `eval` and `new Function` blocked, against
1188 before, with no schema failing to build.

That matters here because a page served under a strict Content-Security-Policy is
an ordinary deployment for a form library, not an edge case, and the same applies
to forms rendered on Cloudflare Workers or Deno Deploy. A caret range already
allows 1.4.0 for a fresh install; raising the floor is what moves projects with a
committed lockfile off the affected versions.

Two additions come along with it and change nothing for existing schemas. 1.5.0
adds `propertyDependencies`, which selects a subschema by the value of a property
rather than by its presence. 1.6.0 adds the JSON Schema v1 dialect, selected by
`$schema`; a schema that does not declare it takes the path it always did.

### Lockfile

The change is limited to the seven ata entries, versions and integrity hashes,
29 insertions against 29 deletions.

As in #5181, regenerating the lockfile wholesale with the pinned pnpm (10.17.1)
strips `libc:` from around sixty unrelated native packages across the workspace,
which would change optional dependency selection on musl. Those lines are put
back, so only the ata entries are touched. `pnpm install --frozen-lockfile`
accepts the result.

### Checks

Package tests pass unchanged against 1.6.0: 1274 tests across 8 files, coverage
still 100%. That includes the precompiled path, `compileSchemaValidators`,
`compileSchemaValidatorsCode`, `createPrecompiledValidator` and
`precompiledValidator`. `build:ts` and `lint` are clean.

The playground is not covered by this, since it needs a full workspace build.
