### PR TITLE
fix(utils): Use defaults when toggling between oneOf/anyOf schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 6.9.1
+
+## @rjsf/core
+
+- Fixed defaults not being restored when returning to an `anyOf` or `oneOf` option with disjoint properties ([#3736](https://github.com/rjsf-team/react-jsonschema-form/issues/3736))
+
+## @rjsf/utils
+
+- Fixed `sanitizeDataForNewSchema()` clearing existing arrays or preserving stale `undefined` values instead of retaining data or applying defaults for properties newly defined by the incoming schema ([#3736](https://github.com/rjsf-team/react-jsonschema-form/issues/3736))
+
 # 6.9.0
 
 > **Potentially breaking change:** `lodash` and `lodash-es` are no longer dependencies of any `@rjsf/*` package. No RJSF public API changed, but an application that imports `lodash` itself without declaring it — relying on it being hoisted into `node_modules` because RJSF depended on it — must now add `lodash` to its own `package.json`.
@@ -153,12 +163,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
-- Fixed defaults not being restored when returning to an `anyOf` or `oneOf` option with disjoint properties ([#3736](https://github.com/rjsf-team/react-jsonschema-form/issues/3736))
 - Fixed `TimeWidget` to respect schema `multipleOf` time precision, preserving second-precision values while keeping minute-precision native inputs synchronized with their displayed value ([#5174](https://github.com/rjsf-team/react-jsonschema-form/pull/5174))
 
 ## @rjsf/utils
 
-- Fixed `sanitizeDataForNewSchema()` clearing existing arrays or preserving stale `undefined` values instead of retaining data or applying defaults for properties newly defined by the incoming schema ([#3736](https://github.com/rjsf-team/react-jsonschema-form/issues/3736))
 - Fixed an issue in `sortedJSONStringify` with regards to handling arrays containing `null` and `undefined` values.
 
 ## @rjsf/validator-ata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,10 +153,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
+- Fixed defaults not being restored when returning to an `anyOf` or `oneOf` option with disjoint properties ([#3736](https://github.com/rjsf-team/react-jsonschema-form/issues/3736))
 - Fixed `TimeWidget` to respect schema `multipleOf` time precision, preserving second-precision values while keeping minute-precision native inputs synchronized with their displayed value ([#5174](https://github.com/rjsf-team/react-jsonschema-form/pull/5174))
 
 ## @rjsf/utils
 
+- Fixed `sanitizeDataForNewSchema()` clearing existing arrays or preserving stale `undefined` values instead of retaining data or applying defaults for properties newly defined by the incoming schema ([#3736](https://github.com/rjsf-team/react-jsonschema-form/issues/3736))
 - Fixed an issue in `sortedJSONStringify` with regards to handling arrays containing `null` and `undefined` values.
 
 ## @rjsf/validator-ata

--- a/packages/core/test/Form.behaviors.test.tsx
+++ b/packages/core/test/Form.behaviors.test.tsx
@@ -2483,6 +2483,66 @@ describe('clearing a field with a schema default does not re-apply the default (
   });
 });
 
+describe('dependency defaults in controlled forms', () => {
+  const triggersSchema: RJSFSchema = {
+    type: 'array',
+    default: [],
+    items: { type: 'object' },
+  };
+  const schema: RJSFSchema = {
+    type: 'object',
+    properties: {
+      triggersOverride: {
+        type: 'boolean',
+        oneOf: [
+          { title: 'Override Repo Triggers', enum: [true] },
+          { title: 'Default to Repo Triggers', enum: [false] },
+        ],
+      },
+    },
+    dependencies: {
+      triggersOverride: {
+        oneOf: [
+          {
+            properties: {
+              triggersOverride: { enum: [false] },
+              repoData: {
+                type: 'object',
+                properties: {
+                  triggers: triggersSchema,
+                },
+              },
+            },
+          },
+          {
+            properties: {
+              triggersOverride: { enum: [true] },
+              triggers: triggersSchema,
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  it('preserves an empty array already present when enabling the dependency branch', async () => {
+    const { node, onChange } = createFormComponent({
+      schema,
+      formData: {
+        triggersOverride: false,
+        triggers: [],
+        repoData: { triggersOverride: true, triggers: [] },
+      },
+      liveValidate: 'onChange',
+      uiSchema: { triggersOverride: { 'ui:widget': 'radio' } },
+    });
+
+    await user.click(node.querySelectorAll<HTMLInputElement>('input[type=radio]')[0]);
+
+    expectToHaveBeenCalledWithFormData(onChange, { triggersOverride: true, triggers: [] }, 'root_triggersOverride');
+  });
+});
+
 describe('enum-based array values do not update when dependencies change (#1357 and #2492)', () => {
   it('should remove enum values in array when dependency switches', async () => {
     const schema: RJSFSchema = {

--- a/packages/core/test/anyOf.test.tsx
+++ b/packages/core/test/anyOf.test.tsx
@@ -186,6 +186,50 @@ describe('anyOf', () => {
     );
   });
 
+  it('should restore defaults when returning to an option with disjoint properties', async () => {
+    const { node, onChange } = createFormComponent({
+      schema: {
+        type: 'object',
+        properties: {
+          age: { type: 'integer', title: 'Age' },
+        },
+        anyOf: [
+          {
+            title: 'First method of identification',
+            properties: {
+              firstName: { type: 'string', title: 'First name', default: 'Chuck' },
+              lastName: { type: 'string', title: 'Last name' },
+            },
+          },
+          {
+            title: 'Second method of identification',
+            properties: {
+              idCode: { type: 'string', title: 'ID code' },
+            },
+          },
+        ],
+      },
+    });
+    const $select = node.querySelector<HTMLSelectElement>('#root__anyof_select');
+
+    expect(node.querySelector('#root_firstName')).toHaveValue('Chuck');
+    await user.selectOptions($select!, '1');
+    expect($select).toHaveValue('1');
+
+    await user.type(node.querySelector('#root_age')!, '42');
+    expect($select).toHaveValue('1');
+    expect(node.querySelector('#root_firstName')).not.toBeInTheDocument();
+
+    await user.selectOptions($select!, '0');
+    expect(node.querySelector('#root_firstName')).toHaveValue('Chuck');
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        formData: expect.objectContaining({ firstName: 'Chuck' }),
+      }),
+      'root__anyof_select',
+    );
+  });
+
   it('should assign a default value and set defaults on option change for scalar types schemas', async () => {
     const { node, onChange } = createFormComponent({
       schema: {

--- a/packages/core/test/oneOf.test.tsx
+++ b/packages/core/test/oneOf.test.tsx
@@ -127,6 +127,34 @@ describe('oneOf', () => {
     );
   });
 
+  it('should restore defaults when returning to an option with disjoint properties', async () => {
+    const { node } = createFormComponent({
+      schema: {
+        type: 'object',
+        oneOf: [
+          {
+            title: 'First method of identification',
+            properties: {
+              firstName: { type: 'string', default: 'Chuck' },
+            },
+          },
+          {
+            title: 'Second method of identification',
+            properties: {
+              idCode: { type: 'string' },
+            },
+          },
+        ],
+      },
+    });
+    const $select = node.querySelector<HTMLSelectElement>('#root__oneof_select');
+
+    await user.selectOptions($select!, '1');
+    await user.selectOptions($select!, '0');
+
+    expect(node.querySelector('#root_firstName')).toHaveValue('Chuck');
+  });
+
   it('should assign a default value and set defaults on option change when using refs', async () => {
     const { node, onChange } = createFormComponent({
       schema: {

--- a/packages/utils/src/schema/sanitizeDataForNewSchema.ts
+++ b/packages/utils/src/schema/sanitizeDataForNewSchema.ts
@@ -162,16 +162,13 @@ export default function sanitizeDataForNewSchema<
           delete removeOldSchemaData[key];
         }
         // If it is an object, we'll recurse and store the resulting sanitized data for the key
-        if (
-          newSchemaTypeForKey === 'object' ||
-          (!isNewProperty && newSchemaTypeForKey === 'array' && Array.isArray(formValue))
-        ) {
+        if (newSchemaTypeForKey === 'object' || (newSchemaTypeForKey === 'array' && Array.isArray(formValue))) {
           // SIDE-EFFECT: process the new schema type of object recursively to save iterations
           const itemData = sanitizeDataForNewSchema<T, S, F>(
             validator,
             rootSchema,
             newKeyedSchema,
-            oldKeyedSchema,
+            isNewProperty && newSchemaTypeForKey === 'array' ? newKeyedSchema : oldKeyedSchema,
             formValue,
             experimental_customMergeAllOf,
           );

--- a/packages/utils/src/schema/sanitizeDataForNewSchema.ts
+++ b/packages/utils/src/schema/sanitizeDataForNewSchema.ts
@@ -69,7 +69,7 @@ function replacementForInvalidEnumValue<S extends StrictRJSFSchema = RJSFSchema>
  *       - Otherwise, check for default or const values:
  *         - Get the old and new `default` values from the schema and check:
  *           - If the new `default` value does not match the form value:
- *             - If the old `default` value DOES match the form value, then:
+ *             - If the key is new and its form value is undefined, or the old `default` matches the form value, then:
  *               - Replace `removeOldSchemaData[key]` with the new `default`
  *               - Otherwise, if the new schema is `readOnly` then replace `removeOldSchemaData[key]` with undefined
  *         - Get the old and new `const` values from the schema and check:
@@ -78,7 +78,7 @@ function replacementForInvalidEnumValue<S extends StrictRJSFSchema = RJSFSchema>
  *             - Replace `removeOldSchemaData[key]` with the new `const`
  *             - Otherwise, replace `removeOldSchemaData[key]` with undefined
  *   - Once all keys have been processed, return an object built as follows:
- *     - `{ ...removeOldSchemaData, ...nestedData, ...pick(data, keysToKeep) }`
+ *     - `{ ...data, ...removeOldSchemaData, ...nestedData }`
  * - If the new and old schema types are array and the `data` is an array then:
  *   - If the type of the old and new schema `items` are a non-array objects:
  *     - Retrieve the schema for any refs within each `oldKeySchema.items` and/or `newKeySchema.items`
@@ -130,6 +130,7 @@ export default function sanitizeDataForNewSchema<
     const nestedData: GenericObjectType = {};
     keys.forEach((key) => {
       const formValue = data?.[key];
+      const isNewProperty = !hasByPath(oldSchema, [PROPERTIES_KEY, key]);
       let oldKeyedSchema = getPropertySchema<S>(oldSchema, key);
       let newKeyedSchema = getPropertySchema<S>(newSchema, key);
       // Resolve the refs if they exist
@@ -161,7 +162,10 @@ export default function sanitizeDataForNewSchema<
           delete removeOldSchemaData[key];
         }
         // If it is an object, we'll recurse and store the resulting sanitized data for the key
-        if (newSchemaTypeForKey === 'object' || (newSchemaTypeForKey === 'array' && Array.isArray(formValue))) {
+        if (
+          newSchemaTypeForKey === 'object' ||
+          (!isNewProperty && newSchemaTypeForKey === 'array' && Array.isArray(formValue))
+        ) {
           // SIDE-EFFECT: process the new schema type of object recursively to save iterations
           const itemData = sanitizeDataForNewSchema<T, S, F>(
             validator,
@@ -182,8 +186,8 @@ export default function sanitizeDataForNewSchema<
           const newOptionDefault = getByPath(newKeyedSchema, DEFAULT_KEY, NO_VALUE);
           const oldOptionDefault = getByPath(oldKeyedSchema, DEFAULT_KEY, NO_VALUE);
           if (newOptionDefault !== NO_VALUE && newOptionDefault !== formValue) {
-            if (oldOptionDefault === formValue) {
-              // If the old default matches the formValue, we'll update the new value to match the new default
+            if ((isNewProperty && formValue === undefined) || oldOptionDefault === formValue) {
+              // Initialize a newly entered property or replace an old default with the new default.
               removeOldSchemaData[key] = newOptionDefault;
             } else if (newKeyedSchema.readOnly === true) {
               // If the new schema has the default set to read-only, treat it like a const and remove the value

--- a/packages/utils/test/schema/sanitizeDataForNewSchemaTest.ts
+++ b/packages/utils/test/schema/sanitizeDataForNewSchemaTest.ts
@@ -14,7 +14,7 @@ export default function sanitizeDataForNewSchemaTest(testValidator: TestValidato
     const newArraySchema: RJSFSchema = {
       type: 'object',
       properties: {
-        values: { type: 'array', default: [], items: { type: 'string' } },
+        values: { type: 'array', default: [], items: { type: 'string', enum: ['a', 'b'] } },
       },
     };
     let schemaUtils: SchemaUtilsType;
@@ -76,13 +76,13 @@ export default function sanitizeDataForNewSchemaTest(testValidator: TestValidato
         }),
       ).toEqual({ values: [], idCode: undefined });
     });
-    it('preserves an empty array already present for a property newly defined by the new schema', () => {
+    it('sanitizes array data already present for a property newly defined by the new schema', () => {
       expect(
         schemaUtils.sanitizeDataForNewSchema(newArraySchema, oldDisjointSchema, {
-          values: [],
+          values: ['a', 'x'],
           idCode: undefined,
         }),
-      ).toEqual({ values: [], idCode: undefined });
+      ).toEqual({ values: ['a'], idCode: undefined });
     });
     it('continues sanitizing an existing array when the old schema omits its type', () => {
       const oldSchema: RJSFSchema = {

--- a/packages/utils/test/schema/sanitizeDataForNewSchemaTest.ts
+++ b/packages/utils/test/schema/sanitizeDataForNewSchemaTest.ts
@@ -5,6 +5,18 @@ import type { TestValidatorType } from './types';
 
 export default function sanitizeDataForNewSchemaTest(testValidator: TestValidatorType) {
   describe('sanitizeDataForNewSchema', () => {
+    const oldDisjointSchema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        idCode: { type: 'string' },
+      },
+    };
+    const newArraySchema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        values: { type: 'array', default: [], items: { type: 'string' } },
+      },
+    };
     let schemaUtils: SchemaUtilsType;
     beforeAll(() => {
       schemaUtils = createSchemaUtils(testValidator, oneOfSchema);
@@ -40,6 +52,67 @@ export default function sanitizeDataForNewSchemaTest(testValidator: TestValidato
     it('returns input formData when the old schema does not contain a "property" object', () => {
       const newSchema = schemaUtils.retrieveSchema(SECOND_ONE_OF, oneOfSchema);
       expect(sanitizeDataForNewSchema(testValidator, oneOfSchema, newSchema, {}, oneOfData)).toEqual(oneOfData);
+    });
+    it('restores the default for an undefined property that is newly defined by the new schema', () => {
+      const newSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          firstName: { type: 'string', default: 'Chuck' },
+        },
+      };
+
+      expect(
+        schemaUtils.sanitizeDataForNewSchema(newSchema, oldDisjointSchema, {
+          firstName: undefined,
+          idCode: undefined,
+        }),
+      ).toEqual({ firstName: 'Chuck', idCode: undefined });
+    });
+    it('restores an empty array default for an undefined property newly defined by the new schema', () => {
+      expect(
+        schemaUtils.sanitizeDataForNewSchema(newArraySchema, oldDisjointSchema, {
+          values: undefined,
+          idCode: undefined,
+        }),
+      ).toEqual({ values: [], idCode: undefined });
+    });
+    it('preserves an empty array already present for a property newly defined by the new schema', () => {
+      expect(
+        schemaUtils.sanitizeDataForNewSchema(newArraySchema, oldDisjointSchema, {
+          values: [],
+          idCode: undefined,
+        }),
+      ).toEqual({ values: [], idCode: undefined });
+    });
+    it('continues sanitizing an existing array when the old schema omits its type', () => {
+      const oldSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          values: { items: { type: 'string' } },
+        },
+      };
+
+      expect(schemaUtils.sanitizeDataForNewSchema(newArraySchema, oldSchema, { values: ['existing'] })).toEqual({
+        values: undefined,
+      });
+    });
+    it('preserves explicit undefined data for a property shared by both schemas', () => {
+      const oldSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          firstName: { type: 'string' },
+        },
+      };
+      const newSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          firstName: { type: 'string', default: 'Chuck' },
+        },
+      };
+
+      expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, { firstName: undefined })).toEqual({
+        firstName: undefined,
+      });
     });
     it('returns input formData when the new schema matches the data for the new schema rather than the old', () => {
       const newSchema = schemaUtils.retrieveSchema(SECOND_ONE_OF, oneOfSchema);


### PR DESCRIPTION
### Reasons for making this change

fixes #3736 

This change has caused us some trouble when upgrading from v4 to v6 (😅). This should restore the previous behavior where defaults are used when a field does not exist in all of the schemas within anyOf/oneOf.

Thanks a lot in advance for your help! My team is a big fan of RJSF.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
