### PR TITLE
perf(utils,core): eliminate lodash's deep-equality chain from the bundle

### DIFF
--- a/packages/core/src/components/fields/LayoutGridField.tsx
+++ b/packages/core/src/components/fields/LayoutGridField.tsx
@@ -11,6 +11,7 @@ import type {
 } from '@rjsf/utils';
 import {
   ANY_OF_KEY,
+  deepEquals,
   getDiscriminatorFieldFromSchema,
   getTemplate,
   getTestIds,
@@ -34,12 +35,8 @@ import has from 'lodash/has';
 import includes from 'lodash/includes';
 import intersection from 'lodash/intersection';
 import isEmpty from 'lodash/isEmpty';
-import isEqual from 'lodash/isEqual';
-import isFunction from 'lodash/isFunction';
 import isObject from 'lodash/isObject';
 import isPlainObject from 'lodash/isPlainObject';
-import isString from 'lodash/isString';
-import isUndefined from 'lodash/isUndefined';
 import last from 'lodash/last';
 import set from 'lodash/set';
 
@@ -177,7 +174,7 @@ export function computeFieldUiSchema<T = any, S extends StrictRJSFSchema = RJSFS
     set(fieldUiSchema, [UI_GLOBAL_OPTIONS_KEY], globalUiOptions);
   }
   let { readonly: uiReadonly } = getUiOptions<T, S, F>(fieldUiSchema);
