### PR TITLE
perf: declare sideEffects: false on the remaining packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 
 # 6.9.0
+
 ## @rjsf/antd
 
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
@@ -74,7 +75,8 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/shadcn
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
+- Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
+- - Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
 
 ## @rjsf/utils
 
@@ -104,7 +106,6 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules; a consumer importing only `Form` no longer bundles the AJV validator chain pulled in by `getTestRegistry`, shrinking a minimal bundle by ~34kB gzipped
 - Fixed `TimeWidget` to respect schema `multipleOf` time precision, preserving second-precision values while keeping minute-precision native inputs synchronized with their displayed value ([#5174](https://github.com/rjsf-team/react-jsonschema-form/pull/5174))
 
 ## @rjsf/utils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ should change the heading of the (upcoming) version to include a major version b
 # 6.9.0
 ## @rjsf/antd
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
 
 ## @rjsf/chakra-ui
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
 
 
@@ -35,34 +37,46 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/daisyui
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules; removed the module-level `library.add()` FontAwesome registration that made this unsafe, which was already dead code since every icon is passed by value
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
 
 ## @rjsf/fluentui-rc
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
 
 ## @rjsf/mantine
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules; moved the module-level `dayjs.extend(customParseFormat)` call into `DateTimeInput`, the only module that needs it
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
 
 ## @rjsf/mui
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
 
 ## @rjsf/primereact
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
 
 ## @rjsf/react-bootstrap
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
 
 ## @rjsf/semantic-ui
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
+
+## @rjsf/shadcn
+
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 
 ## @rjsf/utils
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Fixed `mergeDefaultsWithFormData()` to take the recursive path when the default under an object key holds an array, so a default that lives inside a `dependencies` subschema is no longer dropped when the owning array sits more than one object below the root, fixing part of [#5198](https://github.com/rjsf-team/react-jsonschema-form/issues/5198) ([#5202](https://github.com/rjsf-team/react-jsonschema-form/pull/5202))
 - Added new path utilities `getByPath`, `setByPath`, `hasByPath`, `unsetByPath` and `toPath`, and switched all path-based `lodash` usage (`get`, `set`, `setWith`, `has`, `unset`, `toPath`, `pick`) over to them. Unlike their lodash counterparts, these treat a bare string as a single literal key, lodash-style dotted path strings are parsed explicitly via `toPath()`, and `getByPath()`/`hasByPath()` resolve **own** properties only (inherited members and prototype internals such as `__proto__` never resolve)
 - Made the default value of a required boolean field be false if a `default` is not present in the schema
@@ -70,15 +84,18 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/validator-ajv8
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Replaced all `lodash/get` usage with the new `@rjsf/utils` path utilities
 
 ## @rjsf/validator-ata
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Replaced all `lodash/get` usage with the new `@rjsf/utils` path utilities
 - Updated `ata-validator` dependency to `^1.7.1`, picking up lazily materialized errors and the closure-tree interpreted engine ([#5211](https://github.com/rjsf-team/react-jsonschema-form/pull/5211))
 
 ## @rjsf/validator-cfworker
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Replaced all `lodash/get` usage with the new `@rjsf/utils` path utilities and dropped the `lodash`/`lodash-es` dependencies entirely
 
 # 6.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,13 @@ should change the heading of the (upcoming) version to include a major version b
 # 6.9.0
 ## @rjsf/antd
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
 
 ## @rjsf/chakra-ui
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
 
 
 ## @rjsf/core
@@ -37,71 +37,74 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/daisyui
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules; removed the module-level `library.add()` FontAwesome registration that made this unsafe, which was already dead code since every icon is passed by value
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
+- Removed the module-level Font Awesome `library.add()` call from `AddButton`; every icon is passed to `FontAwesomeIcon` as an imported icon object, so the global registry was never consulted
 
 ## @rjsf/fluentui-rc
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
 
 ## @rjsf/mantine
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules; moved the module-level `dayjs.extend(customParseFormat)` call into `DateTimeInput`, the only module that needs it
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
+- Moved the `dayjs` `customParseFormat` plugin registration from the widgets barrel file into `DateTimeInput`, so it loads with the date widgets that actually need it
 
 ## @rjsf/mui
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
 
 ## @rjsf/primereact
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
 
 ## @rjsf/react-bootstrap
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
 
 ## @rjsf/semantic-ui
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
 
 ## @rjsf/shadcn
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
 
 ## @rjsf/utils
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Fixed `mergeDefaultsWithFormData()` to take the recursive path when the default under an object key holds an array, so a default that lives inside a `dependencies` subschema is no longer dropped when the owning array sits more than one object below the root, fixing part of [#5198](https://github.com/rjsf-team/react-jsonschema-form/issues/5198) ([#5202](https://github.com/rjsf-team/react-jsonschema-form/pull/5202))
 - Added new path utilities `getByPath`, `setByPath`, `hasByPath`, `unsetByPath` and `toPath`, and switched all path-based `lodash` usage (`get`, `set`, `setWith`, `has`, `unset`, `toPath`, `pick`) over to them. Unlike their lodash counterparts, these treat a bare string as a single literal key, lodash-style dotted path strings are parsed explicitly via `toPath()`, and `getByPath()`/`hasByPath()` resolve **own** properties only (inherited members and prototype internals such as `__proto__` never resolve)
 - Made the default value of a required boolean field be false if a `default` is not present in the schema
 - Fixed `omitExtraData()` by removing the over-reaching `additionalProperties: false` post-processing block introduced in [#5147](https://github.com/rjsf-team/react-jsonschema-form/pull/5147) that incorrectly stripped keys written by winning `oneOf`/`anyOf` and `if/then/else` branches, fixing [#5194](https://github.com/rjsf-team/react-jsonschema-form/issues/5194)
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
 
 ## @rjsf/validator-ajv8
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Replaced all `lodash/get` usage with the new `@rjsf/utils` path utilities
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
 
 ## @rjsf/validator-ata
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Replaced all `lodash/get` usage with the new `@rjsf/utils` path utilities
 - Updated `ata-validator` dependency to `^1.7.1`, picking up lazily materialized errors and the closure-tree interpreted engine ([#5211](https://github.com/rjsf-team/react-jsonschema-form/pull/5211))
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
 
 ## @rjsf/validator-cfworker
 
-- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules
 - Replaced all `lodash/get` usage with the new `@rjsf/utils` path utilities and dropped the `lodash`/`lodash-es` dependencies entirely
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
 
 # 6.8.0
 
 ## @rjsf/core
 
+- Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused modules; a consumer importing only `Form` no longer bundles the AJV validator chain pulled in by `getTestRegistry`, shrinking a minimal bundle by ~34kB gzipped
 - Fixed `TimeWidget` to respect schema `multipleOf` time precision, preserving second-precision values while keeping minute-precision native inputs synchronized with their displayed value ([#5174](https://github.com/rjsf-team/react-jsonschema-form/pull/5174))
 
 ## @rjsf/utils

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -6,6 +6,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -6,6 +6,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",

--- a/packages/daisyui/package.json
+++ b/packages/daisyui/package.json
@@ -6,6 +6,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",

--- a/packages/daisyui/src/templates/ButtonTemplates/AddButton.tsx
+++ b/packages/daisyui/src/templates/ButtonTemplates/AddButton.tsx
@@ -1,11 +1,8 @@
-import { library } from '@fortawesome/fontawesome-svg-core';
-import { faArrowDown, faArrowUp, faCopy, faTrash, faPlus } from '@fortawesome/free-solid-svg-icons';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import type { FormContextType, IconButtonProps, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
 import { TranslatableString } from '@rjsf/utils';
 
 import DaisyUIButton from './DaisyUIButton';
-
-library.add(faPlus, faCopy, faArrowDown, faArrowUp, faTrash);
 
 /** The `AddButton` renders a button that represent the `Add` action on a form
  *

--- a/packages/fluentui-rc/package.json
+++ b/packages/fluentui-rc/package.json
@@ -28,6 +28,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",

--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -5,6 +5,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "description": "Mantine theme, fields and widgets for react-jsonschema-form",
   "exports": {
     ".": {

--- a/packages/mantine/src/widgets/DateTime/DateTimeInput.tsx
+++ b/packages/mantine/src/widgets/DateTime/DateTimeInput.tsx
@@ -3,6 +3,10 @@ import { DateInput } from '@mantine/dates';
 import type { FormContextType, RJSFSchema, StrictRJSFSchema, WidgetProps } from '@rjsf/utils';
 import { ariaDescribedByIds, labelValue } from '@rjsf/utils';
 import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat.js';
+
+// This plugin is needed to support the parsing of date and time values in the `DateWidget` and `DateTimeWidget`
+dayjs.extend(customParseFormat);
 
 const dateParser = (input: string, format: string) => {
   if (!input) {

--- a/packages/mantine/src/widgets/index.ts
+++ b/packages/mantine/src/widgets/index.ts
@@ -1,6 +1,4 @@
 import type { FormContextType, RegistryWidgetsType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
-import dayjs from 'dayjs';
-import customParseFormat from 'dayjs/plugin/customParseFormat';
 
 import CheckboxesWidget from './CheckboxesWidget';
 import CheckboxWidget from './CheckboxWidget';
@@ -12,9 +10,6 @@ import RadioWidget from './RadioWidget';
 import RangeWidget from './RangeWidget';
 import SelectWidget from './SelectWidget';
 import TextareaWidget from './TextareaWidget';
-
-// This plugin is needed to support the parsing of date and time values in the `DateWidget` and `DateTimeWidget`
-dayjs.extend(customParseFormat);
 
 export function generateWidgets<
   T = any,

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -5,6 +5,7 @@
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "description": "Material UI 7 theme, fields and widgets for react-jsonschema-form",
   "exports": {
     ".": {

--- a/packages/primereact/package.json
+++ b/packages/primereact/package.json
@@ -6,6 +6,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",

--- a/packages/react-bootstrap/package.json
+++ b/packages/react-bootstrap/package.json
@@ -5,6 +5,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "description": "React Bootstrap theme, fields and widgets for react-jsonschema-form, powered by react-bootstrap",
   "exports": {
     ".": {

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -5,6 +5,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "description": "Semantic UI theme, fields and widgets for react-jsonschema-form",
   "exports": {
     ".": {

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -5,6 +5,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "description": "shadcn theme, fields and widgets for react-jsonschema-form",
   "exports": {
     ".": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,6 +5,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "description": "Utility functions for @rjsf/core",
   "exports": {
     ".": {

--- a/packages/validator-ajv8/package.json
+++ b/packages/validator-ajv8/package.json
@@ -5,6 +5,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "description": "The ajv-8 based validator for @rjsf/core",
   "exports": {
     ".": {

--- a/packages/validator-ata/package.json
+++ b/packages/validator-ata/package.json
@@ -5,6 +5,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "description": "ata-validator based validator for @rjsf/core",
   "exports": {
     ".": {

--- a/packages/validator-cfworker/package.json
+++ b/packages/validator-cfworker/package.json
@@ -5,6 +5,7 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "description": "@cfworker/json-schema based validator for @rjsf/core",
   "exports": {
     ".": {


### PR DESCRIPTION
## Reasons for making this change

In #5206 I declared `"sideEffects": false` for `@rjsf/core` but accidentally forgot to include it for all the other packages, so bundlers still had to assume side effects for `@rjsf/utils`, the themes and the validators.

I audited the built output of all 15 runtime packages. Two had real module-level side effects, fixed here:

- **`@rjsf/daisyui`** called `library.add()` to register FontAwesome icons. Dead code — every icon is passed by value (`icon={faPlus}`), never by string name, and `faXmark`/`faCalendar` already render without being registered.
- **`@rjsf/mantine`** called `dayjs.extend(customParseFormat)` in `widgets/index.ts`. Moved into `DateTimeInput`, its only consumer, so it drops with the module instead of mutating global `dayjs` on import.

Everything else was already clean. `@rjsf/snapshot-tests` is deliberately excluded — its modules call `vi.mock()` at module scope.

### Bundle size

esbuild, minified + gzipped, React external:

| import | before | after | |
|---|---:|---:|---:|
| `{ getUiOptions } from '@rjsf/utils'` | 13,411 | 432 | **−96.8%** |
| `{ Widgets } from '@rjsf/mui'` | 169,864 | 77,998 | **−54.1%** |
| 3 helpers from `@rjsf/utils` | 22,799 | 21,325 | −6.5% |
| `Form` from `@rjsf/core` + validator | 123,830 | 123,833 | ~0% |
| `Form` from `@rjsf/mui` + validator | 210,669 | 210,672 | ~0% |

Whole-`Form` imports are unchanged, as expected — everything reachable from the default registry is genuinely used. The win is for consumers importing a subset of a package.

## Checklist

- [x] I'm updating documentation
- [x] I'm adding or updating code
  - [x] I've added and/or updated tests (existing suite; no behavior change)
  - [x] I've updated the changelog
- [ ] I'm adding a new feature