### PR TITLE
Fix defaults for single-element allOf-wrapped $ref

### DIFF
--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -304,6 +304,22 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
     if (shouldMergeDefaultsIntoFormData && schemaToCompute && !isObject(rawFormData)) {
       formData = rawFormData as T;
     }
+  } else if (
+    schema[ALL_OF_KEY]?.length === 1 &&
+    isObject(schema[ALL_OF_KEY][0]) &&
+    REF_KEY in schema[ALL_OF_KEY][0] &&
+    !_recurseList.includes(schema[ALL_OF_KEY][0][REF_KEY]!)
+  ) {
+    // A single referenced schema wrapped in allOf is equivalent to the resolved schema plus any sibling keywords.
+    // Resolve this transparent wrapper so defaults from the referenced schema are computed normally.
+    updatedRecurseList = _recurseList.concat(schema[ALL_OF_KEY][0][REF_KEY]!);
+    schemaToCompute = retrieveSchema<T, S, F>(
+      validator,
+      schema,
+      rootSchema,
+      rawFormData,
+      experimental_customMergeAllOf,
+    );
   } else if (DEPENDENCIES_KEY in schema) {
     // Get the default if set from properties to ensure the dependencies conditions are resolved based on it
     const defaultFormData: T = {

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -74,6 +74,36 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         });
       });
 
+      describe('schema with a ref wrapped in a single-element allOf (issue #5177)', () => {
+        const schema: RJSFSchema = {
+          definitions: {
+            person: {
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string',
+                  default: 'Jane',
+                },
+              },
+            },
+          },
+          type: 'object',
+          properties: {
+            person: {
+              allOf: [{ $ref: '#/definitions/person' }],
+            },
+          },
+        };
+
+        test('populates the default from the referenced schema', () => {
+          expect(getDefaultFormState(testValidator, schema, undefined, schema)).toEqual({
+            person: {
+              name: 'Jane',
+            },
+          });
+        });
+      });
+
       describe('schema with anyOf containing $ref AND default should preserve existing formData', () => {
         // This test verifies the fix for a bug where anyOf schemas with $ref AND default
         // would incorrectly override existing formData with the default value.
@@ -1119,7 +1149,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         describe('a recursive allof schema', () => {
           const schema = RECURSIVE_REF_ALLOF;
           const expected = {
-            value: [undefined],
+            value: [{ name: '' }],
           };
 
           test('getDefaultFormState', () => {


### PR DESCRIPTION
## Summary

- Populate defaults through a single-element `allOf` that wraps a `$ref`.
- Preserve recursive-reference protection and add focused regression coverage.

## Testing

- `pnpm --filter @rjsf/utils exec vitest run test/schema.test.ts --coverage.enabled=false` — 667 tests passed.
- `pnpm --filter @rjsf/utils run lint`
- `pnpm --filter @rjsf/utils run cs-check`
- `pnpm --filter @rjsf/utils run build`

Fixes #5177
