### PR TITLE
Require ata-validator 1.6.1 in @rjsf/validator-ata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Raised the `ata-validator` requirement to `^1.3.0`, which fixes a `$ref` that could not be resolved being treated as vacuous rather than reported as an error ([#5181](https://github.com/rjsf-team/react-jsonschema-form/pull/5181))
 - Raised the `ata-validator` requirement to `^1.6.0`, so that validation runs correctly where `new Function` is refused, such as a page under a strict Content-Security-Policy ([#5184](https://github.com/rjsf-team/react-jsonschema-form/pull/5184))
+- Raised the `ata-validator` requirement to `^1.6.1`, which stops a `$ref` into another document from silently dropping the constraints behind it ([#5186](https://github.com/rjsf-team/react-jsonschema-form/pull/5186))
 
 ## @rjsf/validator-cfworker
 

--- a/packages/validator-ata/package.json
+++ b/packages/validator-ata/package.json
@@ -77,7 +77,7 @@
     ]
   },
   "dependencies": {
-    "ata-validator": "^1.6.0",
+    "ata-validator": "^1.6.1",
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -915,8 +915,8 @@ importers:
   packages/validator-ata:
     dependencies:
       ata-validator:
-        specifier: ^1.6.0
-        version: 1.6.0(yaml@2.9.0)
+        specifier: ^1.6.1
+        version: 1.6.1(yaml@2.9.0)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -1098,37 +1098,37 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@ata-validator/native-darwin-arm64@1.6.0':
-    resolution: {integrity: sha512-n65/WAXwF7e6yiir1xHMavksu6z37CRcVMwZbsya1ehLdgDT1xTwXhoZhO5W92VyYOPtCCP+W+klZF0TmuoUcw==}
+  '@ata-validator/native-darwin-arm64@1.6.1':
+    resolution: {integrity: sha512-GeQg5rLY1PtjaL414TUwmzEqYdXoGUjm/ZzwqYjY22SPhOGtY9CMjb5lhDTxaXfpG3Oav6EsQwPs7bniIS21vg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@ata-validator/native-linux-arm64-gnu@1.6.0':
-    resolution: {integrity: sha512-vII4nY3Hy/9R4dKz9v1DzN/coD0rqQsSEYoimLpG/QsGK6Lg9dg+pN4jDirJaSJS/M7UQnQBy1MQNNBCc8VcRQ==}
+  '@ata-validator/native-linux-arm64-gnu@1.6.1':
+    resolution: {integrity: sha512-Cb7v34UqaiffcodcOGqHQgpKuCXr8XCmrHGUgSMaR8aFFKBBwwc8//WEJhevsGkcMiX4KwC6sElTOsRppMdHHA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@ata-validator/native-linux-arm64-musl@1.6.0':
-    resolution: {integrity: sha512-0vagQh4axlSoQxSgFdhQc+ZlHsr0rtJtg3zig+8felNuhb+BxqvUf5Qvn+Z0E2LLiVyU/IrnYxSfK2tHOv/kGw==}
+  '@ata-validator/native-linux-arm64-musl@1.6.1':
+    resolution: {integrity: sha512-l5AeWjUvLM+oJzM9lE4Uicau2bvi4AH873NazAaM8hxVLzk5QdUhl+F42h5uDwlz4JsvovG+Oz9XgJZ7ha+gdw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@ata-validator/native-linux-x64-gnu@1.6.0':
-    resolution: {integrity: sha512-Qmbfh6Z1vUTSzY6xZtWll77b2GkZu13JyIMmyADX2d3wA0DfM1kfLSMHTW8wNEHpwHLit2v5WSKJ1VEHAAkrdA==}
+  '@ata-validator/native-linux-x64-gnu@1.6.1':
+    resolution: {integrity: sha512-2dt/dpRXQJE28KpEBA+uNtq6Y8SbBd2V8Pu7uj1yCWWYUdeLV2vZ/w2ri39CCoTbs89yQWY/MfFuLy+81iQ5FQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@ata-validator/native-linux-x64-musl@1.6.0':
-    resolution: {integrity: sha512-Ghh/n4XN4lAGR10dPujz9E9ZsFDqmNxlRT/1XmgJxRYDEjYzsek2+LSaeUYUHGXdDypVcd2+8ZOgjcaovsmWWQ==}
+  '@ata-validator/native-linux-x64-musl@1.6.1':
+    resolution: {integrity: sha512-IM4TlsPcpNelrqa2tQ5TAMgU8SqMlblmRJsnIBzPJimlk947W6K7GTmsgIIXfcLmWD3pR7Kj0F37QFSaDqvANg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@ata-validator/native-win32-x64@1.6.0':
-    resolution: {integrity: sha512-yk78kHvL/jJRSVZl3OXToz+K4ygpycEX8sr+E02OSNpR6K+9qg5EE8O+bnAQQYgeumFug7DPraEJ/fnjntUFHA==}
+  '@ata-validator/native-win32-x64@1.6.1':
+    resolution: {integrity: sha512-EMuHoDa2OFMsfB9YUZH+UPdSfA0CLEJpmhZ42nJ+GIBCLA3Bg3hYj3cFlHh0R4kK8S+l+gj+//0Id/jAY04gCw==}
     cpu: [x64]
     os: [win32]
 
@@ -6159,8 +6159,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  ata-validator@1.6.0:
-    resolution: {integrity: sha512-ZJ1hRDPZXhE7yg392+Dx+GVaq0qFHgIgVi5V0XFJ2Ftpvq0ke+HcCGWkuH2Vo1AZNQloyFLIOH5+o6X4pVn8Pw==}
+  ata-validator@1.6.1:
+    resolution: {integrity: sha512-MSC3BlldpTzvknWjQ5FTwAJG5DQF+h6B4tpzrczof5X6nBRkzkQcqETd5E6rKy+9HX2n6C2AKMiebL8Yhw/Rwg==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -11480,22 +11480,22 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@ata-validator/native-darwin-arm64@1.6.0':
+  '@ata-validator/native-darwin-arm64@1.6.1':
     optional: true
 
-  '@ata-validator/native-linux-arm64-gnu@1.6.0':
+  '@ata-validator/native-linux-arm64-gnu@1.6.1':
     optional: true
 
-  '@ata-validator/native-linux-arm64-musl@1.6.0':
+  '@ata-validator/native-linux-arm64-musl@1.6.1':
     optional: true
 
-  '@ata-validator/native-linux-x64-gnu@1.6.0':
+  '@ata-validator/native-linux-x64-gnu@1.6.1':
     optional: true
 
-  '@ata-validator/native-linux-x64-musl@1.6.0':
+  '@ata-validator/native-linux-x64-musl@1.6.1':
     optional: true
 
-  '@ata-validator/native-win32-x64@1.6.0':
+  '@ata-validator/native-win32-x64@1.6.1':
     optional: true
 
   '@babel/code-frame@7.29.7':
@@ -18516,14 +18516,14 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  ata-validator@1.6.0(yaml@2.9.0):
+  ata-validator@1.6.1(yaml@2.9.0):
     optionalDependencies:
-      '@ata-validator/native-darwin-arm64': 1.6.0
-      '@ata-validator/native-linux-arm64-gnu': 1.6.0
-      '@ata-validator/native-linux-arm64-musl': 1.6.0
-      '@ata-validator/native-linux-x64-gnu': 1.6.0
-      '@ata-validator/native-linux-x64-musl': 1.6.0
-      '@ata-validator/native-win32-x64': 1.6.0
+      '@ata-validator/native-darwin-arm64': 1.6.1
+      '@ata-validator/native-linux-arm64-gnu': 1.6.1
+      '@ata-validator/native-linux-arm64-musl': 1.6.1
+      '@ata-validator/native-linux-x64-gnu': 1.6.1
+      '@ata-validator/native-linux-x64-musl': 1.6.1
+      '@ata-validator/native-win32-x64': 1.6.1
       yaml: 2.9.0
 
   atob@2.1.2: {}


### PR DESCRIPTION
Raises the `ata-validator` requirement in `@rjsf/validator-ata` from `^1.6.0` to `^1.6.1`. Follows #5184.

### Why

1.6.1 fixes a `$ref` into another document silently dropping the constraints behind it.

ata's code generator has three entry points, and only one of them ran the bail that routes a reference it cannot follow to the interpreted engine. The other two emitted no code for the reference and returned the empty program as always-valid, so a schema shaped like this accepted any input at all:

```js
// user.json holds its constraints behind its own root $ref
{ "$id": "user.json", "$defs": { "inner": { ... } }, "$ref": "#/$defs/inner" }

// and the schema that references it
{ "$ref": "user.json" }   // => every input valid, before 1.6.1
```

Splitting a schema across files and keeping the shape under `#/$defs/...` is an ordinary thing to do in form schemas, and nothing reported an error when it happened, so raising the floor seems better than leaving it to the caret range. It affects Draft 2020-12, not only the v1 dialect.

### Lockfile

The change is limited to the seven ata entries, 29 insertions against 29 deletions.

As in #5181 and #5184, regenerating the lockfile with the pinned pnpm (10.17.1) strips `libc:` from around seventy unrelated native packages, which would change optional dependency selection on musl. Those lines are put back, so only the ata entries are touched: `libc:` line count is identical before and after, and `pnpm install --frozen-lockfile` accepts the result.

### Checks

Package tests pass unchanged against 1.6.1: 1274 tests across 8 files, coverage still 100%, including the precompiled path (`compileSchemaValidators`, `compileSchemaValidatorsCode`, `createPrecompiledValidator`, `precompiledValidator`).
