### PR TITLE
Fix 3920: prevent source/target aliasing in omitExtraData for multiple if/then allOf conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - Fixed `mergeDefaultsWithFormData()` to take the recursive path when the default under an object key holds an array, so a default that lives inside a `dependencies` subschema is no longer dropped when the owning array sits more than one object below the root, fixing part of [#5198](https://github.com/rjsf-team/react-jsonschema-form/issues/5198) ([#5202](https://github.com/rjsf-team/react-jsonschema-form/pull/5202))
+- Fixed `omitExtraData()` to guard against source/target aliasing when a schema has multiple `if/then` `allOf` entries; previously `shallowAllOfMerge` could only hoist one entry, leaving the rest processed by the `remainingAllOf` loop which aliased `source` as the accumulator, causing `handleArray` to push onto the array it was iterating (infinite growth) and dropping conditional properties with numeric-string keys (e.g. `"1"`, `"2"`, `"3"`), fixing [#3920](https://github.com/rjsf-team/react-jsonschema-form/issues/3920)
+  - Fixed `omitExtraData()` array branch to reuse a non-aliased filtered array already built by `handleOneOf`/`handleAnyOf` rather than always seeding `handleArray` with `[]`; previously a `type:'array'` schema with `oneOf`/`anyOf` but no top-level `items` would return `[]` instead of the oneOf-filtered content
 
 # 6.8.0
 

--- a/packages/utils/src/schema/omitExtraData.ts
+++ b/packages/utils/src/schema/omitExtraData.ts
@@ -467,12 +467,23 @@ export default function omitExtraData<
       if (!isObjectValue(source)) {
         return undefined;
       }
-      filtered = handleObject(localSchema, source, isObjectValue(filtered) ? filtered : {});
+      // Guard against source/target aliasing: when filtered === source (caused by the remainingAllOf
+      // loop returning source when an allOf entry has no top-level type), passing source as both source
+      // and target into handleObject causes any nested array to receive the same reference for both
+      // arguments, triggering an infinite push-loop in handleArray. Use a fresh {} instead so that
+      // handleObject builds the filtered result independently of source.
+      // See: https://github.com/rjsf-team/react-jsonschema-form/issues/3920
+      filtered = handleObject(localSchema, source, isObjectValue(filtered) && filtered !== source ? filtered : {});
     } else if (type === 'array') {
       if (!Array.isArray(source)) {
         return undefined;
       }
-      filtered = handleArray(localSchema, source, Array.isArray(filtered) ? filtered : []);
+      // Guard against source/target aliasing (same reason as the object branch above): when
+      // filtered === source, seeding handleArray with it would push source elements onto the same
+      // array being iterated, causing duplicates or an infinite loop. Reuse filtered when it is
+      // already a distinct (non-aliased) array so that oneOf/anyOf-filtered content is preserved.
+      // See: https://github.com/rjsf-team/react-jsonschema-form/issues/3920
+      filtered = handleArray(localSchema, source, Array.isArray(filtered) && filtered !== source ? filtered : []);
     } else if (filtered === undefined) {
       filtered = source;
     }

--- a/packages/utils/test/schema/omitExtraDataTest.ts
+++ b/packages/utils/test/schema/omitExtraDataTest.ts
@@ -1080,6 +1080,105 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
         const result = omitExtraData(testValidator, schema, schema, formData);
         expect(result).toEqual({ prop1: 'with required', prop2: { subprop1: '123', subprop2: '456' } });
       });
