### PR TITLE
fix(utils): deep merge an array that sits under an object key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 6.8.1
+
+## @rjsf/utils
+
+- Fixed `mergeDefaultsWithFormData()` to take the recursive path when the default under an object key holds an array, so a default that lives inside a `dependencies` subschema is no longer dropped when the owning array sits more than one object below the root, fixing part of [#5198](https://github.com/rjsf-team/react-jsonschema-form/issues/5198) ([#5202](https://github.com/rjsf-team/react-jsonschema-form/pull/5202))
+
 # 6.8.0
 
 ## @rjsf/core
@@ -25,7 +31,6 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - Fixed an issue in `sortedJSONStringify` with regards to handling arrays containing `null` and `undefined` values.
-- Fixed `mergeDefaultsWithFormData()` to take the recursive path when the default under an object key holds an array, so a default that lives inside a `dependencies` subschema is no longer dropped when the owning array sits more than one object below the root, fixing part of [#5198](https://github.com/rjsf-team/react-jsonschema-form/issues/5198) ([#5202](https://github.com/rjsf-team/react-jsonschema-form/pull/5202))
 
 ## @rjsf/validator-ata
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - Fixed an issue in `sortedJSONStringify` with regards to handling arrays containing `null` and `undefined` values.
+- Fixed `mergeDefaultsWithFormData()` to take the recursive path when the default under an object key holds an array, so a default that lives inside a `dependencies` subschema is no longer dropped when the owning array sits more than one object below the root, fixing part of [#5198](https://github.com/rjsf-team/react-jsonschema-form/issues/5198) ([#5202](https://github.com/rjsf-team/react-jsonschema-form/pull/5202))
 
 ## @rjsf/validator-ata
 

--- a/packages/utils/src/mergeDefaultsWithFormData.ts
+++ b/packages/utils/src/mergeDefaultsWithFormData.ts
@@ -68,9 +68,9 @@ export default function mergeDefaultsWithFormData<T = any>(
       const keyExistsInDefaults = isObject(defaults) && key in (defaults as GenericObjectType);
       const keyExistsInFormData = key in (formData as GenericObjectType);
       const keyDefault = get(defaults, key) ?? {};
-      // Anything below this key that is an object or an array has merge rules of its
-      // own, and the shallow spread below bypasses them, so those cases take the
-      // recursive path instead.
+      // If any direct child of this key's default is itself an object or array,
+      // the shallow spread below would bypass its merge rules. Route those cases
+      // to the recursive path; the recursive call repeats this check one level deeper.
       const defaultValueNeedsDeepMerge =
         keyExistsInDefaults &&
         isObject(keyDefault) &&

--- a/packages/utils/src/mergeDefaultsWithFormData.ts
+++ b/packages/utils/src/mergeDefaultsWithFormData.ts
@@ -68,13 +68,18 @@ export default function mergeDefaultsWithFormData<T = any>(
       const keyExistsInDefaults = isObject(defaults) && key in (defaults as GenericObjectType);
       const keyExistsInFormData = key in (formData as GenericObjectType);
       const keyDefault = get(defaults, key) ?? {};
-      const defaultValueIsNestedObject =
-        keyExistsInDefaults && isObject(keyDefault) && Object.values(keyDefault).some((v) => isObject(v));
+      // Anything below this key that is an object or an array has merge rules of its
+      // own, and the shallow spread below bypasses them, so those cases take the
+      // recursive path instead.
+      const defaultValueNeedsDeepMerge =
+        keyExistsInDefaults &&
+        isObject(keyDefault) &&
+        Object.values(keyDefault).some((v) => isObject(v) || Array.isArray(v));
 
       const keyDefaultIsObject = keyExistsInDefaults && isObject(get(defaults, key));
       const keyHasFormDataObject = keyExistsInFormData && isObject(keyValue);
 
-      if (keyDefaultIsObject && keyHasFormDataObject && !defaultValueIsNestedObject) {
+      if (keyDefaultIsObject && keyHasFormDataObject && !defaultValueNeedsDeepMerge) {
         accumulator[key as keyof T] = {
           ...get(defaults, key),
           ...keyValue,

--- a/packages/utils/test/mergeDefaultsWithFormData.test.ts
+++ b/packages/utils/test/mergeDefaultsWithFormData.test.ts
@@ -63,6 +63,15 @@ describe('mergeDefaultsWithFormData()', () => {
     expect(mergeDefaultsWithFormData([1, 2, 3], [4, 5], true)).toEqual([4, 5, 3]);
   });
 
+  it('should append extra array defaults under an object key, the same as at the root', () => {
+    expect(mergeDefaultsWithFormData({ config: { tags: ['a', 'b'] } }, { config: { tags: ['x'] } }, true)).toEqual({
+      config: { tags: ['x', 'b'] },
+    });
+    expect(mergeDefaultsWithFormData({ config: { tags: ['a', 'b'] } }, { config: { tags: ['x'] } })).toEqual({
+      config: { tags: ['x'] },
+    });
+  });
+
   it('should deeply merge arrays with overlapping entries', () => {
     expect(mergeDefaultsWithFormData([{ a: 1 }], [{ b: 2 }, { c: 3 }])).toEqual([{ a: 1, b: 2 }, { c: 3 }]);
   });

--- a/packages/utils/test/mergeDefaultsWithFormData.test.ts
+++ b/packages/utils/test/mergeDefaultsWithFormData.test.ts
@@ -315,6 +315,15 @@ describe('mergeDefaultsWithFormData()', () => {
       expect(mergeDefaultsWithFormData<any>(obj1, obj2, undefined, undefined, true)).toEqual(expected);
     });
 
+    it('should deeply merge an array that sits under an object key', () => {
+      const defaults = { outer: { rows: [{ name: 'Name', grade: 'A' }] } };
+      const formData = { outer: { rows: [{ name: 'Name' }] } };
+      // oxlint-disable-next-line typescript/no-unnecessary-type-arguments
+      expect(mergeDefaultsWithFormData<any>(defaults, formData, true, false, true)).toEqual({
+        outer: { rows: [{ name: 'Name', grade: 'A' }] },
+      });
+    });
+
     it('should recursively merge File objects', () => {
       const file = new File(['test'], 'test.txt');
       const obj1 = {

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -6142,6 +6142,56 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           },
         ]);
       });
+      it('should populate defaults for nested dependencies in arrays that sit below another object', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            outer: {
+              type: 'object',
+              properties: {
+                rows: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      name: {
+                        type: 'string',
+                      },
+                    },
+                    dependencies: {
+                      name: {
+                        oneOf: [
+                          {
+                            properties: {
+                              name: {
+                                type: 'string',
+                              },
+                              grade: {
+                                type: 'string',
+                                default: 'A',
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        expect(getDefaultFormState(testValidator, schema, { outer: { rows: [{ name: 'Name' }] } })).toEqual({
+          outer: {
+            rows: [
+              {
+                name: 'Name',
+                grade: 'A',
+              },
+            ],
+          },
+        });
+      });
       it('should populate defaults for nested dependencies in arrays when matching enum values in oneOf', () => {
         // Mock isValid so that withExactlyOneSubschema works as expected
         testValidator.setReturnValues({


### PR DESCRIPTION
Fixes case 2 of #5198.

`mergeDefaultsWithFormData` has a shortcut for the case where the default under a key is an object: if none of that object's values is itself an object, it shallow spreads `{ ...default, ...formData }` and skips the recursion. `isObject` returns false for arrays, so an array of objects does not count as nested, and the shortcut fires. The form data array then replaces the merged default array whole.

Measured on the schema from the issue, with the `getDefaultFormState` arguments:

```js
merge({ rows: [{ t: 0, p: 5 }] },            { rows: [{ t: 0 }] })            // { rows: [{ t: 0, p: 5 }] }
merge({ f: { rows: [{ t: 0, p: 5 }] } },     { f: { rows: [{ t: 0 }] } })     // { f: { rows: [{ t: 0 }] } }
```

The first call never reaches the shortcut because the value under `rows` is an array, so `keyDefaultIsObject` is false. The second one goes through `f`, whose default is an object holding only an array, so it takes the spread and `p` is gone. That is why the reported schema works with the array one level below the root and fails two levels down.

The condition now counts arrays as needing the recursive path, which is where the array merge rules described in the function's own doc comment live.

### What this does not fix

Case 1 of the issue, a `dependencies` default with no form data at all, has a different cause and is untouched here. `getDefaultFormState` resolves the schema before computing defaults:

```js
retrieveSchema(validator, child, undefined, undefined)
// { type: 'object', required: ['t'], properties: { t: { type: 'integer', default: 0 } } }
```

With no form data the dependency is not triggered, so `dependencies` is gone from the schema that reaches `computeDefaults`, and its `DEPENDENCIES_KEY` branch never runs. Calling `computeDefaults` on the raw schema returns `{ t: 0, p: 5 }`, so that branch itself is fine. Fixing it means changing when the schema is resolved relative to when defaults are computed, which is a wider change than this one and I would rather not bundle it. Happy to look at it separately if you want it.

### Tests

- `mergeDefaultsWithFormData.test.ts`, unit test for an array under an object key, in the `overrideFormDataWithDefaults` block.
- `getDefaultFormStateTest.ts`, end to end test next to the existing `nested dependencies in arrays` one, with the array one object deeper.

Both fail on `main` and pass with the change.

Suites run locally: utils 1444, validator-ajv8 2681, validator-ata 1277, validator-cfworker 613, core 2235, all passing. `oxfmt --check`, `oxlint` and `tsc --noEmit` are clean for `utils`; the oxlint warnings it prints are pre-existing and in files this PR does not touch.

One thing I could not run: the husky pre-commit hook. It goes through `nx run-many` into `pnpm`, which tries to create a symlink in its own store and fails with `os error 1314` on this Windows box. I ran what it would have run, `oxlint --fix` and `oxfmt` over the three changed files, and both are no-ops.

CHANGELOG entry is in the second commit.
