### PR TITLE
Fix 5213: clear antd integer/number fields to undefined instead of null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
 - Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
+- Fixed `BaseInputTemplate` to clear `number`/`integer` fields back to `undefined` instead of `null` when the `InputNumber` widget is emptied, fixing [#5213](https://github.com/rjsf-team/react-jsonschema-form/issues/5213)
 
 ## @rjsf/chakra-ui
 

--- a/packages/antd/src/templates/BaseInputTemplate/index.tsx
+++ b/packages/antd/src/templates/BaseInputTemplate/index.tsx
@@ -50,7 +50,8 @@ export default function BaseInputTemplate<
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
   const { ClearButton } = registry.templates.ButtonTemplates;
 
-  const handleNumberChange = (nextValue: number | null) => onChange(nextValue);
+  const handleNumberChange = (nextValue: number | null) =>
+    onChange(nextValue === null ? options.emptyValue : nextValue);
 
   const handleTextChange =
     onChangeOverride ||

--- a/packages/antd/test/Form.test.tsx
+++ b/packages/antd/test/Form.test.tsx
@@ -1,7 +1,7 @@
 import { formTests } from '@rjsf/snapshot-tests';
 import type { RJSFSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 import Form from '../src';
 
@@ -40,6 +40,28 @@ describe('antd specific tests', () => {
     const { container } = render(<Form schema={schema} validator={validator} />);
 
     expect(container.querySelector('input#root_age')).toHaveAttribute('required');
+  });
+
+  test('clearing an optional integer field removes the value instead of setting null', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        age: {
+          type: 'integer',
+          title: 'Age',
+        },
+      },
+    };
+    const onChange = vi.fn();
+
+    const { container } = render(<Form schema={schema} validator={validator} onChange={onChange} />);
+    const input = container.querySelector('input#root_age') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: '1' } });
+    fireEvent.change(input, { target: { value: '' } });
+
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(lastCall.formData).toEqual({});
   });
 
   test('descriptionLocation tooltip in formContext', () => {


### PR DESCRIPTION
### Reasons for making this change

Fixes #5213

The antd InputNumber widget's onChange handler passed the null it emits on clear straight through to RJSF, unlike the text-input handler which already maps an empty value to options.emptyValue. That left a stale null in formData for optional fields, which failed AJV's "must be integer" check on submit.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
