### PR TITLE
fix: populate defaults for a $ref wrapped in a single-element allOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 6.9.1
+
+## @rjsf/utils
+
+- Fixed `computeDefaults()` to merge a non-object schema's `allOf` when `experimental_defaultFormStateBehavior.allOf` is set to `populateDefaults`, so a `$ref` wrapped in a single-element `allOf` now populates the same defaults as the bare `$ref` does, fixing [#5177](https://github.com/rjsf-team/react-jsonschema-form/issues/5177)
+
 # 6.9.0
 
 > **Potentially breaking change:** `lodash` and `lodash-es` are no longer dependencies of any `@rjsf/*` package. No RJSF public API changed, but an application that imports `lodash` itself without declaring it — relying on it being hoisted into `node_modules` because RJSF depended on it — must now add `lodash` to its own `package.json`.

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -404,6 +404,28 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       )
     ] as S;
     schemaToCompute = mergeSchemas(remaining, schemaToCompute) as S;
+  } else if (
+    ALL_OF_KEY in schema &&
+    experimental_defaultFormStateBehavior?.allOf === 'populateDefaults' &&
+    getSchemaType<S>(schema) !== 'object'
+  ) {
+    // `allOf` on an object schema is already resolved by `getObjectDefaults()`. On any other schema
+    // nothing resolves it, so the defaults of the subschemas are lost. This happens, for instance,
+    // for a single-element `allOf` wrapping a `$ref` to a string, which is equivalent to using the
+    // `$ref` directly. Merge the `allOf` here so those defaults are picked up as well.
+    const mergedSchema = retrieveSchema<T, S, F>(
+      validator,
+      schema,
+      rootSchema,
+      rawFormData,
+      experimental_customMergeAllOf,
+    );
+    // `retrieveSchema()` leaves `allOf` in place when it cannot merge every subschema, such as when
+    // one of them uses `contains`. Recursing on such a schema would never terminate, so only use it
+    // once the merge has actually resolved the `allOf`.
+    if (!(ALL_OF_KEY in mergedSchema)) {
+      schemaToCompute = mergedSchema;
+    }
   }
 
   if (schemaToCompute) {

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -3078,6 +3078,70 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           }),
         ).toEqual({ animalInfo: { animal: 'Cat', food: 'meat' } });
       });
+      it('should populate the default of a `$ref` wrapped in a single-element `allOf`', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            animal: { title: 'Animal', allOf: [{ $ref: '#/definitions/Animal' }] },
+          },
+          required: ['animal'],
+          definitions: {
+            Animal: { type: 'string', enum: ['Cat', 'Dog', 'Bird'], default: 'Dog' },
+          },
+        };
+
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { allOf: 'populateDefaults' },
+          }),
+        ).toEqual({ animal: 'Dog' });
+      });
+      it('should populate the defaults of a `$ref` to an object wrapped in a single-element `allOf`', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            pet: { allOf: [{ $ref: '#/definitions/Pet' }] },
+          },
+          definitions: {
+            Pet: {
+              type: 'object',
+              properties: {
+                name: { type: 'string', default: 'Rex' },
+                legs: { type: 'integer', default: 4 },
+              },
+            },
+          },
+        };
+
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { allOf: 'populateDefaults' },
+          }),
+        ).toEqual({ pet: { name: 'Rex', legs: 4 } });
+      });
+      it('should not recurse endlessly on an `allOf` that cannot be merged', () => {
+        // An `allOf` subschema using `contains` is left in place by `retrieveSchema()` instead of
+        // being merged away, so the merged schema must not be resolved a second time.
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            list: {
+              type: 'array',
+              items: { type: 'string' },
+              allOf: [{ contains: { const: 'a' } }],
+            },
+          },
+        };
+
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { allOf: 'populateDefaults' },
+          }),
+        ).toEqual({});
+      });
     });
 
     describe('default form state behaviour: allOf = "skipDefaults"', () => {
@@ -3125,6 +3189,25 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
             experimental_defaultFormStateBehavior: { allOf: 'skipDefaults' },
           }),
         ).toEqual({ animalInfo: { animal: 'Cat' } });
+      });
+      it('should not populate the default of a `$ref` wrapped in a single-element `allOf`', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            animal: { title: 'Animal', allOf: [{ $ref: '#/definitions/Animal' }] },
+          },
+          required: ['animal'],
+          definitions: {
+            Animal: { type: 'string', enum: ['Cat', 'Dog', 'Bird'], default: 'Dog' },
+          },
+        };
+
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { allOf: 'skipDefaults' },
+          }),
+        ).toEqual({});
       });
     });
     describe('default form state behavior: arrayMinItems.populate = "never"', () => {


### PR DESCRIPTION
### Reasons for making this change

Fixes #5177.

When `experimental_defaultFormStateBehavior.allOf` is set to `populateDefaults`, `computeDefaults()` only merged a schema's `allOf` for schemas that resolve to an object, because `getObjectDefaults()` is the only caller of `retrieveSchema()` on that path. A property declared as `allOf: [{ "$ref": "#/definitions/Animal" }]` therefore produced no default at all, while the equivalent bare `$ref` correctly produced `{ "animal": "Dog" }`.

This change merges the `allOf` of a non object schema in `computeDefaults()` as well, so the wrapped form and the bare form behave the same. Object schemas keep going through `getObjectDefaults()` as before, and the default `skipDefaults` behavior is unchanged.

`retrieveSchema()` leaves `allOf` in place when it cannot merge every subschema, for example when one of them uses `contains`. Recursing on such a schema would never terminate, so the merged schema is only used once the `allOf` has actually been resolved. A test covers that case as well.

No documentation change was needed, since the behavior now matches what the `populateDefaults` value is already documented to do.

The second point raised in the issue, about the select widget showing an enum option that is not present in `formData`, is a rendering concern in the widget rather than a default form state one, so it is not addressed here.

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature