### PR TITLE
fix: stop leaking non-DOM props in primereact and semantic-ui widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
 - Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
+- Fixed `ArrayFieldTemplate` leaking the `errorSchema` object into the DOM as an `errorschema="[object Object]"` attribute
+- Fixed `SelectWidget` clobbering a consumer-supplied `options.prime.autoComplete` with `undefined` when `ui:autocomplete` is not set
 
 ## @rjsf/react-bootstrap
 
@@ -76,6 +78,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated `CheckboxWidget` to append a `*` onto the end of the label when the field is required AND the schema value is hardcoded to `true`, fixing [#4136](https://github.com/rjsf-team/react-jsonschema-form/issues/4136)
 - Declared `"sideEffects": false` in `package.json`, allowing bundlers to tree-shake unused exports
+- Fixed `RadioWidget` forwarding the unsupported `fluid`/`inverted` props to Semantic UI's `Radio`, which triggered React unknown-attribute warnings
 
 ## @rjsf/shadcn
 

--- a/packages/primereact/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/primereact/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -30,6 +30,7 @@ export default function ArrayFieldTemplate<
     // Destructure the following props out so that they aren't put into the DOM
     formData,
     rawErrors,
+    errorSchema,
     ...rest
   } = props;
 

--- a/packages/primereact/src/SelectWidget/SelectWidget.tsx
+++ b/packages/primereact/src/SelectWidget/SelectWidget.tsx
@@ -70,7 +70,9 @@ function SingleSelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F 
     onBlur(id, enumOptionValueDecoder<S>(target?.value, enumOptions, optionValueFormat, optEmptyVal));
   const handleFocus = ({ target }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionValueDecoder<S>(target?.value, enumOptions, optionValueFormat, optEmptyVal));
-  const { ...dropdownRemainingProps } = dropdownProps;
+  // autoComplete is spread conditionally below: a plain autoComplete={undefined} would still
+  // override a consumer-supplied options.prime.autoComplete from the earlier primeProps spread
+  const { autocomplete, ...dropdownRemainingProps } = dropdownProps;
 
   return (
     <Dropdown
@@ -89,6 +91,7 @@ function SingleSelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F 
       placeholder={placeholder}
       disabled={disabled || readonly}
       autoFocus={autofocus}
+      {...(autocomplete === undefined ? {} : { autoComplete: autocomplete })}
       aria-describedby={ariaDescribedByIds(id)}
       {...dropdownRemainingProps}
     />

--- a/packages/primereact/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/primereact/test/__snapshots__/Array.test.tsx.snap
@@ -491,7 +491,6 @@ exports[`array fields > fixed array 1`] = `
           class="rjsf-field rjsf-field-array rjsf-field-array-fixed-items p-fieldset p-component"
           data-pc-name="fieldset"
           data-pc-section="root"
-          errorschema="[object Object]"
           id="root"
         >
           <div
@@ -1422,7 +1421,6 @@ exports[`nameGenerator > bracketNameGenerator > fixed array 1`] = `
           class="rjsf-field rjsf-field-array rjsf-field-array-fixed-items p-fieldset p-component"
           data-pc-name="fieldset"
           data-pc-section="root"
-          errorschema="[object Object]"
           id="root"
         >
           <div
@@ -3324,7 +3322,6 @@ exports[`with title and description > fixed array 1`] = `
           class="rjsf-field rjsf-field-array rjsf-field-array-fixed-items p-fieldset p-component"
           data-pc-name="fieldset"
           data-pc-section="root"
-          errorschema="[object Object]"
           id="root"
         >
           <div
@@ -3925,7 +3922,6 @@ exports[`with title and description from both > fixed array 1`] = `
           class="rjsf-field rjsf-field-array rjsf-field-array-fixed-items p-fieldset p-component"
           data-pc-name="fieldset"
           data-pc-section="root"
-          errorschema="[object Object]"
           id="root"
         >
           <div
@@ -4526,7 +4522,6 @@ exports[`with title and description from uiSchema > fixed array 1`] = `
           class="rjsf-field rjsf-field-array rjsf-field-array-fixed-items p-fieldset p-component"
           data-pc-name="fieldset"
           data-pc-section="root"
-          errorschema="[object Object]"
           id="root"
         >
           <div
@@ -5081,7 +5076,6 @@ exports[`with title and description with global label off > fixed array 1`] = `
           class="rjsf-field rjsf-field-array rjsf-field-array-fixed-items p-fieldset p-component"
           data-pc-name="fieldset"
           data-pc-section="root"
-          errorschema="[object Object]"
           id="root"
         >
           <div

--- a/packages/semantic-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/semantic-ui/src/RadioWidget/RadioWidget.tsx
@@ -42,6 +42,9 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
     formContext: registry.formContext,
     options,
     uiSchema,
+    // Radio supports neither `fluid` nor `inverted`, so don't default them; they
+    // would be forwarded to the DOM element and trigger React unknown-attribute warnings
+    defaultSchemaProps: {},
   });
   const handleChange = (_: FormEvent<HTMLInputElement>, { value: eventValue }: CheckboxProps) =>
     onChange(enumOptionValueDecoder<S>(String(eventValue!), enumOptions, optionValueFormat, emptyValue));


### PR DESCRIPTION
## Reasons for making this change

I've started working on some test modernization and cleanup, with a focus on test performance. While chasing down console noise in the test runs, the React "unknown attribute" warnings pointed at three real prop leaks — this PR fixes them. More cleanup PRs to follow.

- **primereact `ArrayFieldTemplate`** spread `errorSchema` onto the `Fieldset`, so it ended up in the actual DOM as `errorschema="[object Object]"` (you can see it removed from the snapshots in this diff).
- **primereact `SelectWidget`** always passed `autoComplete={...}` to the `Dropdown`, which meant a consumer-supplied `options.prime.autoComplete` was clobbered with `undefined` whenever `ui:autocomplete` wasn't set. It's now only spread when set.
- **semantic-ui `RadioWidget`** defaulted the `fluid`/`inverted` schema props that Semantic UI's `Radio` doesn't support, so they were forwarded to the DOM element and triggered React unknown-attribute warnings on every radio field.

The benefit: cleaner DOM output for primereact users, `options.prime.autoComplete` works as documented, and semantic-ui radio fields no longer warn in the console.

## Checklist

- [x] I'm updating documentation — CHANGELOG.md entries added
- [x] I'm adding or updating tests — existing snapshots cover the `errorSchema` fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
