### PR TITLE
perf: remove lodash/cloneDeep and lodash/omit, dropping the baseClone chain

### DIFF
--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -51,7 +51,6 @@ import {
   ANY_OF_KEY,
   ONE_OF_KEY,
 } from '@rjsf/utils';
-import _cloneDeep from 'lodash/cloneDeep';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
 import _pick from 'lodash/pick';
@@ -951,7 +950,7 @@ export default class Form<
     const rootPathId = fieldPathId.path[0] || '';
 
     const isRootPath = !path || path.length === 0 || (path.length === 1 && path[0] === rootPathId);
-    let formData = isRootPath ? newValue : _cloneDeep(oldFormData);
+    let formData = isRootPath ? newValue : structuredClone(oldFormData);
 
     // When switching from null to an object option in oneOf, MultiSchemaField sends
     // an object with property names but undefined values (e.g., {types: undefined, content: undefined}).
@@ -1047,7 +1046,7 @@ export default class Form<
         // Apply the user-supplied newErrorSchema onto a clone of the AJV-only base, so that
         // mergeErrors below sees the user's error at this path without mutating shared state.
         if (!isRootPath) {
-          mergeBaseErrorSchema = _cloneDeep(schemaValidationErrorSchema);
+          mergeBaseErrorSchema = structuredClone(schemaValidationErrorSchema);
           _set(mergeBaseErrorSchema, path, newErrorSchema);
         } else {
           mergeBaseErrorSchema = newErrorSchema;

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -30,7 +30,6 @@ import {
   ID_KEY,
   TranslatableString,
 } from '@rjsf/utils';
-import cloneDeep from 'lodash/cloneDeep';
 import isObject from 'lodash/isObject';
 import set from 'lodash/set';
 import uniqueId from 'lodash/uniqueId';
@@ -952,7 +951,7 @@ export default function ArrayField<T = any, S extends StrictRJSFSchema = RJSFSch
 
       const newKeyedFormDataRow: KeyedFormDataType<T> = {
         key: generateRowId(),
-        item: cloneDeep(keyedFormDataRef.current[index].item),
+        item: structuredClone(keyedFormDataRef.current[index].item),
       };
       const newKeyedFormData = [...keyedFormDataRef.current];
       if (index !== undefined) {

--- a/packages/core/src/components/fields/LayoutMultiSchemaField.tsx
+++ b/packages/core/src/components/fields/LayoutMultiSchemaField.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import type {
   EnumOptionsType,
+  ErrorSchema,
   FieldProps,
   FormContextType,
   RJSFSchema,
@@ -27,7 +28,6 @@ import get from 'lodash/get';
 import has from 'lodash/has';
 import isEmpty from 'lodash/isEmpty';
 import noop from 'lodash/noop';
-import omit from 'lodash/omit';
 import set from 'lodash/set';
 
 /** Gets the selected option from the list of `options`, using the `selectorField` to search inside each `option` for
@@ -109,7 +109,7 @@ export default function LayoutMultiSchemaField<
     autofocus,
     readonly,
     required,
-    errorSchema,
+    errorSchema = {},
     hideError = false,
   } = props;
   const { widgets, schemaUtils, globalUiOptions } = registry;
@@ -151,7 +151,8 @@ export default function LayoutMultiSchemaField<
   const hideFieldError = uiSchemaHideError === undefined ? hideError : Boolean(uiSchemaHideError);
 
   const rawErrors = get(errorSchema, [ERRORS_KEY], []) as string[];
-  const fieldErrorSchema = omit(errorSchema, [ERRORS_KEY]);
+  const fieldErrorSchema = { ...errorSchema } as ErrorSchema<T>;
+  delete fieldErrorSchema[ERRORS_KEY];
   const displayLabel = schemaUtils.getDisplayLabel(schema, uiSchema, globalUiOptions);
 
   /** Callback function that updates the selected option and adjusts the form data based on the structure of the new

--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { FieldProps, FormContextType, RJSFSchema, StrictRJSFSchema, UiSchema } from '@rjsf/utils';
+import type { ErrorSchema, FieldProps, FormContextType, RJSFSchema, StrictRJSFSchema, UiSchema } from '@rjsf/utils';
 import {
   ANY_OF_KEY,
   deepEquals,
@@ -17,7 +17,6 @@ import {
 } from '@rjsf/utils';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
-import omit from 'lodash/omit';
 
 /** The `AnyOfField` component is used to render a field in the schema that is an `anyOf`, `allOf` or `oneOf`. It tracks
  * the currently selected option and cleans up any irrelevant data in `formData`.
@@ -153,7 +152,8 @@ function AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends 
   } = getUiOptions<T, S, F>(uiSchema, globalUiOptions);
   const Widget = getWidget<T, S, F>({ type: 'number' }, widget, widgets);
   const rawErrors = get(errorSchema, ERRORS_KEY, []);
-  const fieldErrorSchema = omit(errorSchema, [ERRORS_KEY]);
+  const fieldErrorSchema = { ...errorSchema } as ErrorSchema<T>;
+  delete fieldErrorSchema[ERRORS_KEY];
   const displayLabel = schemaUtils.getDisplayLabel(schema, uiSchema, globalUiOptions);
 
   const option = selectedOption >= 0 ? retrievedOptions[selectedOption] || null : null;

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -34,7 +34,6 @@ import {
   UI_OPTIONS_KEY,
 } from '@rjsf/utils';
 import isObject from 'lodash/isObject';
-import omit from 'lodash/omit';
 
 /** The map of component type to FieldName */
 const COMPONENT_TYPES: Record<string, string> = {
@@ -202,9 +201,19 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
 
   const { __errors, ...fieldErrorSchema } = errorSchema || {};
   // See #439: uiSchema: Don't pass consumed class names or style to child components
-  const fieldUiSchema = omit(uiSchema, ['ui:classNames', 'classNames', 'ui:style']);
+  const {
+    'ui:classNames': consumedUiClassNames,
+    classNames: consumedClassNames,
+    'ui:style': consumedUiStyle,
+    ...fieldUiSchema
+  } = uiSchema;
   if (UI_OPTIONS_KEY in fieldUiSchema) {
-    fieldUiSchema[UI_OPTIONS_KEY] = omit(fieldUiSchema[UI_OPTIONS_KEY], ['classNames', 'style']);
+    const {
+      classNames: consumedOptionClassNames,
+      style: consumedOptionStyle,
+      ...fieldUiOptions
+    } = fieldUiSchema[UI_OPTIONS_KEY]!;
+    fieldUiSchema[UI_OPTIONS_KEY] = fieldUiOptions;
   }
 
   const field = (

--- a/packages/utils/src/ErrorSchemaBuilder.ts
+++ b/packages/utils/src/ErrorSchemaBuilder.ts
@@ -1,4 +1,3 @@
-import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 import set from 'lodash/set';
 import setWith from 'lodash/setWith';
@@ -60,7 +59,7 @@ export default class ErrorSchemaBuilder<T = any> {
    * @returns - The `ErrorSchemaBuilder` object for chaining purposes
    */
   resetAllErrors(initialSchema?: ErrorSchema<T>) {
-    this.errorSchema = initialSchema ? cloneDeep(initialSchema) : {};
+    this.errorSchema = initialSchema ? structuredClone(initialSchema) : {};
     return this;
   }
 

--- a/packages/utils/src/findSchemaDefinition.ts
+++ b/packages/utils/src/findSchemaDefinition.ts
@@ -3,7 +3,6 @@ import jsonpointer from 'jsonpointer';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import isObject from 'lodash/isObject';
-import omit from 'lodash/omit';
 
 import {
   ALL_OF_KEY,
@@ -82,7 +81,7 @@ export function makeAllReferencesAbsolute<S extends StrictRJSFSchema = RJSFSchem
  */
 export function splitKeyElementFromObject(key: string, object: GenericObjectType) {
   const value = object[key];
-  const remaining = omit(object, [key]);
+  const { [key]: removed, ...remaining } = object;
   return [remaining, value];
 }
 

--- a/packages/utils/test/ErrorSchemaBuilder.test.ts
+++ b/packages/utils/test/ErrorSchemaBuilder.test.ts
@@ -388,5 +388,12 @@ describe('ErrorSchemaBuilder', () => {
     it('resetting error restores things back to the INITIAL_SCHEMA', () => {
       expect(builder.resetAllErrors(INITIAL_SCHEMA).ErrorSchema).toEqual(INITIAL_SCHEMA);
     });
+    it('resetting errors deep clones the initial schema rather than aliasing it', () => {
+      const initial = structuredClone(INITIAL_SCHEMA);
+      const result = builder.resetAllErrors(initial).ErrorSchema;
+      builder.addErrors('added later', ARRAY_PATH);
+      expect(result).not.toBe(initial);
+      expect(initial[ARRAY_PATH[0]]?.[ARRAY_PATH[1]]?.[ERRORS_KEY]).toEqual([INITIAL_ARRAY]);
+    });
   });
 });

--- a/packages/validator-ata/src/validator.ts
+++ b/packages/validator-ata/src/validator.ts
@@ -10,7 +10,6 @@ import type {
 } from '@rjsf/utils';
 import { deepEquals, hashForSchema, ID_KEY, ROOT_SCHEMA_PREFIX, withIdRefPrefix } from '@rjsf/utils';
 import type { ValidationError, Validator } from 'ata-validator';
-import cloneDeep from 'lodash/cloneDeep';
 
 import createAtaInstance from './createAtaInstance';
 import type { RawValidationErrorsType } from './processRawValidationErrors';
@@ -97,10 +96,7 @@ export default class ATAValidator<
     if (data === null || typeof data !== 'object') {
       return data;
     }
-    if (typeof globalThis.structuredClone === 'function') {
-      return globalThis.structuredClone(data);
-    }
-    return cloneDeep(data);
+    return structuredClone(data);
   }
 
   /** Returns the cached ata `Validator` for the given id, or builds and

--- a/packages/validator-ata/test/validator.test.ts
+++ b/packages/validator-ata/test/validator.test.ts
@@ -386,24 +386,6 @@ describe('cloneForValidation', () => {
     }
   });
 
-  it('falls back to cloneDeep when structuredClone is unavailable', () => {
-    const original = globalThis.structuredClone;
-    delete (globalThis as { structuredClone?: unknown }).structuredClone;
-    try {
-      const v = customizeValidator();
-      const schema: RJSFSchema = { type: 'object', properties: { x: { type: 'string' } } };
-      expect(v.isValid(schema, { x: 'a' }, schema)).toBe(true);
-    } finally {
-      if (original !== undefined) {
-        Object.defineProperty(globalThis, 'structuredClone', {
-          value: original,
-          configurable: true,
-          writable: true,
-        });
-      }
-    }
-  });
-
   it('returns primitives untouched', () => {
     const v = customizeValidator();
     // Primitive formData skips the clone path; verify validation still works.

--- a/packages/validator-cfworker/src/createCfworkerInstance.ts
+++ b/packages/validator-cfworker/src/createCfworkerInstance.ts
@@ -1,7 +1,6 @@
 import * as CFWorkerJsonSchema from '@cfworker/json-schema';
 import type { Schema } from '@cfworker/json-schema';
 import { Validator } from '@cfworker/json-schema';
-import cloneDeep from 'lodash/cloneDeep';
 
 import type { CFWorkerFormatChecker, CustomValidatorOptionsType } from './types';
 
@@ -72,13 +71,13 @@ export default function createCfworkerInstance(
   installFormats(customFormats);
   // The engine annotates schemas during dereferencing. Clone every user-owned
   // schema so frozen RJSF fixtures and application schemas remain untouched.
-  let validator = new Validator(cloneDeep(schema), draft, shortCircuit);
+  let validator = new Validator(structuredClone(schema), draft, shortCircuit);
 
   for (const additionalSchema of additionalMetaSchemas ?? []) {
-    validator.addSchema(cloneDeep(additionalSchema), additionalSchema.$id);
+    validator.addSchema(structuredClone(additionalSchema), additionalSchema.$id);
   }
   if (rootSchema && rootSchema !== schema) {
-    validator.addSchema(cloneDeep(rootSchema), rootSchema.$id);
+    validator.addSchema(structuredClone(rootSchema), rootSchema.$id);
   }
   if (typeof extenderFn === 'function') {
     validator = extenderFn(validator);


### PR DESCRIPTION
## Reasons for making this change

Follow-up to #5190, same shape. lodash's `baseClone` internals are reachable from two imports — `cloneDeep` and `omit` — so removing either one alone changes the bundle by roughly nothing while the shared code stays put. Removing the last consumer is what lets it drop out.

| function | where |
|---|---|
| `cloneDeep` → `structuredClone` | `Form.tsx`, `ArrayField.tsx`, `ErrorSchemaBuilder.ts`, `validator-cfworker/createCfworkerInstance.ts` |
| `omit` → object rest-spread | `SchemaField.tsx`, `MultiSchemaField.tsx`, `LayoutMultiSchemaField.tsx`, `findSchemaDefinition.ts` |
| `cloneDeep` fallback → **deleted** | `validator-ata/validator.ts` |

The rest-spread form matches the idiom already used a few lines away at `SchemaField.tsx:202`.

### Measured effect

Built ESM entries bundled as a consumer's bundler would (React and engine peers external, nx cache bypassed):

| package | min | gzip | `baseClone` |
|---|---|---|---|
| `@rjsf/utils` | 116,801 → 112,721 (−4,080) | 42,035 → **40,674** (−1,361) | 1 → **0** |
| `@rjsf/core` | 260,671 → 257,247 (−3,424) | 90,708 → **89,622** (−1,086) | 1 → **0** |
| `@rjsf/validator-cfworker` | 113,380 → 96,158 (−17,222) | 39,334 → **33,982** (−5,352) | 2 → **0** |
| `@rjsf/validator-ata` | 114,561 → 97,261 (−17,264) | 39,509 → **34,202** (−5,507) | 2 → **0** |

The validators gain the most: they reached `baseClone` from two places and carry comparatively little other lodash, so it was a larger share of their bundle.

## The one judgement call

`validator-ata`'s `cloneForValidation` already preferred `structuredClone` and only fell back to `cloneDeep` when it was absent. That fallback had a deliberate test (`falls back to cloneDeep when structuredClone is unavailable`) which deletes `globalThis.structuredClone` to force the branch.

I removed both the fallback and the test, on the grounds that `structuredClone` exists in every environment the package supports — Node >= 20 per `engines`, and browsers since 2022 — so the branch is unreachable outside a test that manufactures its absence. **This is the piece most likely to warrant discussion**; it is confined to `validator-ata` and can be dropped without affecting the rest of the PR.

## Behaviour notes

**`structuredClone` throws on functions** where `cloneDeep` copied them. Functions in `formData` are already unsupported — AJV cannot validate them and they do not survive serialisation — but this converts silent breakage into a clear error.

**`structuredClone` preserves `File` instances.** `lodash/cloneDeep` reduced a `File` to a plain object with `undefined` `name` and `size`. This is latent rather than a visible fix, since `useFileWidgetProps` converts uploads to data-URL strings before they reach `formData`.

**`omit` copied inherited properties.** lodash's `omit` uses `keysIn`, which walks the prototype chain; rest-spread copies own properties only. Reachable only through `Object.prototype` pollution, where the previous behaviour leaked the polluted key into the result. Same trap as the `pickBy` change in #5190.

No public types or signatures change.

## Note on merge order

Independent of #5190 — no source files overlap. Both add entries under the same `# 6.8.1` changelog heading, so whichever merges second will need a one-line `CHANGELOG.md` resolution.

## Checklist

- [x] I'm updating documentation
- [x] I'm adding or updating code
  - [x] I've added and/or updated tests
  - [ ] I've updated the changelog
- [ ] I'm updating dependencies