-  if (forceReadonly === true || (isUndefined(uiReadonly) && schemaReadonly === true)) {
+  if (forceReadonly === true || (uiReadonly === undefined && schemaReadonly === true)) {
     // If we are forcing all widgets to be readonly, OR the schema indicates it is readonly AND the uiSchema does not
     // have an overriding value, then update the uiSchema to set readonly to true. Doing this will
     uiReadonly = true;
@@ -215,7 +212,7 @@ export function conditionMatches(
   const values = flatten([value]).sort();
   switch (operator) {
     case Operators.ALL:
-      return isEqual(data, values);
+      return deepEquals(data, values);
     case Operators.SOME:
       return intersection(data, values).length > 0;
     case Operators.NONE:
@@ -417,10 +414,10 @@ export function getCustomRenderComponent<
   F extends FormContextType = any,
 >(render: string | RenderComponent, registry: Registry<T, S, F>): RenderComponent | null {
   let customRenderer = render;
-  if (isString(customRenderer)) {
+  if (typeof customRenderer === 'string') {
     customRenderer = lookupFromFormContext<T, S, F>(registry, customRenderer);
   }
-  if (isFunction(customRenderer)) {
+  if (typeof customRenderer === 'function') {
     return customRenderer;
   }
   return null;
@@ -443,7 +440,7 @@ export function computeUIComponentPropsFromGridSchema<
   let UIComponent: RenderComponent | null = null;
   let uiProps: ConfigObject = {};
   let rendered: ReactNode | undefined;
-  if (isString(gridSchema) || isUndefined(gridSchema)) {
+  if (typeof gridSchema === 'string' || gridSchema === undefined) {
     name = gridSchema ?? '';
   } else {
     const { name: innerName = '', render, ...innerProps } = gridSchema;
@@ -452,7 +449,7 @@ export function computeUIComponentPropsFromGridSchema<
     if (!isEmpty(uiProps)) {
       // Transform any `$lookup=` in the uiProps props with the appropriate value
       each(uiProps, (prop: ConfigObject, key: string) => {
-        if (isString(prop)) {
+        if (typeof prop === 'string') {
           const match: string[] | null = LOOKUP_REGEX.exec(prop);
           if (Array.isArray(match) && match.length > 1) {
             const lookupName = match[1];

--- a/packages/utils/src/getChangedFields.ts
+++ b/packages/utils/src/getChangedFields.ts
@@ -1,8 +1,6 @@
 import difference from 'lodash/difference';
 import get from 'lodash/get';
 import isPlainObject from 'lodash/isPlainObject';
-import keys from 'lodash/keys';
-import pickBy from 'lodash/pickBy';
 
 import deepEquals from './deepEquals';
 
@@ -30,12 +28,14 @@ export default function getChangedFields(a: unknown, b: unknown): string[] {
     return [];
   }
   if (aIsPlainObject && !bIsPlainObject) {
-    return keys(a);
+    return Object.keys(a as object);
   }
   if (!aIsPlainObject && bIsPlainObject) {
-    return keys(b);
+    return Object.keys(b as object);
   }
-  const unequalFields = keys(pickBy(a as object, (value, key) => !deepEquals(value, get(b, key))));
-  const diffFields = difference(keys(b), keys(a));
+  const unequalFields = Object.entries(a as object)
+    .filter(([key, value]) => !deepEquals(value, get(b, key)))
+    .map(([key]) => key);
+  const diffFields = difference(Object.keys(b as object), Object.keys(a as object));
   return [...unequalFields, ...diffFields];
 }

--- a/packages/utils/src/schema/getClosestMatchingOption.ts
+++ b/packages/utils/src/schema/getClosestMatchingOption.ts
@@ -1,9 +1,6 @@
 import get from 'lodash/get';
 import has from 'lodash/has';
-import isNumber from 'lodash/isNumber';
 import isObject from 'lodash/isObject';
-import isString from 'lodash/isString';
-import reduce from 'lodash/reduce';
 import times from 'lodash/times';
 
 import { ONE_OF_KEY, REF_KEY, JUNK_OPTION_ID, ANY_OF_KEY } from '../constants';
@@ -64,77 +61,73 @@ export function calculateIndexScore<T = any, S extends StrictRJSFSchema = RJSFSc
   let totalScore = 0;
   if (schema) {
     if (isObject(schema.properties)) {
-      totalScore += reduce(
-        schema.properties,
-        (score, value, key) => {
-          const formValue = get(formData, key);
-          if (typeof value === 'boolean') {
-            return score;
-          }
-          if (has(value, REF_KEY)) {
-            const newSchema = retrieveSchema<T, S, F>(
+      totalScore += Object.entries(schema.properties).reduce((score, [key, value]) => {
+        const formValue = get(formData, key);
+        if (typeof value === 'boolean') {
+          return score;
+        }
+        if (has(value, REF_KEY)) {
+          const newSchema = retrieveSchema<T, S, F>(
+            validator,
+            value as S,
+            rootSchema,
+            formValue,
+            experimental_customMergeAllOf,
+          );
+          return (
+            score +
+            calculateIndexScore<T, S, F>(
               validator,
-              value as S,
+              rootSchema,
+              newSchema,
+              formValue || {},
+              experimental_customMergeAllOf,
+            )
+          );
+        }
+        if ((has(value, ONE_OF_KEY) || has(value, ANY_OF_KEY)) && formValue) {
+          const xxxOfKey = has(value, ONE_OF_KEY) ? ONE_OF_KEY : ANY_OF_KEY;
+          const discriminator = getDiscriminatorFieldFromSchema<S>(value as S);
+          return (
+            score +
+            getClosestMatchingOption<T, S, F>(
+              validator,
               rootSchema,
               formValue,
+              get(value, xxxOfKey) as S[],
+              -1,
+              discriminator,
               experimental_customMergeAllOf,
-            );
-            return (
-              score +
-              calculateIndexScore<T, S, F>(
-                validator,
-                rootSchema,
-                newSchema,
-                formValue || {},
-                experimental_customMergeAllOf,
-              )
-            );
+            )
+          );
+        }
+        if (value.type === 'object') {
+          // If the structure is matching then give it a little boost in score
+          const structureBoost = isObject(formValue) ? 1 : 0;
+          return (
+            score +
+            structureBoost +
+            calculateIndexScore<T, S, F>(validator, rootSchema, value as S, formValue, experimental_customMergeAllOf)
+          );
+        }
+        if (value.type === guessType(formValue)) {
+          // If the types match, then we bump the score by one
+          let newScore = score + 1;
+          if (value.default) {
+            // If the schema contains a readonly default value score the value that matches the default higher and
+            // any non-matching value lower
+            newScore += formValue === value.default ? 1 : -1;
+          } else if (value.const) {
+            // If the schema contains a const value score the value that matches the default higher and
+            // any non-matching value lower
+            newScore += formValue === value.const ? 1 : -1;
           }
-          if ((has(value, ONE_OF_KEY) || has(value, ANY_OF_KEY)) && formValue) {
-            const xxxOfKey = has(value, ONE_OF_KEY) ? ONE_OF_KEY : ANY_OF_KEY;
-            const discriminator = getDiscriminatorFieldFromSchema<S>(value as S);
-            return (
-              score +
-              getClosestMatchingOption<T, S, F>(
-                validator,
-                rootSchema,
-                formValue,
-                get(value, xxxOfKey) as S[],
-                -1,
-                discriminator,
-                experimental_customMergeAllOf,
-              )
-            );
-          }
-          if (value.type === 'object') {
-            // If the structure is matching then give it a little boost in score
-            const structureBoost = isObject(formValue) ? 1 : 0;
-            return (
-              score +
-              structureBoost +
-              calculateIndexScore<T, S, F>(validator, rootSchema, value as S, formValue, experimental_customMergeAllOf)
-            );
-          }
-          if (value.type === guessType(formValue)) {
-            // If the types match, then we bump the score by one
-            let newScore = score + 1;
-            if (value.default) {
-              // If the schema contains a readonly default value score the value that matches the default higher and
-              // any non-matching value lower
-              newScore += formValue === value.default ? 1 : -1;
-            } else if (value.const) {
-              // If the schema contains a const value score the value that matches the default higher and
-              // any non-matching value lower
-              newScore += formValue === value.const ? 1 : -1;
-            }
-            // TODO eventually, deal with enums/arrays
-            return newScore;
-          }
-          return score;
-        },
-        0,
-      );
-    } else if (isString(schema.type) && schema.type === guessType(formData)) {
+          // TODO eventually, deal with enums/arrays
+          return newScore;
+        }
+        return score;
+      }, 0);
+    } else if (typeof schema.type === 'string' && schema.type === guessType(formData)) {
       totalScore += 1;
     }
   }
@@ -181,7 +174,7 @@ export default function getClosestMatchingOption<
   const resolvedOptions = options.map((option) => resolveAllReferences<S>(option, rootSchema, []));
 
   const simpleDiscriminatorMatch = getOptionMatchingSimpleDiscriminator(formData, options, discriminatorField);
-  if (isNumber(simpleDiscriminatorMatch)) {
+  if (typeof simpleDiscriminatorMatch === 'number') {
     return simpleDiscriminatorMatch;
   }
 

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -1,11 +1,7 @@
-import flattenDeep from 'lodash/flattenDeep';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
-import merge from 'lodash/merge';
 import set from 'lodash/set';
 import times from 'lodash/times';
-import transform from 'lodash/transform';
-import uniq from 'lodash/uniq';
 
 import {
   ADDITIONAL_PROPERTIES_KEY,
@@ -402,27 +398,28 @@ export function resolveAllReferences<S extends StrictRJSFSchema = RJSFSchema>(
 
   if (PROPERTIES_KEY in resolvedSchema) {
     const childrenLists: string[][] = [];
-    const updatedProps = transform(
-      resolvedSchema[PROPERTIES_KEY]!,
-      (acc, value, key: string) => {
-        const childList: string[] = [...recurseList];
-        // Mark cycles only when NOT in resolveAnyOfOrOneOfRefs mode. When resolveAnyOfOrOneOfRefs=true
-        // (e.g. from ObjectField), options are resolved against a shared recurseList that accumulates
-        // refs across branches, causing false positives. In simple (non-anyOf) resolution, a $ref cycle
-        // in an object property always causes an infinite render loop and must be caught.
-        acc[key] = resolveAllReferences(
-          value as S,
-          rootSchema,
-          childList,
-          currentBaseURI,
-          resolveAnyOfOrOneOfRefs,
-          !resolveAnyOfOrOneOfRefs,
-        );
-        childrenLists.push(childList);
-      },
-      {} as RJSFSchema,
-    );
-    merge(recurseList, uniq(flattenDeep(childrenLists)));
+    const updatedProps: RJSFSchema = {};
+    for (const [key, value] of Object.entries(resolvedSchema[PROPERTIES_KEY] ?? {})) {
+      const childList: string[] = [...recurseList];
+      // Mark cycles only when NOT in resolveAnyOfOrOneOfRefs mode. When resolveAnyOfOrOneOfRefs=true
+      // (e.g. from ObjectField), options are resolved against a shared recurseList that accumulates
+      // refs across branches, causing false positives. In simple (non-anyOf) resolution, a $ref cycle
+      // in an object property always causes an infinite render loop and must be caught.
+      updatedProps[key] = resolveAllReferences(
+        value as S,
+        rootSchema,
+        childList,
+        currentBaseURI,
+        resolveAnyOfOrOneOfRefs,
+        !resolveAnyOfOrOneOfRefs,
+      );
+      childrenLists.push(childList);
+    }
+    for (const ref of new Set(childrenLists.flat())) {
+      if (!recurseList.includes(ref)) {
+        recurseList.push(ref);
+      }
+    }
     resolvedSchema = { ...resolvedSchema, [PROPERTIES_KEY]: updatedProps };
   }
 

--- a/packages/utils/src/shouldRenderOptionalField.ts
+++ b/packages/utils/src/shouldRenderOptionalField.ts
@@ -1,5 +1,4 @@
 import isObject from 'lodash/isObject';
-import uniq from 'lodash/uniq';
 
 import { ANY_OF_KEY, ONE_OF_KEY } from './constants';
 import getSchemaType from './getSchemaType';
@@ -13,12 +12,14 @@ import type { FormContextType, Registry, RJSFSchema, StrictRJSFSchema, UiSchema 
  * @returns - All of the unique types contained within the oneOf list
  */
 export function getSchemaTypesForXxxOf<S extends StrictRJSFSchema = RJSFSchema>(schemas: S[]): string | string[] {
-  const allTypes: string[] = uniq(
-    schemas
-      .map((s) => (isObject(s) ? getSchemaType(s) : undefined))
-      .flat()
-      .filter((t) => t !== undefined),
-  );
+  const allTypes: string[] = [
+    ...new Set(
+      schemas
+        .map((s) => (isObject(s) ? getSchemaType(s) : undefined))
+        .flat()
+        .filter((t) => t !== undefined),
+    ),
+  ];
   return allTypes.length === 1 ? allTypes[0] : allTypes;
 }
 

--- a/packages/utils/test/schema/retrieveSchemaTest.ts
+++ b/packages/utils/test/schema/retrieveSchemaTest.ts
@@ -52,6 +52,10 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
     it('returns empty object when schema is not an object', () => {
       expect(retrieveSchema(testValidator, [] as RJSFSchema)).toEqual({});
     });
+    it('tolerates a schema with an explicitly undefined `properties`', () => {
+      const schema = { type: 'object', properties: undefined } as RJSFSchema;
+      expect(retrieveSchema(testValidator, schema)).toEqual({ type: 'object', properties: {} });
+    });
     it('should `resolve` a schema which contains definitions', () => {
       const schema: RJSFSchema = { $ref: '#/definitions/address' };
       const address: RJSFSchema = {


### PR DESCRIPTION
## Reasons for making this change

`@rjsf/utils` and `@rjsf/core` pull in lodash's deep-equality internals (`baseIsEqualDeep` and its supporting chain — `equalArrays`, `equalObjects`, `equalByTag`, `Stack`, `getTag`, …). That code is reachable from four separate imports, so removing any one of them individually changes the bundle by roughly nothing while the shared ~8KB stays put. Removing the last consumer is what lets it drop out.

This PR removes all of them together, plus the adjacent lodash calls in the same block.

| function | where |
|---|---|
| `transform`, `merge`, `uniq`, `flattenDeep` | `utils/src/schema/retrieveSchema.ts` (one block) |
| `uniq` | `utils/src/shouldRenderOptionalField.ts` |
| `pickBy`, `keys` | `utils/src/getChangedFields.ts` |
| `reduce` | `utils/src/schema/getClosestMatchingOption.ts` |
| `isEqual` | `core/src/components/fields/LayoutGridField.tsx` (uses the existing `deepEquals`) |

`transform` and `merge` are not merely adjacent but coupled — `transform`'s callback populates `childrenLists`, which the `merge` line then consumes — so they are rewritten as one loop.

### Also converts the type guards in these two files

`LayoutGridField.tsx` and `getClosestMatchingOption.ts` additionally have lodash's simple type guards converted to native ones (`isString`/`isNumber`/`isUndefined`/`isFunction` → `typeof`, `isNil` → `== null`). Those conversions belong here rather than in the type-guards PR (#5189) so that the two PRs share no source file and can merge in either order — this PR reindents `getClosestMatchingOption.ts` substantially, and a conflict resolution across the two could silently drop the `typeof` conversions while still compiling and passing tests.

### Measured effect

Built ESM entries bundled as a consumer's bundler would (React external, nx cache bypassed):

| | min | gzip | `baseIsEqualDeep` present |
|---|---|---|---|
| `@rjsf/utils` before | 116,801 | 42,035 | yes |
| `@rjsf/utils` after | 110,902 | **39,835** | **no** |
| `@rjsf/core` before | 387,786 | 129,309 | yes |
| `@rjsf/core` after | 381,828 | **127,042** | **no** |

≈2.2KB gzipped off `@rjsf/utils` and ≈2.3KB off `@rjsf/core`.

## Notes on equivalence

Three replacements are not literal one-for-one swaps and deserve attention:

**1. `merge(recurseList, uniq(flattenDeep(childrenLists)))`** was doing something non-obvious. `merge` on two *arrays* assigns index-wise, not by append. It behaved as an append only because every `childList` starts as a copy of `recurseList` and only ever grows, making `recurseList` an exact prefix of the deduped result. The replacement appends the missing refs directly. This is equivalent under that invariant and preserves the no-op case where `properties` yields no children — a naive clear-and-refill rewrite would wrongly empty the list there.

**2. `Object.entries(resolvedSchema[PROPERTIES_KEY] ?? {})`** — the `?? {}` preserves `lodash/transform`'s tolerance of a nullish collection. `'properties' in schema` passes for `{ properties: undefined }`, where a bare `Object.entries` throws. A test covers this and was verified to fail when the guard is removed.

**3. `getChangedFields` is now own-properties-only.** lodash's `pickBy` uses `keysIn`, which walks the prototype chain, so the function previously mixed `keys` (own) with `pickBy` (own and inherited) three lines apart. The `isPlainObject` guard means the only way to observe the difference is an enumerable property on `Object.prototype`, in which case the old behaviour reported that polluted key as a changed field — and `Form` then wrote it into the error schema as a cleared entry. The new behaviour cannot return anything that is not an own property of the form data.

`deepEquals` differs from `lodash/isEqual` in treating functions as equal and tracking circular references. The `LayoutGridField` call site compares sorted arrays of primitives, so the two agree there; they also agree on `NaN`, `-0` and sparse arrays.

No public types or signatures change.

## Review tip

`getClosestMatchingOption.ts` shows ~127 changed lines but is **+2 / −7** ignoring whitespace — the callback body de-indents one level when moving from lodash's 3-argument form to native `Array.prototype.reduce`. Reviewing with `?w=1` makes this much easier to read.

## Checklist

- [x] I'm updating documentation
- [x] I'm adding or updating code
  - [x] I've added and/or updated tests
  - [ ] I've updated the changelog
- [ ] I'm updating dependencies
