### PR TITLE
refactor: use native type guards instead of lodash, dropping antd's lodash dependency

### DIFF
--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -72,8 +72,6 @@
   },
   "dependencies": {
     "classnames": "^2.5.1",
-    "lodash": "^4.18.1",
-    "lodash-es": "^4.18.1",
     "rc-picker": "^4.11.3"
   },
   "devDependencies": {

--- a/packages/antd/src/templates/ObjectFieldTemplate/index.tsx
+++ b/packages/antd/src/templates/ObjectFieldTemplate/index.tsx
@@ -11,9 +11,6 @@ import type {
 import { canExpand, getTemplate, getUiOptions, titleId, buttonId } from '@rjsf/utils';
 import { Col, Row, ConfigProvider } from 'antd';
 import classNames from 'classnames';
-import isNumber from 'lodash/isNumber';
-import isObject from 'lodash/isObject';
-import isString from 'lodash/isString';
 
 /** The `ObjectFieldTemplate` is the template to use to render all the inner properties of an object along with the
  * title and description if available. If the object is expandable, then an `AddButton` is also rendered after all
@@ -74,19 +71,18 @@ export default function ObjectFieldTemplate<
         ? 24
         : 12;
 
-    if (isObject(colSpan)) {
-      const colSpanObj: GenericObjectType = colSpan;
-      if (isString(widget)) {
-        return colSpanObj[widget];
+    if (typeof colSpan === 'object' && colSpan !== null) {
+      if (typeof widget === 'string') {
+        return colSpan[widget];
       }
-      if (isString(field)) {
-        return colSpanObj[field];
+      if (typeof field === 'string') {
+        return colSpan[field];
       }
-      if (isString(type)) {
-        return colSpanObj[type];
+      if (typeof type === 'string') {
+        return colSpan[type];
       }
     }
-    if (isNumber(colSpan)) {
+    if (typeof colSpan === 'number') {
       return colSpan;
     }
     return defaultColSpan;

--- a/packages/antd/src/widgets/SelectWidget/index.tsx
+++ b/packages/antd/src/widgets/SelectWidget/index.tsx
@@ -12,7 +12,6 @@ import {
 import type { SelectProps } from 'antd';
 import { Select } from 'antd';
 import type { DefaultOptionType } from 'antd/es/select';
-import isString from 'lodash/isString';
 
 const SELECT_STYLE = {
   width: '100%',
@@ -59,7 +58,7 @@ export default function SelectWidget<
   const handleFocus = () => onFocus(id, enumOptionValueDecoder<S>(value, enumOptions, optionValueFormat, emptyValue));
 
   const filterOption: SelectProps['filterOption'] = (input, option) => {
-    if (option && isString(option.label)) {
+    if (option && typeof option.label === 'string') {
       // labels are strings in this context
       return option.label.toLowerCase().includes(input.toLowerCase());
     }

--- a/packages/utils/src/constIsAjvDataReference.ts
+++ b/packages/utils/src/constIsAjvDataReference.ts
@@ -1,5 +1,4 @@
 import type { JSONSchema7Type } from 'json-schema';
-import isString from 'lodash/isString';
 
 import { CONST_KEY, getSchemaType, isObject } from './';
 import type { RJSFSchema, StrictRJSFSchema } from './types';
@@ -14,5 +13,7 @@ import type { RJSFSchema, StrictRJSFSchema } from './types';
 export default function constIsAjvDataReference<S extends StrictRJSFSchema = RJSFSchema>(schema: S): boolean {
   const schemaConst = schema[CONST_KEY] as JSONSchema7Type & { $data: string };
   const schemaType = getSchemaType<S>(schema);
-  return isObject(schemaConst) && isString(schemaConst?.$data) && schemaType !== 'object' && schemaType !== 'array';
+  return (
+    isObject(schemaConst) && typeof schemaConst?.$data === 'string' && schemaType !== 'object' && schemaType !== 'array'
+  );
 }

--- a/packages/utils/src/enumOptionValueEncoder.ts
+++ b/packages/utils/src/enumOptionValueEncoder.ts
@@ -1,5 +1,3 @@
-import isNil from 'lodash/isNil';
-
 import type { OptionValueFormat } from './types';
 
 /** Encodes an enum option value into a string for a DOM value attribute.
@@ -23,7 +21,7 @@ export default function enumOptionValueEncoder(
   if (format !== 'realValue') {
     return String(index);
   }
-  if (isNil(value)) {
+  if (value == null) {
     return '';
   }
   if (typeof value === 'object') {

--- a/packages/utils/src/enumOptionsSelectValue.ts
+++ b/packages/utils/src/enumOptionsSelectValue.ts
@@ -1,5 +1,3 @@
-import isNil from 'lodash/isNil';
-
 import enumOptionsValueForIndex from './enumOptionsValueForIndex';
 import type { EnumOptionsType, RJSFSchema, StrictRJSFSchema } from './types';
 
@@ -17,7 +15,7 @@ export default function enumOptionsSelectValue<S extends StrictRJSFSchema = RJSF
   allEnumOptions: EnumOptionsType<S>[] = [],
 ) {
   const value = enumOptionsValueForIndex<S>(valueIndex, allEnumOptions);
-  if (!isNil(value)) {
+  if (value != null) {
     const index = allEnumOptions.findIndex((opt) => value === opt.value);
     const all = allEnumOptions.map(({ value: val }) => val);
     const updated = selected.slice(0, index).concat(value, selected.slice(index));

--- a/packages/utils/src/getDiscriminatorFieldFromSchema.ts
+++ b/packages/utils/src/getDiscriminatorFieldFromSchema.ts
@@ -1,5 +1,4 @@
 import get from 'lodash/get';
-import isString from 'lodash/isString';
 
 import { DISCRIMINATOR_PATH } from './constants';
 import type { RJSFSchema, StrictRJSFSchema } from './types';
@@ -13,7 +12,7 @@ import type { RJSFSchema, StrictRJSFSchema } from './types';
 export default function getDiscriminatorFieldFromSchema<S extends StrictRJSFSchema = RJSFSchema>(schema: S) {
   let discriminator: string | undefined;
   const maybeString = get(schema, DISCRIMINATOR_PATH);
-  if (isString(maybeString)) {
+  if (typeof maybeString === 'string') {
     discriminator = maybeString;
   } else if (maybeString !== undefined) {
     // oxlint-disable-next-line no-console

--- a/packages/utils/src/idGenerators.ts
+++ b/packages/utils/src/idGenerators.ts
@@ -1,5 +1,3 @@
-import isString from 'lodash/isString';
-
 import { ID_KEY } from './constants';
 import type { FieldPathId } from './types';
 
@@ -9,7 +7,7 @@ import type { FieldPathId } from './types';
  * @param suffix - The suffix to append to the id
  */
 function idGenerator(id: FieldPathId | string, suffix: string) {
-  const theId = isString(id) ? id : id[ID_KEY];
+  const theId = typeof id === 'string' ? id : id[ID_KEY];
   return `${theId}__${suffix}`;
 }
 /** Return a consistent `id` for the field description element

--- a/packages/utils/src/isFormDataAvailable.ts
+++ b/packages/utils/src/isFormDataAvailable.ts
@@ -1,5 +1,4 @@
 import isEmpty from 'lodash/isEmpty';
-import isNil from 'lodash/isNil';
 import isObject from 'lodash/isObject';
 
 /** Determines whether the given `formData` represents valid form data, such as a primitive type, an array, or a
@@ -9,5 +8,5 @@ import isObject from 'lodash/isObject';
  * @returns - True if `formData` is not undefined, null, a primitive type or an array or an empty object
  */
 export default function isFormDataAvailable<T = any>(formData?: T): boolean {
-  return !isNil(formData) && (!isObject(formData) || Array.isArray(formData) || !isEmpty(formData));
+  return formData != null && (!isObject(formData) || Array.isArray(formData) || !isEmpty(formData));
 }

--- a/packages/utils/src/mergeDefaultsWithFormData.ts
+++ b/packages/utils/src/mergeDefaultsWithFormData.ts
@@ -1,5 +1,4 @@
 import get from 'lodash/get';
-import isNil from 'lodash/isNil';
 
 import type { GenericObjectType } from '../src';
 import isObject from './isObject';
@@ -104,8 +103,8 @@ export default function mergeDefaultsWithFormData<T = any>(
    */
   if (
     (defaultSupercedesUndefined &&
-      ((!(defaults === undefined) && isNil(formData)) || (typeof formData === 'number' && Number.isNaN(formData)))) ||
-    (overrideFormDataWithDefaults && !isNil(formData))
+      ((!(defaults === undefined) && formData == null) || (typeof formData === 'number' && Number.isNaN(formData)))) ||
+    (overrideFormDataWithDefaults && formData != null)
   ) {
     return defaults;
   }

--- a/packages/utils/src/schema/getFirstMatchingOption.ts
+++ b/packages/utils/src/schema/getFirstMatchingOption.ts
@@ -1,6 +1,5 @@
 import get from 'lodash/get';
 import has from 'lodash/has';
-import isNumber from 'lodash/isNumber';
 
 import { PROPERTIES_KEY } from '../constants';
 import getOptionMatchingSimpleDiscriminator from '../getOptionMatchingSimpleDiscriminator';
@@ -35,7 +34,7 @@ export default function getFirstMatchingOption<
   }
 
   const simpleDiscriminatorMatch = getOptionMatchingSimpleDiscriminator(formData, options, discriminatorField);
-  if (isNumber(simpleDiscriminatorMatch)) {
+  if (typeof simpleDiscriminatorMatch === 'number') {
     return simpleDiscriminatorMatch;
   }
 

--- a/packages/utils/src/schema/omitExtraData.ts
+++ b/packages/utils/src/schema/omitExtraData.ts
@@ -1,6 +1,5 @@
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
-import isNil from 'lodash/isNil';
 import pick from 'lodash/pick';
 
 import { NAME_KEY, RJSF_ADDITIONAL_PROPERTIES_FLAG } from '../constants';
@@ -91,7 +90,7 @@ export function getFieldNames<T = any>(pathSchema: PathSchema<T>, formData?: T):
  * @returns - True if the value is considered empty, false otherwise
  */
 export function isValueEmpty(value: unknown): boolean {
-  if (isNil(value) || value === '') {
+  if (value == null || value === '') {
     return true;
   }
   if (Array.isArray(value)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,12 +121,6 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
-      lodash:
-        specifier: ^4.18.1
-        version: 4.18.1
-      lodash-es:
-        specifier: ^4.18.1
-        version: 4.18.1
       rc-picker:
         specifier: ^4.11.3
         version: 4.11.3(date-fns@4.4.0)(dayjs@1.11.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Reasons for making this change

Replaces lodash's simple type-guard functions with their native equivalents, and removes `@rjsf/antd`'s last lodash import along the way.

| | |
|---|---|
| `isNil(x)` | `x == null` (and `!isNil(x)` → `x != null`) |
| `isUndefined(x)` | `x === undefined` |
| `isString(x)` | `typeof x === 'string'` |
| `isNumber(x)` | `typeof x === 'number'` |
| `isFunction(x)` | `typeof x === 'function'` |

These are exact. The only behavioural difference from lodash is boxed primitives (`new String('x')`, `new Number(1)`), which do not occur in this codebase. Every call site is a direct call in conditional position — none are passed by reference — so there are no function-identity or memoisation effects. TypeScript narrowing is preserved, since `typeof` guards and `== null` narrow natively just as the lodash type predicates did.

`== null` is already sanctioned by the repo's lint config, which sets `eqeqeq: ["error", "always", { "null": "ignore" }]` specifically to permit it.

## The one site that needed an audit

`ObjectFieldTemplate`'s `isObject(colSpan)` is antd's last lodash import, so converting it makes **`@rjsf/antd` free of direct lodash imports**. Unlike the guards above this is not a mechanical swap — lodash's `isObject` also returns `true` for arrays and functions:

```ts
if (isObject(colSpan)) {
  if (typeof widget === 'string') { return colSpan[widget]; }
  // ...field, type
}
if (typeof colSpan === 'number') { return colSpan; }
return defaultColSpan;
```

**Arrays are unaffected** — `typeof [] === 'object'`, so they enter the branch either way, index to `undefined`, and return it.

**Functions do differ.** lodash enters the branch and returns `colSpan[widget]` (i.e. `undefined`); the `typeof` guard skips the branch and returns `defaultColSpan`. A function-valued `colSpan` is invalid configuration — it comes from `formContext.colSpan`, which is expected to be a number or a lookup object — and returning the computed default is the more sensible outcome. But it is a behaviour change, not an equivalence, so it is called out here rather than buried.

I checked this across 55 combinations of `colSpan` value (number, lookup object, empty object, array, function, `null`, `undefined`, string, `Date`, boolean) against widget/field/type context. The function case is the only divergence.

Removing lodash here also makes the `colSpanObj` intermediate dead, so it is deleted. It existed only because `isObject`'s `thing is object` predicate narrowed `colSpan` from `any` to `object`, which TypeScript will not let you index; the `typeof` guard does not narrow that way, so the lookups read `colSpan` directly.

## Measured effect: essentially none, and that is expected

Built ESM entries, bundled as a consumer's would be (peers external, nx cache bypassed):

| | min | gzip | own lodash imports |
|---|---|---|---|
| `@rjsf/antd` before | 1,216,302 | 383,334 | 3 files |
| `@rjsf/antd` after | 1,216,409 | 383,362 | **0 files** |
| `@rjsf/utils` before | 116,801 | 42,029 | 41 files |
| `@rjsf/utils` after | 116,823 | 42,010 | 37 files |

Slightly *larger* in antd's case. That is the point worth being explicit about: these are leaf functions with no internal dependency graph, and lodash's shared internals stay reachable until their last consumer goes. `@rjsf/antd` no longer imports lodash **directly**, but its bundle still contains `baseGet`, `baseIsEqualDeep` and `baseClone` transitively via `@rjsf/utils` and `@rjsf/core`.

So this PR should be judged as a safe, mechanical step toward removing the dependency — not as a size win. The size arrives when the shared chains go.

## Not included

- The remaining `isObject` sites — lodash's version, `@rjsf/utils`' own exported `isObject`, and a naive `typeof` check all disagree on arrays, Dates and functions, so each needs its own audit.
- `isEmpty` — returns `true` for `42`, `true`, `null` and `new Map()`.
- `noop` — passed as a prop reference, so it needs a stable module-level constant rather than an inlined arrow.
- `getClosestMatchingOption.ts` and `LayoutGridField.tsx` — converted in the deep-equality chain PR instead, so the two PRs share no source file and can merge in either order.

No public types or signatures change.

### The dependency is removed too

With no lodash imports left, `lodash` and `lodash-es` are also removed from `@rjsf/antd`'s `dependencies`, so consumers no longer install them on the package's behalf.

The `pnpm-lock.yaml` change is confined to that package's own importer section — a few lines — and `pnpm install --frozen-lockfile`, which is what CI runs, accepts it without rewriting the file.

One thing this does **not** do: the published bundle still contains lodash internals (`baseGet`, `baseIsEqualDeep`, `baseClone`) pulled in transitively via `@rjsf/utils` and `@rjsf/core`. Those go when the shared chains are removed there.

## Checklist

- [ ] I'm updating documentation
- [x] I'm adding or updating code
  - [ ] I've added and/or updated tests
  - [ ] I've updated the changelog
- [ ] I'm updating dependencies

