### PR TITLE
refactor: drop @rjsf/shadcn's lodash dependency

### DIFF
--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -97,8 +97,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "lodash": "^4.18.1",
-    "lodash-es": "^4.18.1",
     "lucide-react": "^1.16.0",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",

--- a/packages/shadcn/src/RangeWidget/RangeWidget.tsx
+++ b/packages/shadcn/src/RangeWidget/RangeWidget.tsx
@@ -1,6 +1,5 @@
 import type { FormContextType, RJSFSchema, StrictRJSFSchema, WidgetProps } from '@rjsf/utils';
 import { ariaDescribedByIds, rangeSpec } from '@rjsf/utils';
-import _pick from 'lodash/pick';
 
 import { Slider } from '../components/ui/slider';
 
@@ -46,7 +45,11 @@ export default function RangeWidget<T = any, S extends StrictRJSFSchema = RJSFSc
   const handleChange = (newValue: number[]) => onChange(newValue[0]);
 
   const sliderProps = { value, label, id, ...rangeSpec<S>(schema) };
-  const uiProps = { id, ..._pick((options.props as object) || {}, allowedProps) };
+  const optionProps = new Map(Object.entries(options.props ?? {}));
+  const uiProps = {
+    id,
+    ...Object.fromEntries(allowedProps.filter((key) => optionProps.has(key)).map((key) => [key, optionProps.get(key)])),
+  };
   return (
     <>
       <Slider

--- a/packages/shadcn/src/components/ui/fancy-multi-select.tsx
+++ b/packages/shadcn/src/components/ui/fancy-multi-select.tsx
@@ -2,8 +2,8 @@
 
 import type { FocusEvent, FocusEventHandler, KeyboardEvent, ReactElement } from 'react';
 import { useCallback, useMemo, useRef, useState } from 'react';
+import { deepEquals } from '@rjsf/utils';
 import { Command as CommandPrimitive } from 'cmdk';
-import isEqual from 'lodash/isEqual';
 import { X } from 'lucide-react';
 
 import { cn } from '../../lib/utils';
@@ -78,12 +78,12 @@ export function FancyMultiSelect({
   const [inputValue, setInputValue] = useState('');
 
   const selectedItems = useMemo(
-    () => items.filter((item) => selected.some((selectedValue) => isEqual(item.value, selectedValue))),
+    () => items.filter((item) => selected.some((selectedValue) => deepEquals(item.value, selectedValue))),
     [items, selected],
   );
 
   const selectables = useMemo(
-    () => items.filter((framework) => !selectedItems.some((item) => isEqual(item.value, framework.value))),
+    () => items.filter((framework) => !selectedItems.some((item) => deepEquals(item.value, framework.value))),
     [items, selectedItems],
   );
 
@@ -92,7 +92,7 @@ export function FancyMultiSelect({
       if (disabled) {
         return;
       }
-      const newSelected = selectedItems.filter((s) => !isEqual(s.value, framework.value));
+      const newSelected = selectedItems.filter((s) => !deepEquals(s.value, framework.value));
       onValueChange?.(newSelected.map((item) => item.index));
     },
     [selectedItems, onValueChange, disabled],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,12 +784,6 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      lodash:
-        specifier: ^4.18.1
-        version: 4.18.1
-      lodash-es:
-        specifier: ^4.18.1
-        version: 4.18.1
       lucide-react:
         specifier: ^1.16.0
         version: 1.17.0(react@18.3.1)


### PR DESCRIPTION
## Reasons for making this change

`@rjsf/shadcn` imported exactly two lodash functions, and this removes both. Same shape as #5192, which does it for `@rjsf/semantic-ui`.

### The dependency is removed too

With no lodash imports left, `lodash` and `lodash-es` are also removed from `@rjsf/shadcn`'s `dependencies`, so consumers no longer install them on the package's behalf.

The `pnpm-lock.yaml` change is confined to that package's own importer section — a few lines — and `pnpm install --frozen-lockfile`, which is what CI runs, accepts it without rewriting the file.

One thing this does **not** do: the published bundle still contains lodash internals (`baseGet`, `baseIsEqualDeep`, `baseClone`) pulled in transitively via `@rjsf/utils` and `@rjsf/core`. Those go when the shared chains are removed there.

## One thing worth a maintainer's opinion

`fancy-multi-select.tsx` lives in `src/components/ui/`, where **0 of 14 files currently import anything from `@rjsf/*`**. That directory follows the shadcn/ui convention of being kept syncable with upstream, so this change makes it the first file there to depend on an RJSF package.

If you would rather keep that boundary clean, the alternative is to inline the comparison locally instead of importing `deepEquals`. Happy to switch — it is a three-line change either way.

## Behaviour notes

- `lodash/pick` copies inherited enumerable properties via `keysIn`; `Object.entries` copies own properties only. A polluted `Object.prototype` can therefore no longer leak keys into the slider's `uiProps`. Same trap as the `pickBy` change in #5190 and the `omit` change in #5191.
- `deepEquals` treats functions as equal and tracks circular references, unlike `lodash/isEqual`. Neither applies to the enum option values compared here; the two also agree on `NaN`, `-0` and sparse arrays.

No public types or signatures change.

## Note on merge order

Independent of #5189, #5190, #5191 and #5192 — none of them touch `packages/shadcn`. Only `CHANGELOG.md` overlaps.

## Checklist

- [x] I'm updating documentation
- [x] I'm adding or updating code
  - [ ] I've added and/or updated tests
  - [ ] I've updated the changelog
- [ ] I'm updating dependencies

