### PR TITLE
docs(changelog): remove a stray merge-conflict marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ should change the heading of the (upcoming) version to include a major version b
 - Wired the previously-unused `getDaisy()`/`DaisyProps` helpers into `FieldTemplate`, so `ui:options: { daisy: { theme, className, style } }` now applies a per-field DaisyUI theme, class name and/or style
 - Fixed `build:esm`/`build:umd` in `package.json`, which built and named the bundle as `@rjsf/chakra-ui` (`dist/chakra-ui.esm.js`/`.umd.js`) instead of `@rjsf/daisyui`
 - Gave `ArrayFieldTitleTemplate` and `ArrayFieldDescriptionTemplate` the `id` (`titleId`/`descriptionId` derived from `fieldPathId`) and empty-value guard every other template implementing these has, and that registering them in `generateTemplates()` had otherwise dropped from array titles/descriptions
->>>>>>> origin/main
 
 ## @rjsf/fluentui-rc
 


### PR DESCRIPTION
A `>>>>>>> origin/main` line slipped through conflict resolution in #5194's CHANGELOG entry (my mistake while rebasing it). One-line removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)