### PR TITLE
Fix 5201: normalize array-shaped errorSchema branches before merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,16 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 6.9.0
 
+## @rjsf/core
+
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules; a consumer importing only `Form` no longer bundles the AJV validator chain pulled in by `getTestRegistry`, shrinking a minimal bundle by ~34kB gzipped
+- Fixed `validationDataMerge()` to normalize array-shaped `ErrorSchema` branches (such as the optimistic `newErrorSchema` built by `ArrayField`'s add/copy/remove/reorder handlers) into RJSF's own numeric-keyed-object convention before merging, fixing inline field errors that stopped rendering anywhere under an array once one of its items was added/copied/removed/reordered, while the top-level error list remained correct, fixing [#5201](https://github.com/rjsf-team/react-jsonschema-form/issues/5201)
+- Fixed `mergeDefaultsWithFormData()` to take the recursive path when the default under an object key holds an array, so a default that lives inside a `dependencies` subschema is no longer dropped when the owning array sits more than one object below the root, fixing part of [#5198](https://github.com/rjsf-team/react-jsonschema-form/issues/5198) ([#5202](https://github.com/rjsf-team/react-jsonschema-form/pull/5202))
+- Replaced all path-based `lodash` usage (`get`, `set`, `unset`, `toPath`, `pick`) with the new `@rjsf/utils` path utilities
+
 ## @rjsf/utils
 
 - Added new path utilities `getByPath`, `setByPath`, `hasByPath`, `unsetByPath` and `toPath`, and switched all path-based `lodash` usage (`get`, `set`, `setWith`, `has`, `unset`, `toPath`, `pick`) over to them. Unlike their lodash counterparts, these treat a bare string as a single literal key, lodash-style dotted path strings are parsed explicitly via `toPath()`, and `getByPath()`/`hasByPath()` resolve **own** properties only (inherited members and prototype internals such as `__proto__` never resolve)
-
-## @rjsf/core
-
-- Replaced all path-based `lodash` usage (`get`, `set`, `unset`, `toPath`, `pick`) with the new `@rjsf/utils` path utilities
 
 ## @rjsf/validator-ajv8
 
@@ -38,17 +41,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Replaced all `lodash/get` usage with the new `@rjsf/utils` path utilities and dropped the `lodash`/`lodash-es` dependencies entirely
 
-# 6.8.1
-
-## @rjsf/utils
-
-- Fixed `mergeDefaultsWithFormData()` to take the recursive path when the default under an object key holds an array, so a default that lives inside a `dependencies` subschema is no longer dropped when the owning array sits more than one object below the root, fixing part of [#5198](https://github.com/rjsf-team/react-jsonschema-form/issues/5198) ([#5202](https://github.com/rjsf-team/react-jsonschema-form/pull/5202))
-
 # 6.8.0
 
 ## @rjsf/core
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules; a consumer importing only `Form` no longer bundles the AJV validator chain pulled in by `getTestRegistry`, shrinking a minimal bundle by ~34kB gzipped
 - Fixed `TimeWidget` to respect schema `multipleOf` time precision, preserving second-precision values while keeping minute-precision native inputs synchronized with their displayed value ([#5174](https://github.com/rjsf-team/react-jsonschema-form/pull/5174))
 
 ## @rjsf/utils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,14 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules; a consumer importing only `Form` no longer bundles the AJV validator chain pulled in by `getTestRegistry`, shrinking a minimal bundle by ~34kB gzipped
-- Fixed `validationDataMerge()` to normalize array-shaped `ErrorSchema` branches (such as the optimistic `newErrorSchema` built by `ArrayField`'s add/copy/remove/reorder handlers) into RJSF's own numeric-keyed-object convention before merging, fixing inline field errors that stopped rendering anywhere under an array once one of its items was added/copied/removed/reordered, while the top-level error list remained correct, fixing [#5201](https://github.com/rjsf-team/react-jsonschema-form/issues/5201)
-- Fixed `mergeDefaultsWithFormData()` to take the recursive path when the default under an object key holds an array, so a default that lives inside a `dependencies` subschema is no longer dropped when the owning array sits more than one object below the root, fixing part of [#5198](https://github.com/rjsf-team/react-jsonschema-form/issues/5198) ([#5202](https://github.com/rjsf-team/react-jsonschema-form/pull/5202))
 - Replaced all path-based `lodash` usage (`get`, `set`, `unset`, `toPath`, `pick`) with the new `@rjsf/utils` path utilities
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules; a consumer importing only `Form` no longer bundles the AJV validator chain pulled in by `getTestRegistry`, shrinking a minimal bundle by ~34kB gzipped
 
 ## @rjsf/utils
 
+- Fixed `validationDataMerge()` to normalize array-shaped `ErrorSchema` branches (such as the optimistic `newErrorSchema` built by `ArrayField`'s add/copy/remove/reorder handlers) into RJSF's own numeric-keyed-object convention before merging, fixing inline field errors that stopped rendering anywhere under an array once one of its items was added/copied/removed/reordered, while the top-level error list remained correct, fixing [#5201](https://github.com/rjsf-team/react-jsonschema-form/issues/5201)
 - Added new path utilities `getByPath`, `setByPath`, `hasByPath`, `unsetByPath` and `toPath`, and switched all path-based `lodash` usage (`get`, `set`, `setWith`, `has`, `unset`, `toPath`, `pick`) over to them. Unlike their lodash counterparts, these treat a bare string as a single literal key, lodash-style dotted path strings are parsed explicitly via `toPath()`, and `getByPath()`/`hasByPath()` resolve **own** properties only (inherited members and prototype internals such as `__proto__` never resolve)
+- Fixed `mergeDefaultsWithFormData()` to take the recursive path when the default under an object key holds an array, so a default that lives inside a `dependencies` subschema is no longer dropped when the owning array sits more than one object below the root, fixing part of [#5198](https://github.com/rjsf-team/react-jsonschema-form/issues/5198) ([#5202](https://github.com/rjsf-team/react-jsonschema-form/pull/5202))
 
 ## @rjsf/validator-ajv8
 

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -150,6 +150,20 @@ function computeItemUiSchema<T = any, S extends StrictRJSFSchema = RJSFSchema, F
   }
 }
 
+/** After reindexing `oldErrorSchema` into `newErrorSchema` for an array add/copy/remove/reorder, explicitly clears
+ * (sets to `undefined`) any key that existed in `oldErrorSchema` but wasn't assigned a value at that same key in
+ * `newErrorSchema`. Without this, an error that moved to a different index leaves a stale, duplicate copy of itself
+ * behind: `newErrorSchema` is later merged (not replaced) against the previous errorSchema, and that merge unions
+ * keys from the new tree into the old one without ever deleting keys unique to the old side.
+ */
+function clearStaleReindexedErrorSchemaKeys<T>(oldErrorSchema: ErrorSchema<T[]>, newErrorSchema: ErrorSchema<T>) {
+  for (const key of Object.keys(oldErrorSchema)) {
+    if (!(key in newErrorSchema)) {
+      setByPath(newErrorSchema, [key], undefined);
+    }
+  }
+}
+
 /** Returns the default form information for an item based on the schema for that item. Deals with the possibility
  * that the schema is fixed and allows additional items.
  */
@@ -907,6 +921,7 @@ export default function ArrayField<T = any, S extends StrictRJSFSchema = RJSFSch
             setByPath(newErrorSchema, [i + 1], errorSchemaRef.current[i]);
           }
         }
+        clearStaleReindexedErrorSchemaKeys(errorSchemaRef.current, newErrorSchema);
       }
 
       const newKeyedFormDataRow: KeyedFormDataType<T> = {
@@ -947,6 +962,7 @@ export default function ArrayField<T = any, S extends StrictRJSFSchema = RJSFSch
             setByPath(newErrorSchema, [i + 1], errorSchemaRef.current[i]);
           }
         }
+        clearStaleReindexedErrorSchemaKeys(errorSchemaRef.current, newErrorSchema);
       }
 
       const newKeyedFormDataRow: KeyedFormDataType<T> = {
@@ -987,6 +1003,7 @@ export default function ArrayField<T = any, S extends StrictRJSFSchema = RJSFSch
             setByPath(newErrorSchema, [i - 1], errorSchemaRef.current[i]);
           }
         }
+        clearStaleReindexedErrorSchemaKeys(errorSchemaRef.current, newErrorSchema);
       }
       const newKeyedFormData = keyedFormDataRef.current.filter((_, i) => i !== index);
       onChange(updateKeyedFormData(newKeyedFormData), childFieldPathId.path, newErrorSchema as ErrorSchema<T[]>);
@@ -1020,6 +1037,7 @@ export default function ArrayField<T = any, S extends StrictRJSFSchema = RJSFSch
             setByPath(newErrorSchema, idx, errorSchemaRef.current[i]);
           }
         }
+        clearStaleReindexedErrorSchemaKeys(errorSchemaRef.current, newErrorSchema);
       }
 
       function reOrderArray() {

--- a/packages/core/test/ArrayField.test.tsx
+++ b/packages/core/test/ArrayField.test.tsx
@@ -2945,6 +2945,35 @@ describe('ArrayField', () => {
       );
     });
 
+    it('does not leave a stale, duplicated error behind when removing a valid element between two invalid ones', async () => {
+      const threeItemFormData = [{}, { text: 'y' }, {}];
+      const { node, onChange } = createFormComponent({
+        schema,
+        formData: threeItemFormData,
+        templates,
+      });
+
+      // forceFireEvent=true: seeds errorSchema in form state via fireEvent.submit to avoid
+      // user.click(button) focusing the button, blurring a field, and firing onChange which
+      // would mutate formData before the submit runs.
+      await submitForm(node, user, true);
+
+      // Remove the middle (valid) element so the last (invalid) element reindexes from 2 down to 1.
+      const button = node.querySelectorAll('[title="remove"]')[1];
+
+      await user.click(button);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+      // Only the reindexed element (now at 1) should have an error; no stale entry should remain at 2,
+      // and the flat errors list must not contain a duplicated message.
+      expect(lastCall.errorSchema).toEqual({
+        0: { text: { __errors: ["must have required property 'text'"] } },
+        1: { text: { __errors: ["must have required property 'text'"] } },
+      });
+      expect(lastCall.errors).toHaveLength(2);
+    });
+
     it('leaves errors in place when inserting elements', async () => {
       const { node, onChange } = createFormComponent({
         schema,

--- a/packages/utils/src/validationDataMerge.ts
+++ b/packages/utils/src/validationDataMerge.ts
@@ -1,8 +1,51 @@
 import isEmpty from 'lodash/isEmpty';
 
+import { ERRORS_KEY } from './constants';
+import isObject from './isObject';
 import mergeObjects from './mergeObjects';
 import toErrorList from './toErrorList';
-import type { ErrorSchema, ValidationData } from './types';
+import type { ErrorSchema, GenericObjectType, ValidationData } from './types';
+
+/** Recursively rewrites any array found in an `ErrorSchema` (other than the `__errors` message list) into a plain
+ * object keyed by index. RJSF's own AJV-derived `ErrorSchema`s always represent per-index array item sub-schemas as
+ * plain numeric-keyed objects, never as real arrays. `additionalErrorSchema`, however, can arrive with real arrays
+ * at those same paths (e.g. `ArrayField`'s add/copy/remove/reorder handlers build their optimistic `newErrorSchema`
+ * with lodash's `set()`, which auto-vivifies real arrays for numeric path segments). `mergeObjects()` treats a real
+ * array and a same-path numeric-keyed object as incompatible shapes and overwrites the whole branch rather than
+ * merging it, silently dropping real validation errors. Normalizing first keeps both sides in the same shape so the
+ * merge recurses correctly.
+ *
+ * Returns the original `errorSchema` reference whenever nothing needed rewriting (no array was found anywhere in the
+ * sub-tree), only allocating new objects along the path to a change. Some call sites rely on `additionalErrorSchema`
+ * being returned by reference when unchanged (e.g. `Form` sometimes mutates `customErrors.ErrorSchema` in place and
+ * relies on that being visible through a previously-shared `state.errorSchema` reference), so this must not force a
+ * new object identity when the input already matches RJSF's own indexed-object convention.
+ *
+ * @param errorSchema - The `ErrorSchema` (or sub-tree) to normalize
+ * @returns - An equivalent `ErrorSchema` where every non-`__errors` array has been converted to an indexed object
+ */
+function normalizeErrorSchemaArrays<T = any>(errorSchema: ErrorSchema<T>): ErrorSchema<T> {
+  if (Array.isArray(errorSchema)) {
+    return errorSchema.reduce((acc: GenericObjectType, value, index) => {
+      acc[index] = normalizeErrorSchemaArrays(value);
+      return acc;
+    }, {}) as ErrorSchema<T>;
+  }
+  if (!isObject(errorSchema)) {
+    return errorSchema;
+  }
+  let changed = false;
+  const result: GenericObjectType = {};
+  Object.keys(errorSchema).forEach((key) => {
+    const value = (errorSchema as GenericObjectType)[key];
+    const normalizedValue = key === ERRORS_KEY ? value : normalizeErrorSchemaArrays(value);
+    if (normalizedValue !== value) {
+      changed = true;
+    }
+    result[key] = normalizedValue;
+  });
+  return (changed ? result : errorSchema) as ErrorSchema<T>;
+}
 
 /** Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in the
  * two `ErrorSchema`s and then appending the error list from the `additionalErrorSchema` obtained by calling
@@ -22,13 +65,14 @@ export default function validationDataMerge<T = any>(
   if (!additionalErrorSchema) {
     return validationData;
   }
+  const normalizedAdditionalErrorSchema = normalizeErrorSchemaArrays(additionalErrorSchema);
   const { errors: oldErrors, errorSchema: oldErrorSchema } = validationData;
-  let errors = toErrorList(additionalErrorSchema);
-  let errorSchema = additionalErrorSchema;
+  let errors = toErrorList(normalizedAdditionalErrorSchema);
+  let errorSchema = normalizedAdditionalErrorSchema;
   if (!isEmpty(oldErrorSchema)) {
     errorSchema = mergeObjects(
       oldErrorSchema,
-      additionalErrorSchema,
+      normalizedAdditionalErrorSchema,
       preventDuplicates ? 'preventDuplicates' : true,
     ) as ErrorSchema<T>;
     errors = [...oldErrors].concat(errors);

--- a/packages/utils/test/validationDataMerge.test.ts
+++ b/packages/utils/test/validationDataMerge.test.ts
@@ -53,4 +53,30 @@ describe('validationDataMerge()', () => {
     };
     expect(validationDataMerge(validationData, errorSchema, true)).toEqual(expected);
   });
+  it('Normalizes real arrays in additionalErrorSchema to indexed objects so they merge instead of clobbering', () => {
+    // Simulates `ArrayField`'s optimistic `newErrorSchema`, which lodash's `set()` builds as a real array for
+    // numeric path segments, while RJSF's own AJV-derived `errorSchema` always uses numeric-keyed objects.
+    const validationData: ValidationData<any> = {
+      errorSchema: {
+        arrayLevel1: {
+          0: { field1: { [ERRORS_KEY]: ['must NOT have fewer than 1 characters'] } },
+        },
+      } as ErrorSchema,
+      errors: [
+        { stack: '.arrayLevel1.0.field1 must NOT have fewer than 1 characters', name: 'foo', schemaPath: '.foo' },
+      ],
+    };
+    // A real array, as produced by lodash `set({}, ['arrayLevel1', 0], {})`. Also include a non-object,
+    // non-array leaf value at a sibling key to exercise the normalizer's pass-through for arbitrary leaves.
+    const additionalErrorSchema = { arrayLevel1: [{}], someLeaf: 'unchanged' } as unknown as ErrorSchema;
+    const result = validationDataMerge(validationData, additionalErrorSchema, true);
+    // The pre-existing field1 error must survive the merge instead of being overwritten by the empty stub.
+    expect(result.errorSchema).toEqual({
+      arrayLevel1: {
+        0: { field1: { [ERRORS_KEY]: ['must NOT have fewer than 1 characters'] } },
+      },
+      someLeaf: 'unchanged',
+    });
+    expect(result.errors).toEqual(validationData.errors);
+  });
 });

--- a/packages/utils/test/validationDataMerge.test.ts
+++ b/packages/utils/test/validationDataMerge.test.ts
@@ -61,7 +61,7 @@ describe('validationDataMerge()', () => {
         arrayLevel1: {
           0: { field1: { [ERRORS_KEY]: ['must NOT have fewer than 1 characters'] } },
         },
-      } as ErrorSchema,
+      } as unknown as ErrorSchema,
       errors: [
         { stack: '.arrayLevel1.0.field1 must NOT have fewer than 1 characters', name: 'foo', schemaPath: '.foo' },
       ],


### PR DESCRIPTION
### Reasons for making this change
Fixes #5201

ArrayField's add/copy/remove/reorder handlers build their optimistic newErrorSchema with lodash's set(), which auto-vivifies real arrays for numeric path segments. RJSF's own AJV-derived errorSchema always represents per-index array item errors as plain numeric-keyed objects instead. mergeObjects() treated that shape mismatch as incompatible and silently overwrote the whole branch rather than merging it, so inline field errors under any array touched by one of those handlers stopped rendering (while the top error list, built independently from AJV's flat output, stayed correct).

validationDataMerge() now normalizes real arrays in additionalErrorSchema into indexed objects before merging, preserving object identity when nothing needs rewriting so Form's in-place customErrors mutation/reference-sharing behavior for clearing errors still works.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
