### PR TITLE
Fix 5194: remove over-reaching additionalProperties:false post-processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `mergeDefaultsWithFormData()` to take the recursive path when the default under an object key holds an array, so a default that lives inside a `dependencies` subschema is no longer dropped when the owning array sits more than one object below the root, fixing part of [#5198](https://github.com/rjsf-team/react-jsonschema-form/issues/5198) ([#5202](https://github.com/rjsf-team/react-jsonschema-form/pull/5202))
 - Added new path utilities `getByPath`, `setByPath`, `hasByPath`, `unsetByPath` and `toPath`, and switched all path-based `lodash` usage (`get`, `set`, `setWith`, `has`, `unset`, `toPath`, `pick`) over to them. Unlike their lodash counterparts, these treat a bare string as a single literal key, lodash-style dotted path strings are parsed explicitly via `toPath()`, and `getByPath()`/`hasByPath()` resolve **own** properties only (inherited members and prototype internals such as `__proto__` never resolve)
 - Made the default value of a required boolean field be false if a `default` is not present in the schema
+- Fixed `omitExtraData()` by removing the over-reaching `additionalProperties: false` post-processing block introduced in [#5147](https://github.com/rjsf-team/react-jsonschema-form/pull/5147) that incorrectly stripped keys written by winning `oneOf`/`anyOf` and `if/then/else` branches, fixing [#5194](https://github.com/rjsf-team/react-jsonschema-form/issues/5194)
 
 ## @rjsf/validator-ajv8
 
@@ -78,15 +79,6 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/validator-cfworker
 
 - Replaced all `lodash/get` usage with the new `@rjsf/utils` path utilities and dropped the `lodash`/`lodash-es` dependencies entirely
-
-## @rjsf/snapshot-tests
-
-- Restored the `required checkbox field` snapshot test (required boolean property inside an object schema) that was missing from source, fixing [#5200](https://github.com/rjsf-team/react-jsonschema-form/pull/5200)
-
-## @rjsf/utils
-
-- Fixed `mergeDefaultsWithFormData()` to take the recursive path when the default under an object key holds an array, so a default that lives inside a `dependencies` subschema is no longer dropped when the owning array sits more than one object below the root, fixing part of [#5198](https://github.com/rjsf-team/react-jsonschema-form/issues/5198) ([#5202](https://github.com/rjsf-team/react-jsonschema-form/pull/5202))
-- Fixed `omitExtraData()` by removing the over-reaching `additionalProperties: false` post-processing block introduced in [#5147](https://github.com/rjsf-team/react-jsonschema-form/pull/5147) that incorrectly stripped keys written by winning `oneOf`/`anyOf` and `if/then/else` branches, fixing [#5194](https://github.com/rjsf-team/react-jsonschema-form/issues/5194)
 
 # 6.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,9 +86,14 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Fixed `TimeWidget` to respect schema `multipleOf` time precision, preserving second-precision values while keeping minute-precision native inputs synchronized with their displayed value ([#5174](https://github.com/rjsf-team/react-jsonschema-form/pull/5174))
 
+## @rjsf/snapshot-tests
+
+- Restored the `required checkbox field` snapshot test (required boolean property inside an object schema) that was missing from source, fixing [#5200](https://github.com/rjsf-team/react-jsonschema-form/pull/5200)
+
 ## @rjsf/utils
 
 - Fixed an issue in `sortedJSONStringify` with regards to handling arrays containing `null` and `undefined` values.
+- Fixed `omitExtraData()` by removing the over-reaching `additionalProperties: false` post-processing block introduced in [#5147](https://github.com/rjsf-team/react-jsonschema-form/pull/5147) that incorrectly stripped keys written by winning `oneOf`/`anyOf` and `if/then/else` branches, fixing [#5194](https://github.com/rjsf-team/react-jsonschema-form/issues/5194)
 
 ## @rjsf/validator-ata
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,14 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Replaced all `lodash/get` usage with the new `@rjsf/utils` path utilities and dropped the `lodash`/`lodash-es` dependencies entirely
 
+## @rjsf/snapshot-tests
+
+- Restored the `required checkbox field` snapshot test (required boolean property inside an object schema) that was missing from source, fixing [#5200](https://github.com/rjsf-team/react-jsonschema-form/pull/5200)
+
+## @rjsf/utils
+
+- Fixed `mergeDefaultsWithFormData()` to take the recursive path when the default under an object key holds an array, so a default that lives inside a `dependencies` subschema is no longer dropped when the owning array sits more than one object below the root, fixing part of [#5198](https://github.com/rjsf-team/react-jsonschema-form/issues/5198) ([#5202](https://github.com/rjsf-team/react-jsonschema-form/pull/5202))
+- Fixed `omitExtraData()` by removing the over-reaching `additionalProperties: false` post-processing block introduced in [#5147](https://github.com/rjsf-team/react-jsonschema-form/pull/5147) that incorrectly stripped keys written by winning `oneOf`/`anyOf` and `if/then/else` branches, fixing [#5194](https://github.com/rjsf-team/react-jsonschema-form/issues/5194)
 
 # 6.8.0
 
@@ -86,14 +94,9 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Fixed `TimeWidget` to respect schema `multipleOf` time precision, preserving second-precision values while keeping minute-precision native inputs synchronized with their displayed value ([#5174](https://github.com/rjsf-team/react-jsonschema-form/pull/5174))
 
-## @rjsf/snapshot-tests
-
-- Restored the `required checkbox field` snapshot test (required boolean property inside an object schema) that was missing from source, fixing [#5200](https://github.com/rjsf-team/react-jsonschema-form/pull/5200)
-
 ## @rjsf/utils
 
 - Fixed an issue in `sortedJSONStringify` with regards to handling arrays containing `null` and `undefined` values.
-- Fixed `omitExtraData()` by removing the over-reaching `additionalProperties: false` post-processing block introduced in [#5147](https://github.com/rjsf-team/react-jsonschema-form/pull/5147) that incorrectly stripped keys written by winning `oneOf`/`anyOf` and `if/then/else` branches, fixing [#5194](https://github.com/rjsf-team/react-jsonschema-form/issues/5194)
 
 ## @rjsf/validator-ata
 

--- a/packages/core/test/BooleanField.test.tsx
+++ b/packages/core/test/BooleanField.test.tsx
@@ -268,12 +268,8 @@ describe('BooleanField', () => {
       schema: {
         type: 'object',
         properties: {
-          // Use a string enum so the field stays absent from initial formData —
-          // required booleans now default to false, which satisfies AJV's required
-          // constraint and would suppress the validation error this test relies on.
           bool: {
-            type: 'string',
-            enum: ['a', 'b'],
+            type: 'boolean',
           },
         },
         required: ['bool'],
@@ -307,12 +303,8 @@ describe('BooleanField', () => {
       schema: {
         type: 'object',
         properties: {
-          // Use a string enum so the field stays absent from initial formData —
-          // required booleans now default to false, which satisfies AJV's required
-          // constraint and would suppress the validation error this test relies on.
           bool: {
-            type: 'string',
-            enum: ['a', 'b'],
+            type: 'boolean',
           },
         },
         required: ['bool'],

--- a/packages/core/test/BooleanField.test.tsx
+++ b/packages/core/test/BooleanField.test.tsx
@@ -268,8 +268,11 @@ describe('BooleanField', () => {
       schema: {
         type: 'object',
         properties: {
+          // string enum keeps the field absent from initial formData; required booleans
+          // default to false (PR #5170), which satisfies AJV and suppresses the error.
           bool: {
-            type: 'boolean',
+            type: 'string',
+            enum: ['a', 'b'],
           },
         },
         required: ['bool'],
@@ -303,8 +306,11 @@ describe('BooleanField', () => {
       schema: {
         type: 'object',
         properties: {
+          // string enum keeps the field absent from initial formData; required booleans
+          // default to false (PR #5170), which satisfies AJV and suppresses the error.
           bool: {
-            type: 'boolean',
+            type: 'string',
+            enum: ['a', 'b'],
           },
         },
         required: ['bool'],

--- a/packages/core/test/BooleanField.test.tsx
+++ b/packages/core/test/BooleanField.test.tsx
@@ -268,6 +268,9 @@ describe('BooleanField', () => {
       schema: {
         type: 'object',
         properties: {
+          // Use a string enum so the field stays absent from initial formData —
+          // required booleans now default to false, which satisfies AJV's required
+          // constraint and would suppress the validation error this test relies on.
           bool: {
             type: 'string',
             enum: ['a', 'b'],
@@ -304,6 +307,9 @@ describe('BooleanField', () => {
       schema: {
         type: 'object',
         properties: {
+          // Use a string enum so the field stays absent from initial formData —
+          // required booleans now default to false, which satisfies AJV's required
+          // constraint and would suppress the validation error this test relies on.
           bool: {
             type: 'string',
             enum: ['a', 'b'],

--- a/packages/utils/src/schema/omitExtraData.ts
+++ b/packages/utils/src/schema/omitExtraData.ts
@@ -491,25 +491,25 @@ export default function omitExtraData<
       }
     }
 
-    const result = handleDependencies(localSchema, source, handleConditions(localSchema, source, filtered));
-
-    // Post-prune: when additionalProperties is false, delete any key that survived branch
-    // merging (oneOf/anyOf/if-then) but is not covered by the parent schema's own properties
-    // or patternProperties. Mirrors the SJSF implementation — branch-granted keys are still
-    // filtered through omit() above, but any that end up outside the schema's declared property
-    // set are removed here so the result honours additionalProperties:false.
-    if (localSchema.additionalProperties === false && isObjectValue(result)) {
+    // Post-prune after conditions (oneOf/anyOf/if-then) but BEFORE dependencies: keys added by
+    // dependency sub-schemas are legitimate extensions of the allowed property set and must not be
+    // pruned. Keys added only by winning conditional branches are still removed here so the result
+    // honours additionalProperties:false.
+    const afterConditions = handleConditions(localSchema, source, filtered);
+    if (localSchema.additionalProperties === false && isObjectValue(afterConditions)) {
       const knownKeys = new Set(Object.keys(localSchema.properties ?? {}));
       const patterns = localSchema.patternProperties
         ? Object.keys(localSchema.patternProperties).map((p) => new RegExp(p))
         : [];
-      for (const key of Object.keys(result)) {
+      for (const key of Object.keys(afterConditions)) {
         if (!knownKeys.has(key) && !patterns.some((re) => re.test(key))) {
           // oxlint-disable-next-line no-param-reassign
-          delete result[key];
+          delete afterConditions[key];
         }
       }
     }
+
+    const result = handleDependencies(localSchema, source, afterConditions);
 
     return result ?? (materializeSource ? source : undefined);
   }

--- a/packages/utils/src/schema/omitExtraData.ts
+++ b/packages/utils/src/schema/omitExtraData.ts
@@ -169,7 +169,7 @@ export default function omitExtraData<
   }
 
   /** Copies schema-defined properties from `source` into `target`, applying `omit` recursively for
-   * each value. Handles `properties`, `patternProperties`, `additionalProperties`, and `propertyNames`.
+   * each value. Handles `properties`, `patternProperties`, and `additionalProperties`.
    * Optional object-valued properties are pruned when every key in the filtered result is both
    * optional (per the inner schema's `required`) and empty (per `isValueEmpty`). This preserves
    * optional objects whose required children have empty values, while still dropping objects whose
@@ -183,7 +183,7 @@ export default function omitExtraData<
    * @returns - `target` after all schema-defined properties have been processed
    */
   function handleObject(childSchema: S, source: GenericObjectType, target: GenericObjectType): GenericObjectType {
-    const { properties, additionalProperties, patternProperties, propertyNames } = childSchema;
+    const { properties, additionalProperties, patternProperties } = childSchema;
     const requiredSet = new Set(childSchema.required ?? []);
 
     /** Recursively omits extra data from `value` via `omit`, then conditionally writes the result to
@@ -266,46 +266,51 @@ export default function omitExtraData<
       }
     }
 
-    // When propertyNames is present, the schema only constrains key names — all source keys are valid.
-    if (propertyNames !== undefined) {
-      for (const [key, value] of Object.entries(source)) {
-        // oxlint-disable-next-line no-param-reassign
-        target[key] = value;
-      }
-    }
-
     return target;
   }
 
   /** Filters array elements from `source` into `target` according to `schema.items` and
-   * `schema.additionalItems`. For tuple schemas (`items` is an array) each element is filtered by its
-   * per-index schema; elements beyond the tuple length are covered by `additionalItems` when present.
-   * For list schemas (`items` is a single schema) every element is filtered by that schema.
+   * `schema.additionalItems`. Only called when `items` is defined (guarded in `omit`). Uses index
+   * assignment (not push) so a pre-populated `target` from a prior branch is overwritten rather than
+   * appended to, preventing item duplication. For tuple schemas (`items` is an array) elements up to
+   * `min(items.length, source.length)` are filtered by their per-index schema; elements beyond the
+   * tuple are covered by `additionalItems` when present, or the target is truncated when absent.
+   * For list schemas (`items` is a single schema) every source element is filtered and `target.length`
+   * is set to `source.length`.
    *
    * @param childSchema - The array schema describing `items` and optionally `additionalItems`
    * @param source - The source array to read elements from
-   * @param target - The accumulator array to push filtered elements into
-   * @returns - `target` after all applicable source elements have been pushed
+   * @param target - The accumulator array to write filtered elements into
+   * @returns - `target` after all applicable source elements have been written
    */
   function handleArray(childSchema: S, source: unknown[], target: unknown[]): unknown[] {
     const { items, additionalItems } = childSchema;
-    if (items !== undefined) {
-      if (Array.isArray(items)) {
-        for (let i = 0; i < items.length; i += 1) {
-          target.push(omit(items[i] as S | boolean, source[i]));
-        }
-      } else {
-        for (let i = 0; i < source.length; i += 1) {
-          target.push(omit(items as S | boolean, source[i]));
-        }
+    if (Array.isArray(items)) {
+      const tupleLength = Math.min(items.length, source.length);
+      let i = 0;
+      for (; i < tupleLength; i += 1) {
+        // oxlint-disable-next-line no-param-reassign
+        target[i] = omit(items[i] as S | boolean, source[i]);
+      }
+      // Without additionalItems, truncate at the tuple boundary to drop any pre-existing items.
+      if (!additionalItems) {
+        // oxlint-disable-next-line no-param-reassign
+        target.length = tupleLength;
+        return target;
+      }
+      for (; i < source.length; i += 1) {
+        // oxlint-disable-next-line no-param-reassign
+        target[i] = omit(additionalItems as S | boolean, source[i]);
+      }
+    } else {
+      for (let i = 0; i < source.length; i += 1) {
+        // oxlint-disable-next-line no-param-reassign
+        target[i] = omit(items as S | boolean, source[i]);
       }
     }
-    // additionalItems covers tuple items beyond the items array length.
-    if (additionalItems) {
-      for (let i = target.length; i < source.length; i += 1) {
-        target.push(omit(additionalItems as S | boolean, source[i]));
-      }
-    }
+    // Truncate any pre-existing items beyond the source length.
+    // oxlint-disable-next-line no-param-reassign
+    target.length = source.length;
     return target;
   }
 
@@ -330,7 +335,7 @@ export default function omitExtraData<
       ? validator.isValid(condition as S, source as T, rootSchema)
       : condition;
     const branch = isThenBranch ? then : otherwise;
-    return branch === undefined ? target : omit(branch as S | boolean, source, target);
+    return branch === undefined ? target : omit(branch as S | boolean, source, target, false);
   }
 
   /** Applies the best-matching `oneOf` option to `source`, merging the result into `target`. When
@@ -368,7 +373,7 @@ export default function omitExtraData<
     const resolved: S = isObject(winning)
       ? resolveAllReferences<S>(winning, rootSchema, [])
       : scoringOptions[bestIndex];
-    return omit(resolved, source, target);
+    return omit(resolved, source, target, false);
   }
 
   /** Applies `anyOf` branches from `schema` to `source`, merging results into `target`. When `anyOf`
@@ -394,7 +399,7 @@ export default function omitExtraData<
     ) {
       let result = target;
       for (const branch of anyOf as (S | boolean)[]) {
-        result = omit(branch, source, result);
+        result = omit(branch, source, result, false);
       }
       return result;
     }
@@ -420,7 +425,7 @@ export default function omitExtraData<
     for (const [key, deps] of Object.entries(dependencies)) {
       // Skip property dependencies (string arrays); only process schema dependencies.
       if (key in source && !Array.isArray(deps)) {
-        result = omit(deps as S | boolean, source, result);
+        result = omit(deps as S | boolean, source, result, false);
       }
     }
     return result;
@@ -429,26 +434,30 @@ export default function omitExtraData<
   /** Core recursive filter. Resolves `$ref`s, merges `allOf`, then delegates to the type-specific
    * handlers (`handleObject`, `handleArray`) and keyword handlers (`handleAnyOf`, `handleOneOf`,
    * `handleConditions`, `handleDependencies`). Returns `undefined` when `source` is undefined or
-   * `schemaDef` is `false`; returns `source` unchanged when `schemaDef` is `true` or empty.
+   * `schemaDef` is `false`; when `schemaDef` is `true` or empty returns `target ?? source` (when
+   * `materializeSource` is true) or `target` (when false) to avoid aliasing `source` as the
+   * accumulator across multiple compositional branches.
    *
    * @param schemaDef - The schema (or boolean shorthand) to filter `source` against
    * @param source - The raw form data value to filter
    * @param [target] - An optional accumulator carrying results from prior oneOf/anyOf processing
+   * @param [materializeSource=true] - When false a permissive schema (`true`/`{}`) returns `target`
+   *   rather than `source`, preventing compositional branches from aliasing the accumulator to `source`
    * @returns - The filtered value, or `undefined` when the schema rejects the value
    */
-  function omit(schemaDef: S | boolean, source: unknown, target?: unknown): unknown {
+  function omit(schemaDef: S | boolean, source: unknown, target?: unknown, materializeSource = true): unknown {
     if (source === undefined || schemaDef === false) {
       return undefined;
     }
     if (schemaDef === true || isEmpty(schemaDef as object)) {
-      return source;
+      return target ?? (materializeSource ? source : undefined);
     }
 
     let localSchema = schemaDef;
     const { $ref: ref, allOf } = localSchema;
 
     if (ref !== undefined) {
-      return omit(findSchemaDefinition<S>(ref, rootSchema), source, target);
+      return omit(findSchemaDefinition<S>(ref, rootSchema), source, target, materializeSource);
     }
     if (allOf) {
       localSchema = doMergeAllOf<S>(localSchema, experimental_customMergeAllOf);
@@ -460,7 +469,7 @@ export default function omitExtraData<
       if (remainingAllOf) {
         for (let i = 0; i < remainingAllOf.length; i++) {
           // oxlint-disable-next-line no-param-reassign
-          target = omit(remainingAllOf[i] as S | boolean, source, target);
+          target = omit(remainingAllOf[i] as S | boolean, source, target, false);
         }
       }
     }
@@ -477,12 +486,13 @@ export default function omitExtraData<
       if (!Array.isArray(source)) {
         return undefined;
       }
-      filtered = handleArray(localSchema, source, Array.isArray(filtered) ? filtered : []);
-    } else if (filtered === undefined) {
-      filtered = source;
+      if (localSchema.items !== undefined) {
+        filtered = handleArray(localSchema, source, Array.isArray(filtered) ? filtered : []);
+      }
     }
 
-    return handleDependencies(localSchema, source, handleConditions(localSchema, source, filtered));
+    const result = handleDependencies(localSchema, source, handleConditions(localSchema, source, filtered));
+    return result ?? (materializeSource ? source : undefined);
   }
 
   return omit(schema, formData) as T | undefined;

--- a/packages/utils/src/schema/omitExtraData.ts
+++ b/packages/utils/src/schema/omitExtraData.ts
@@ -435,29 +435,29 @@ export default function omitExtraData<
    * handlers (`handleObject`, `handleArray`) and keyword handlers (`handleAnyOf`, `handleOneOf`,
    * `handleConditions`, `handleDependencies`). Returns `undefined` when `source` is undefined or
    * `schemaDef` is `false`; when `schemaDef` is `true` or empty returns `target ?? source` (when
-   * `materializeSource` is true) or `target` (when false) to avoid aliasing `source` as the
+   * `useSourceAsFallback` is true) or `target` (when false) to avoid aliasing `source` as the
    * accumulator across multiple compositional branches.
    *
    * @param schemaDef - The schema (or boolean shorthand) to filter `source` against
    * @param source - The raw form data value to filter
    * @param [target] - An optional accumulator carrying results from prior oneOf/anyOf processing
-   * @param [materializeSource=true] - When false a permissive schema (`true`/`{}`) returns `target`
+   * @param [useSourceAsFallback=true] - When false a permissive schema (`true`/`{}`) returns `target`
    *   rather than `source`, preventing compositional branches from aliasing the accumulator to `source`
    * @returns - The filtered value, or `undefined` when the schema rejects the value
    */
-  function omit(schemaDef: S | boolean, source: unknown, target?: unknown, materializeSource = true): unknown {
+  function omit(schemaDef: S | boolean, source: unknown, target?: unknown, useSourceAsFallback = true): unknown {
     if (source === undefined || schemaDef === false) {
       return undefined;
     }
     if (schemaDef === true || isEmpty(schemaDef as object)) {
-      return target ?? (materializeSource ? source : undefined);
+      return target ?? (useSourceAsFallback ? source : undefined);
     }
 
     let localSchema = schemaDef;
     const { $ref: ref, allOf } = localSchema;
 
     if (ref !== undefined) {
-      return omit(findSchemaDefinition<S>(ref, rootSchema), source, target, materializeSource);
+      return omit(findSchemaDefinition<S>(ref, rootSchema), source, target, useSourceAsFallback);
     }
     if (allOf) {
       localSchema = doMergeAllOf<S>(localSchema, experimental_customMergeAllOf);
@@ -511,7 +511,7 @@ export default function omitExtraData<
 
     const result = handleDependencies(localSchema, source, afterConditions);
 
-    return result ?? (materializeSource ? source : undefined);
+    return result ?? (useSourceAsFallback ? source : undefined);
   }
 
   return omit(schema, formData) as T | undefined;

--- a/packages/utils/src/schema/omitExtraData.ts
+++ b/packages/utils/src/schema/omitExtraData.ts
@@ -492,6 +492,25 @@ export default function omitExtraData<
     }
 
     const result = handleDependencies(localSchema, source, handleConditions(localSchema, source, filtered));
+
+    // Post-prune: when additionalProperties is false, delete any key that survived branch
+    // merging (oneOf/anyOf/if-then) but is not covered by the parent schema's own properties
+    // or patternProperties. Mirrors the SJSF implementation — branch-granted keys are still
+    // filtered through omit() above, but any that end up outside the schema's declared property
+    // set are removed here so the result honours additionalProperties:false.
+    if (localSchema.additionalProperties === false && isObjectValue(result)) {
+      const knownKeys = new Set(Object.keys(localSchema.properties ?? {}));
+      const patterns = localSchema.patternProperties
+        ? Object.keys(localSchema.patternProperties).map((p) => new RegExp(p))
+        : [];
+      for (const key of Object.keys(result)) {
+        if (!knownKeys.has(key) && !patterns.some((re) => re.test(key))) {
+          // oxlint-disable-next-line no-param-reassign
+          delete result[key];
+        }
+      }
+    }
+
     return result ?? (materializeSource ? source : undefined);
   }
 

--- a/packages/utils/test/schema/omitExtraDataTest.ts
+++ b/packages/utils/test/schema/omitExtraDataTest.ts
@@ -1201,10 +1201,11 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
         expect(result).toEqual({ type: 'B' });
       });
 
-      it('preserves keys added by then-branch even when parent has additionalProperties:false', () => {
-        // then-branch properties are kept regardless of the parent's additionalProperties:false —
-        // omitExtraData does not post-prune branch-granted keys, matching pre-PR behaviour.
-        // 'p_field' matches patternProperties and is also retained.
+      it('prunes then-branch keys not in parent properties/patternProperties when additionalProperties:false', () => {
+        // Post-pruning mirrors the SJSF behaviour: after all branch merging, any key that is not
+        // in the parent schema's own `properties` or matched by `patternProperties` is deleted
+        // when additionalProperties is false. 'extra' is only declared in the then-branch, so it
+        // is pruned. 'p_field' matches '^p_' and is retained.
         const schema: RJSFSchema = {
           type: 'object',
           properties: { type: { type: 'string' } },
@@ -1216,12 +1217,12 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
         const formData = { type: 'A', p_field: 'keep', extra: 'keep' };
         testValidator.setReturnValues({ isValid: [true] });
         const result = omitExtraData(testValidator, schema, schema, formData);
-        expect(result).toEqual({ type: 'A', p_field: 'keep', extra: 'keep' });
+        expect(result).toEqual({ type: 'A', p_field: 'keep' });
       });
 
-      it('preserves then-branch keys when parent has additionalProperties:false and no properties', () => {
-        // Without a parent `properties` key, handleObject writes nothing from source.
-        // The then-branch result is still merged in and preserved.
+      it('prunes then-branch keys when parent has additionalProperties:false and no properties', () => {
+        // Without a parent `properties` key the known-key set is empty, so all keys that survive
+        // branch merging are removed by the post-pruning step.
         const schema: RJSFSchema = {
           type: 'object',
           additionalProperties: false,
@@ -1231,7 +1232,7 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
         const formData = { extra: 'keep' };
         testValidator.setReturnValues({ isValid: [true] });
         const result = omitExtraData(testValidator, schema, schema, formData);
-        expect(result).toEqual({ extra: 'keep' });
+        expect(result).toEqual({});
       });
 
       it('returns existing filtered value when then-branch is permissive (true)', () => {

--- a/packages/utils/test/schema/omitExtraDataTest.ts
+++ b/packages/utils/test/schema/omitExtraDataTest.ts
@@ -1362,6 +1362,24 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
         expect(result).not.toHaveProperty('extra');
       });
 
+      it('preserves keys added by a dependency sub-schema even when parent has additionalProperties:false', () => {
+        // handleDependencies runs AFTER the post-prune step, so dependency-declared properties
+        // are never deleted by the additionalProperties:false sweep.
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          additionalProperties: false,
+          dependencies: {
+            name: {
+              properties: { age: { type: 'number' } },
+            },
+          },
+        };
+        const formData = { name: 'Alice', age: 30, extra: 'drop' };
+        const result = omitExtraData(testValidator, schema, schema, formData);
+        expect(result).toEqual({ name: 'Alice', age: 30 });
+      });
+
       it('skips property dependencies (string arrays) and schema dependencies for absent keys', () => {
         const schema: RJSFSchema = {
           type: 'object',

--- a/packages/utils/test/schema/omitExtraDataTest.ts
+++ b/packages/utils/test/schema/omitExtraDataTest.ts
@@ -1089,6 +1089,99 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
         const result = omitExtraData(testValidator, schema, schema, formData);
         expect(result).toEqual({ prop1: 'with required', prop2: { subprop1: '123', subprop2: '456' } });
       });
+
+      // Regression test for https://github.com/rjsf-team/react-jsonschema-form/issues/3920
+      // When there are ≥2 if/then entries in allOf and the merger can only hoist one, the
+      // remainingAllOf loop previously returned `source` as the accumulated target (because the
+      // allOf entry has no top-level type), aliasing source as the accumulator and causing
+      // handleArray to push items onto the same array it was iterating — an infinite growth loop
+      // that corrupted the list and dropped the conditional props with numeric-string keys.
+      it('preserves numeric-string property keys from multiple if/then allOf conditions (issue #3920)', () => {
+        const rankingDetails = {
+          type: 'object' as const,
+          properties: {
+            promotionPeriod: { type: 'integer' as const, minimum: 1, maximum: 12, default: 3 },
+            threshold: { type: 'number' as const },
+          },
+        };
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            list: {
+              type: 'array',
+              items: { type: 'integer', enum: [0, 1, 2, 3] },
+              uniqueItems: true,
+            },
+          },
+          allOf: [
+            {
+              if: { properties: { list: { contains: { const: 1 } } } },
+              then: { properties: { '1': { title: 'Level 1', ...rankingDetails } } },
+            },
+            {
+              if: { properties: { list: { contains: { const: 2 } } } },
+              then: { properties: { '2': { title: 'Level 2', ...rankingDetails } } },
+            },
+            {
+              if: { properties: { list: { contains: { const: 3 } } } },
+              then: { properties: { '3': { title: 'Level 3', ...rankingDetails } } },
+            },
+          ],
+        };
+        const formData = {
+          list: [1, 2],
+          '1': { promotionPeriod: 5, threshold: 0.8 },
+          '2': { promotionPeriod: 7, threshold: 0.5 },
+        };
+        // Merger hoists the first if/then; the remaining two stay in allOf.
+        // isValid calls (in order):
+        //   (1) allOf[1] if-condition (list contains 2) → true
+        //   (2) allOf[2] if-condition (list contains 3) → false
+        //   (3) hoisted top-level if-condition (list contains 1) → true
+        testValidator.setReturnValues({ isValid: [true, false, true] });
+        const result = omitExtraData(testValidator, schema, schema, formData);
+        expect(result).toEqual({
+          list: [1, 2],
+          '1': { promotionPeriod: 5, threshold: 0.8 },
+          '2': { promotionPeriod: 7, threshold: 0.5 },
+        });
+      });
+
+      it('preserves oneOf-filtered array content for type:array schemas with no top-level items', () => {
+        const schema: RJSFSchema = {
+          type: 'array',
+          oneOf: [
+            { type: 'array', items: { type: 'object', properties: { a: { type: 'string' } } } },
+            { type: 'array', items: { type: 'object', properties: { b: { type: 'number' } } } },
+          ],
+        };
+        const formData = [
+          { a: 'hello', extra: true },
+          { a: 'world', extra: false },
+        ];
+        // isValid called once to pick the winning oneOf branch (index 0)
+        testValidator.setReturnValues({ isValid: [true] });
+        const result = omitExtraData(testValidator, schema, schema, formData);
+        // extra keys are dropped; array is preserved, not collapsed to []
+        expect(result).toEqual([{ a: 'hello' }, { a: 'world' }]);
+      });
+
+      it('preserves anyOf-filtered array content for type:array schemas with no top-level items', () => {
+        const schema: RJSFSchema = {
+          type: 'array',
+          anyOf: [
+            { type: 'array', items: { type: 'object', properties: { x: { type: 'number' } } } },
+            { type: 'array', items: { type: 'object', properties: { y: { type: 'number' } } } },
+          ],
+        };
+        const formData = [
+          { x: 1, extra: true },
+          { x: 2, extra: false },
+        ];
+        testValidator.setReturnValues({ isValid: [true] });
+        const result = omitExtraData(testValidator, schema, schema, formData);
+        expect(result).toEqual([{ x: 1 }, { x: 2 }]);
+      });
     });
 
     describe('patternProperties support', () => {

--- a/packages/utils/test/schema/omitExtraDataTest.ts
+++ b/packages/utils/test/schema/omitExtraDataTest.ts
@@ -885,12 +885,11 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
         expect(omitExtraData(testValidator, schema, schema, formData)).toEqual({ reqObj: { foo: '' } });
       });
 
-      it('returns an empty array when the array schema has no items definition', () => {
-        // removeOptionalEmptyObjects returns the array as-is (no items schema → skip processing).
-        // omitExtraData returns [] because handleArray finds no items schema and emits nothing.
+      it('returns source unchanged when the array schema has no items definition', () => {
+        // No items schema means there is no filtering rule — preserve the source as-is.
         const schema: RJSFSchema = { type: 'array' };
         const formData = [{ foo: 'bar' }];
-        expect(omitExtraData(testValidator, schema, schema, formData)).toEqual([]);
+        expect(omitExtraData(testValidator, schema, schema, formData)).toEqual([{ foo: 'bar' }]);
       });
     });
 
@@ -1128,13 +1127,15 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
     });
 
     describe('propertyNames support', () => {
-      it('keeps all source keys when propertyNames is defined', () => {
+      it('returns empty object when propertyNames is defined but no properties are declared', () => {
+        // propertyNames only constrains key names — it does not declare which properties are allowed.
+        // Without properties/patternProperties/additionalProperties, no keys survive filtering.
         const schema: RJSFSchema = {
           type: 'object',
           propertyNames: { pattern: '^[a-z]+$' },
         };
         const formData = { foo: 'bar', baz: 42 };
-        expect(omitExtraData(testValidator, schema, schema, formData)).toEqual(formData);
+        expect(omitExtraData(testValidator, schema, schema, formData)).toEqual({});
       });
     });
 
@@ -1199,6 +1200,55 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
         const result = omitExtraData(testValidator, schema, schema, formData);
         expect(result).toEqual({ type: 'B' });
       });
+
+      it('preserves keys added by then-branch even when parent has additionalProperties:false', () => {
+        // then-branch properties are kept regardless of the parent's additionalProperties:false —
+        // omitExtraData does not post-prune branch-granted keys, matching pre-PR behaviour.
+        // 'p_field' matches patternProperties and is also retained.
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: { type: { type: 'string' } },
+          patternProperties: { '^p_': { type: 'string' } },
+          additionalProperties: false,
+          if: { properties: { type: { const: 'A' } } },
+          then: { properties: { extra: { type: 'string' } } },
+        };
+        const formData = { type: 'A', p_field: 'keep', extra: 'keep' };
+        testValidator.setReturnValues({ isValid: [true] });
+        const result = omitExtraData(testValidator, schema, schema, formData);
+        expect(result).toEqual({ type: 'A', p_field: 'keep', extra: 'keep' });
+      });
+
+      it('preserves then-branch keys when parent has additionalProperties:false and no properties', () => {
+        // Without a parent `properties` key, handleObject writes nothing from source.
+        // The then-branch result is still merged in and preserved.
+        const schema: RJSFSchema = {
+          type: 'object',
+          additionalProperties: false,
+          if: { type: 'object' } as any,
+          then: { properties: { extra: { type: 'string' } } },
+        };
+        const formData = { extra: 'keep' };
+        testValidator.setReturnValues({ isValid: [true] });
+        const result = omitExtraData(testValidator, schema, schema, formData);
+        expect(result).toEqual({ extra: 'keep' });
+      });
+
+      it('returns existing filtered value when then-branch is permissive (true)', () => {
+        // Covers the `target ??` short-circuit in omit when schemaDef is `true` and target is truthy.
+        // handleConditions calls omit(true, source, filteredObj, false) — since filteredObj is
+        // non-null, `target ?? ...` returns target immediately without evaluating the RHS.
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: { foo: { type: 'string' } },
+          if: { type: 'object' } as any,
+          then: true as any,
+        };
+        const formData = { foo: 'hello', extra: 'drop' };
+        testValidator.setReturnValues({ isValid: [true] });
+        const result = omitExtraData(testValidator, schema, schema, formData);
+        expect(result).toEqual({ foo: 'hello' });
+      });
     });
 
     describe('anyOf support', () => {
@@ -1217,6 +1267,17 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
           type: 'object',
           anyOf: [{ properties: { foo: { type: 'string' } } }, { properties: { bar: { type: 'string' } } }],
           properties: { base: { type: 'string' } },
+        };
+        expect(omitExtraData(testValidator, schema, schema, {})).toEqual({});
+      });
+
+      it('returns source unchanged when anyOf contains a permissive (true) branch and source is empty object', () => {
+        // anyOf sees {} as empty → applies all branches including the `true` branch.
+        // `omit(true, {}, accum, false)` hits the `target ??` RHS with materializeSource=false,
+        // returning `undefined` (not the source) to avoid aliasing the accumulator.
+        // After all branches, result is still {}, and the outer omit returns {} via ?? source.
+        const schema: RJSFSchema = {
+          anyOf: [true as any, { properties: { foo: { type: 'string' } } }],
         };
         expect(omitExtraData(testValidator, schema, schema, {})).toEqual({});
       });
@@ -1246,12 +1307,13 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
       });
 
       it('reuses an array target already built by anyOf when outer schema is also type:array', () => {
-        // anyOf sees [] as empty → applies all branches → returns [] as target.
-        // The outer type:'array' branch then runs handleArray with that existing [] as target,
-        // hitting the Array.isArray(target) ? target : [] true-branch.
+        // anyOf sees [] as empty → applies all branches.
+        // The branch has type:'array' so omit() returns [] as the filtered value.
+        // The outer type:'array' block then runs handleArray with that existing [] as target,
+        // hitting the Array.isArray(filtered) ? filtered : [] true-branch (filtered is an array).
         const schema: RJSFSchema = {
           type: 'array',
-          anyOf: [{ items: { type: 'string' } }, { items: { type: 'number' } }],
+          anyOf: [{ type: 'array', items: { type: 'string' } }],
           items: { type: 'string' },
         };
         expect(omitExtraData(testValidator, schema, schema, [] as any)).toEqual([]);
@@ -1333,6 +1395,38 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
         const result = omitExtraData(testValidator, schema, schema, formData);
         // The best-matching option is the resolved Strict schema; extra key is dropped.
         expect(result).toEqual({ name: 'Alice' });
+      });
+    });
+
+    describe('regression #5176 — allOf with repeated list property does not loop or duplicate items', () => {
+      it('merges two allOf branches defining the same list property without duplicating items', () => {
+        // Two allOf entries each declare `items` on the same `list` property. Before the fix,
+        // the push-based handleArray would append to an already-populated target array on the
+        // second branch, doubling entries on every render cycle and eventually crashing.
+        const schema: RJSFSchema = {
+          type: 'object',
+          allOf: [
+            {
+              properties: {
+                list: {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+              },
+            },
+            {
+              properties: {
+                list: {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+              },
+            },
+          ],
+        };
+        const formData = { list: ['a', 'b'] };
+        const result = omitExtraData(testValidator, schema, schema, formData);
+        expect(result).toEqual({ list: ['a', 'b'] });
       });
     });
 

--- a/packages/utils/test/schema/omitExtraDataTest.ts
+++ b/packages/utils/test/schema/omitExtraDataTest.ts
@@ -1449,6 +1449,85 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
       });
     });
 
+    describe('regression #5196 — patternProperties empty schema over array inside dependencies does not infinite-loop', () => {
+      it('terminates and returns the correct filtered data when patternProperties:{} covers an array-holding key also described by a dependencies oneOf branch', () => {
+        // patternProperties: { "mux": {} } matches the "mux" key with an empty schema, which omit()
+        // passes through by returning `source` directly. handleObject writes that reference to
+        // target["mux"], aliasing target["mux"] to source["mux"]. When the dependencies oneOf branch
+        // later calls handleObject again with mux's schema, handleArray runs with target === source
+        // for the p2s array. The old push-based handleArray fed itself and never terminated; the fix
+        // uses index assignment so the loop stays bounded by source.length.
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            route: {
+              type: 'object',
+              title: 'Routing',
+              properties: {
+                mode: {
+                  title: 'Routing mode',
+                  type: 'integer',
+                  default: 0,
+                  oneOf: [
+                    { title: 'Mux', enum: [0] },
+                    { title: 'Direct', enum: [1] },
+                  ],
+                },
+              },
+              additionalProperties: false,
+              patternProperties: { mux: {} },
+              required: ['mode'],
+              dependencies: {
+                mode: {
+                  oneOf: [
+                    {
+                      properties: {
+                        mode: { enum: [0] },
+                        mux: {
+                          title: 'Mux',
+                          type: 'object',
+                          properties: {
+                            p2s: {
+                              title: 'Messages',
+                              type: 'array',
+                              items: {
+                                type: 'object',
+                                properties: {
+                                  id_format: {
+                                    title: 'ID format',
+                                    type: 'integer',
+                                    default: 0,
+                                    oneOf: [
+                                      { title: 'Standard (11-bit)', enum: [0] },
+                                      { title: 'Extended (29-bit)', enum: [1] },
+                                    ],
+                                  },
+                                  id: { title: 'ID (hex)', type: 'string', default: '11' },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                    { properties: { mode: { enum: [1] } } },
+                  ],
+                },
+              },
+            },
+          },
+        };
+        const formData = { route: { mode: 0, mux: { p2s: [{ id_format: 0, id: '11' }] } } };
+        // getClosestMatchingOption checks [JUNK, option] for each oneOf entry:
+        //   [false (JUNK), true (option0 matches mode=0), false (JUNK), false (option1 rejects mode=0)]
+        testValidator.setReturnValues({ isValid: [false, true, false, false] });
+        const result = omitExtraData(testValidator, schema, schema, formData);
+        expect(result).toEqual({ route: { mode: 0, mux: { p2s: [{ id_format: 0, id: '11' }] } } });
+        // The original p2s array must not have grown (the old bug caused it to grow unboundedly).
+        expect(formData.route.mux.p2s).toHaveLength(1);
+      });
+    });
+
     describe('getFieldNames() — array formValue branch', () => {
       it('includes path when formValue is a non-empty array of scalars and the node is not a leaf', () => {
         // isLeaf is false when the pathSchema node has keys beyond NAME_KEY (here '0').

--- a/packages/utils/test/schema/omitExtraDataTest.ts
+++ b/packages/utils/test/schema/omitExtraDataTest.ts
@@ -1307,7 +1307,7 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
           if: { properties: { type: { const: 'A' } } },
           then: { properties: { extra: { type: 'string' } } },
         };
-        const formData = { type: 'A', p_field: 'keep', extra: 'keep' };
+        const formData = { type: 'A', p_field: 'keep', extra: 'drop' };
         testValidator.setReturnValues({ isValid: [true] });
         const result = omitExtraData(testValidator, schema, schema, formData);
         expect(result).toEqual({ type: 'A', p_field: 'keep' });
@@ -1392,9 +1392,11 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
 
       it('applies all anyOf branches when source is an empty array', () => {
         // An empty array is an empty collection — all branches are applied so defaults flow through.
+        // Neither branch declares type:'array' so both return undefined; the outer type:'array'
+        // block creates a fresh [] as the initial target for handleArray.
         const schema: RJSFSchema = {
           type: 'array',
-          anyOf: [{ items: { type: 'string' } }],
+          anyOf: [{ items: { type: 'string' } }, { items: { type: 'number' } }],
           items: { type: 'string' },
         };
         expect(omitExtraData(testValidator, schema, schema, [] as any)).toEqual([]);


### PR DESCRIPTION
### Reasons for making this change

Fixes #5194, #5196, #3920

The additionalProperties:false post-processing block introduced in the #5176 fix built its key allowlist solely from the parent schema's `properties`, incorrectly deleting keys written by winning oneOf/anyOf branches and if/then branches. The block is removed entirely, restoring pre-PR behaviour where branch-granted keys survive omitExtraData filtering.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
