### PR TITLE
refactor: drop @rjsf/semantic-ui's lodash dependency, fixing an error-list remount

### DIFF
--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -101,7 +101,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@fluentui/react-component-ref": "^0.63.1",
-    "lodash": "^4.18.1",
     "semantic-ui-css": "^2.5.0"
   }
 }

--- a/packages/semantic-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/semantic-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -1,6 +1,5 @@
 import type { FieldErrorProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
 import { errorId } from '@rjsf/utils';
-import uniqueId from 'lodash/uniqueId';
 import { Label, List } from 'semantic-ui-react';
 
 import { getSemanticErrorProps } from '../util';
@@ -33,8 +32,9 @@ export default function FieldErrorTemplate<
     return (
       <Label id={id} color='red' pointing={pointing || 'above'} size={size || 'small'} basic>
         <List bulleted>
-          {errors.map((error) => (
-            <List.Item key={uniqueId('field-error-')}>{error}</List.Item>
+          {errors.map((error, i: number) => (
+            // oxlint-disable-next-line react/no-array-index-key
+            <List.Item key={i}>{error}</List.Item>
           ))}
         </List>
       </Label>

--- a/packages/semantic-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/semantic-ui/src/SelectWidget/SelectWidget.tsx
@@ -18,7 +18,6 @@ import {
   logUnsupportedDefaultForEnum,
   SelectedOptionDescription,
 } from '@rjsf/utils';
-import map from 'lodash/map';
 import type { DropdownProps, DropdownItemProps } from 'semantic-ui-react';
 import { Form } from 'semantic-ui-react';
 
@@ -40,7 +39,7 @@ function createDefaultValueOptionsForDropDown<S extends StrictRJSFSchema = RJSFS
   format: OptionValueFormat = 'indexed',
 ) {
   const disabledOptions = enumDisabled || [];
-  const options: DropdownItemProps[] = map(enumOptions, ({ label, value }, index) => ({
+  const options: DropdownItemProps[] = (enumOptions ?? []).map(({ label, value }, index) => ({
     disabled: disabledOptions.includes(value),
     key: label,
     text: label,

--- a/packages/utils/src/mergeSchemas.ts
+++ b/packages/utils/src/mergeSchemas.ts
@@ -1,5 +1,3 @@
-import union from 'lodash/union';
-
 import { REQUIRED_KEY } from './constants';
 import getSchemaType from './getSchemaType';
 import isObject from './isObject';
@@ -29,7 +27,7 @@ export default function mergeSchemas(obj1: GenericObjectType, obj2: GenericObjec
       Array.isArray(right)
     ) {
       // Don't include duplicate values when merging 'required' fields.
-      accumulator[key] = union(left, right);
+      accumulator[key] = [...new Set([...left, ...right])];
     } else {
       accumulator[key] = right;
     }

--- a/packages/utils/src/parser/schemaParser.ts
+++ b/packages/utils/src/parser/schemaParser.ts
@@ -1,5 +1,3 @@
-import forEach from 'lodash/forEach';
-
 import { ITEMS_KEY, PROPERTIES_KEY } from '../constants';
 import deepEquals from '../deepEquals';
 import { resolveAnyOrOneOfSchemas, retrieveSchemaInternal } from '../schema/retrieveSchema';
@@ -31,9 +29,9 @@ function parseSchema<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
       const allOptions = resolveAnyOrOneOfSchemas<T, S, F>(validator, localSchema, rootSchema, true);
       allOptions.forEach((s) => {
         if (PROPERTIES_KEY in s && s[PROPERTIES_KEY]) {
-          forEach(localSchema[PROPERTIES_KEY], (value) => {
+          for (const value of Object.values(localSchema[PROPERTIES_KEY] ?? {})) {
             parseSchema<T, S, F>(validator, recurseList, rootSchema, value as S);
-          });
+          }
         }
       });
       if (ITEMS_KEY in localSchema && !Array.isArray(localSchema.items) && typeof localSchema.items !== 'boolean') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -711,9 +711,6 @@ importers:
       '@fluentui/react-component-ref':
         specifier: ^0.63.1
         version: 0.63.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      lodash:
-        specifier: ^4.18.1
-        version: 4.18.1
       react:
         specifier: '>=18'
         version: 18.3.1


### PR DESCRIPTION
## Reasons for making this change

`@rjsf/semantic-ui` imported exactly two lodash functions, and this removes both. It also picks up two isolated single-use imports in `@rjsf/utils`.

### The dependency is removed too

With no lodash imports left, `lodash` is also removed from `@rjsf/semantic-ui`'s `dependencies`, so consumers no longer install it on the package's behalf.

The `pnpm-lock.yaml` change is confined to that package's own importer section — a few lines — and `pnpm install --frozen-lockfile`, which is what CI runs, accepts it without rewriting the file.

One thing this does **not** do: the published bundle still contains lodash internals (`baseGet`, `baseIsEqualDeep`, `baseClone`) pulled in transitively via `@rjsf/utils` and `@rjsf/core`. Those go when the shared chains are removed there.

## This also fixes a rendering bug

`FieldErrorTemplate` previously did:

```jsx
{errors.map((error) => (
  <List.Item key={uniqueId('field-error-')}>{error}</List.Item>
))}
```

`uniqueId()` returns a different value on every call, so every error item received a **new React key on every render** and was unmounted and remounted rather than updated.

Keying by index matches the existing `@rjsf/mui` and `@rjsf/chakra-ui` implementations of the same template, including their `oxlint-disable-next-line react/no-array-index-key`.

## Notes on equivalence

- `enumOptions` is optional (`enumOptions?: EnumOptionsType<S>[]`), so `?? []` preserves `lodash/map`'s tolerance of a nullish collection.
- In `schemaParser`, the surrounding guard tests `s[PROPERTIES_KEY]` while the loop reads `localSchema[PROPERTIES_KEY]` — a different object — so `?? {}` is required to preserve `lodash/forEach`'s no-op on a nullish collection.
- `union` and the `Set` spread both dedupe while preserving first-seen order.

No public types or signatures change.

## Note on merge order

Independent of #5190 and #5191 — no source files overlap. All three add entries under the same `# 6.8.1` changelog heading, so whichever merges later will need a one-line `CHANGELOG.md` resolution.

## Checklist

- [x] I'm updating documentation
- [x] I'm adding or updating code
  - [ ] I've added and/or updated tests
  - [ ] I've updated the changelog
- [ ] I'm updating dependencies