+
+      // Regression test for https://github.com/rjsf-team/react-jsonschema-form/issues/3920
+      // When there are ≥2 if/then entries in allOf and the merger can only hoist one, the
+      // remainingAllOf loop returns `source` as the accumulated target (because the allOf entry has no
+      // top-level type). This aliased `source` was previously passed as the target accumulator into
+      // handleObject/handleArray, causing handleArray to push items onto the same array it was
+      // iterating — an infinite growth loop that corrupted the list and dropped the conditional props.
+      it('preserves numeric-string property keys from multiple if/then allOf conditions (issue #3920)', () => {
+        const rankingDetails = {
+          type: 'object',
+          properties: {
+            promotionPeriod: { type: 'integer', minimum: 1, maximum: 12, default: 3 },
+            threshold: { type: 'number' },
+          },
+        };
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            list: {
+              type: 'array',
+              items: { type: 'integer', enum: [0, 1, 2, 3] },
+              uniqueItems: true,
+            },
+          },
+          allOf: [
+            {
+              if: { properties: { list: { contains: { const: 1 } } } },
+              then: { properties: { '1': { title: 'Level 1', ...rankingDetails } } },
+            },
+            {
+              if: { properties: { list: { contains: { const: 2 } } } },
+              then: { properties: { '2': { title: 'Level 2', ...rankingDetails } } },
+            },
+            {
+              if: { properties: { list: { contains: { const: 3 } } } },
+              then: { properties: { '3': { title: 'Level 3', ...rankingDetails } } },
+            },
+          ],
+        };
+        const formData = {
+          list: [1, 2],
+          '1': { promotionPeriod: 5, threshold: 0.8 },
+          '2': { promotionPeriod: 7, threshold: 0.5 },
+        };
+        // Merger hoists the first if/then; the remaining two stay in allOf.
+        // isValid calls (in order):
+        //   (1) allOf[1] if-condition (list contains 2) → true
+        //   (2) allOf[2] if-condition (list contains 3) → false
+        //   (3) hoisted top-level if-condition (list contains 1) → true
+        testValidator.setReturnValues({ isValid: [true, false, true] });
+        const result = omitExtraData(testValidator, schema, schema, formData);
+        expect(result).toEqual({
+          list: [1, 2],
+          '1': { promotionPeriod: 5, threshold: 0.8 },
+          '2': { promotionPeriod: 7, threshold: 0.5 },
+        });
+      });
+
+      // Regression test: the array branch must reuse a non-aliased filtered array built by
+      // handleOneOf/handleAnyOf rather than always starting from []. When the top-level schema
+      // has no items but a oneOf branch does, discarding filtered returned [] instead of the
+      // oneOf-filtered content.
+      it('preserves oneOf-filtered array content for type:array schemas with no top-level items', () => {
+        const schema: RJSFSchema = {
+          type: 'array',
+          oneOf: [
+            { type: 'array', items: { type: 'object', properties: { a: { type: 'string' } } } },
+            { type: 'array', items: { type: 'object', properties: { b: { type: 'number' } } } },
+          ],
+        };
+        const formData = [
+          { a: 'hello', extra: true },
+          { a: 'world', extra: false },
+        ];
+        // isValid called once to pick the winning oneOf branch (index 0)
+        testValidator.setReturnValues({ isValid: [true] });
+        const result = omitExtraData(testValidator, schema, schema, formData);
+        // extra keys are dropped; array is preserved, not collapsed to []
+        expect(result).toEqual([{ a: 'hello' }, { a: 'world' }]);
+      });
+
+      it('preserves anyOf-filtered array content for type:array schemas with no top-level items', () => {
+        const schema: RJSFSchema = {
+          type: 'array',
+          anyOf: [
+            { type: 'array', items: { type: 'object', properties: { x: { type: 'number' } } } },
+            { type: 'array', items: { type: 'object', properties: { y: { type: 'number' } } } },
+          ],
+        };
+        const formData = [
+          { x: 1, extra: true },
+          { x: 2, extra: false },
+        ];
+        // anyOf picks the winning branch and builds a filtered array (distinct reference from source);
+        // the outer handleArray must reuse it rather than return [].
+        testValidator.setReturnValues({ isValid: [true] });
+        const result = omitExtraData(testValidator, schema, schema, formData);
+        expect(result).toEqual([{ x: 1 }, { x: 2 }]);
+      });
     });
 
     describe('patternProperties support', () => {
@@ -1235,10 +1334,7 @@ export default function omitExtraDataTest(testValidator: TestValidatorType) {
         expect(omitExtraData(testValidator, schema, schema, [] as any)).toEqual([]);
       });
 
-      it('reuses an array target already built by anyOf when outer schema is also type:array', () => {
-        // anyOf sees [] as empty → applies all branches → returns [] as target.
-        // The outer type:'array' branch then runs handleArray with that existing [] as target,
-        // hitting the Array.isArray(target) ? target : [] true-branch.
+      it('returns an empty array for a type:array schema with anyOf and an empty source', () => {
         const schema: RJSFSchema = {
           type: 'array',
           anyOf: [{ items: { type: 'string' } }, { items: { type: 'number' } }],


### PR DESCRIPTION
### Reasons for making this change

Fixes #3920

When a schema has ≥2 if/then entries in allOf, shallowAllOfMerge can only hoist one triple to the parent; the rest stay in allOf and are processed by the remainingAllOf loop. Each such entry has no top-level type, so getSchemaType returns undefined and omit() falls through to `filtered = source`. That aliased value propagated back as `target = source`, causing handleObject to be called with the same object for both source and target. Any nested array property (e.g. the `list` field) then received the identical array reference as both source and target in handleArray, which unconditionally pushes onto target — creating an infinite growth loop that corrupted the list data and caused conditional properties with numeric-string keys ("1", "2", "3") to be dropped.

Fix: add a `filtered !== source` guard on the object accumulator so handleObject always receives a fresh {} when filtered is aliased to source. For arrays, always pass a fresh [] to handleArray since it rebuilds the array from scratch on every call anyway — seeding it with a pre-existing array would cause item duplication.

The aliasing fix for #3920 always seeded handleArray with [], discarding a valid filtered array already built by handleOneOf/handleAnyOf. For type:'array' schemas with oneOf/anyOf but no top-level items this caused omitExtraData to return [] instead of the oneOf-filtered content.

Made the array branch symmetric with the object branch: reuse filtered when it is already a distinct (non-aliased) array, fall back to [] only when filtered === source.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
