### PR TITLE
fix(core): preserve comma decimal input in number fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Renamed the test file `Form.test.tsx` to `Form.behaviors.test.tsx` so all the `Form` test files follow the `Form.<topic>.test.tsx` naming pattern introduced by [#5219](https://github.com/rjsf-team/react-jsonschema-form/pull/5219)
 - Fixed `ObjectField` to coerce a cleared `additionalProperties`/`patternProperties` value to the empty string only when the change targets the additional property's own path, so clearing a field nested inside an entry now omits that field's key instead of storing `""` in it, fixing [#5222](https://github.com/rjsf-team/react-jsonschema-form/issues/5222)
 - Fixed `BaseInputTemplate`'s `ui:allowClearTextInputs` clear button to store `ui:emptyValue` (`undefined` by default) instead of always storing `""`, so clicking it now behaves exactly like clearing the input by typing. **Potentially breaking change:** an app that never sets `ui:emptyValue` and clicks the clear button on a field (rather than backspacing it) previously got `""` back; it now gets `undefined`, matching every other way of emptying the field.
+- Fixed `NumberField` to preserve comma-decimal input by using a text input by default in comma-decimal locales, fixing [#5199](https://github.com/rjsf-team/react-jsonschema-form/issues/5199)
 
 ## @rjsf/daisyui
 

--- a/packages/core/src/components/fields/NumberField.tsx
+++ b/packages/core/src/components/fields/NumberField.tsx
@@ -7,7 +7,7 @@ import type {
   RJSFSchema,
   StrictRJSFSchema,
 } from '@rjsf/utils';
-import { asNumber, getDecimalSeparator, getUiOptions, optionsList } from '@rjsf/utils';
+import { asNumber, getDecimalSeparator, getUiOptions, hasWidget, optionsList } from '@rjsf/utils';
 
 // Static matchers for standard '.' separator used during normalization inside handleChange
 const trailingCharMatcherWithPrefix = /\.([0-9]*0)*$/;
@@ -33,7 +33,7 @@ const trailingCharMatcher = /[0.]0*$/;
 function NumberField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: FieldProps<T, S, F>,
 ) {
-  const { registry, onChange, formData, value: initialValue } = props;
+  const { registry, onChange, formData, schema, uiSchema, value: initialValue } = props;
   const [lastValue, setLastValue] = useState(initialValue);
   const { StringField } = registry.fields;
 
@@ -41,6 +41,27 @@ function NumberField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
   const escapedSeparator = separator === '.' ? '\\.' : separator;
 
   let value = formData;
+  let fieldUiSchema = uiSchema;
+
+  const { schemaUtils, widgets } = registry;
+  const enumOptions = schemaUtils.isSelect(schema) ? optionsList(schema, uiSchema) : undefined;
+  const formatWidget = schema.format && hasWidget<T, S, F>(schema, schema.format, widgets) ? schema.format : undefined;
+  const defaultWidget = enumOptions ? 'select' : (formatWidget ?? 'text');
+  const { widget = defaultWidget, inputType } = getUiOptions(uiSchema);
+
+  if (separator !== '.' && schema.type === 'number') {
+    // Native number inputs reject locale-specific decimal separators. Use a text input
+    // by default so localized values reach handleChange intact and can be normalized.
+    if (widget === 'text' && inputType === undefined) {
+      fieldUiSchema = {
+        ...uiSchema,
+        'ui:options': {
+          ...uiSchema?.['ui:options'],
+          inputType: 'text',
+        },
+      };
+    }
+  }
 
   /** Handle the change from the `StringField` to properly convert to a number
    *
@@ -87,12 +108,6 @@ function NumberField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
   // Format value to use the locale separator for rendering if it is a number
   let displayValue: T | undefined = value;
   if (typeof value === 'number' && separator !== '.') {
-    const { schema, uiSchema } = props;
-    const { schemaUtils } = registry;
-    const enumOptions = schemaUtils.isSelect(schema) ? optionsList(schema, uiSchema) : undefined;
-    const defaultWidget = enumOptions ? 'select' : 'text';
-    const { widget = defaultWidget } = getUiOptions(uiSchema);
-
     // Do not convert the value to a locale-specific string for radio, select,
     // or hidden widgets because option matching relies on the original numeric value.
     if (widget !== 'radio' && widget !== 'select' && widget !== 'hidden') {
@@ -100,7 +115,7 @@ function NumberField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
     }
   }
 
-  return <StringField {...props} formData={displayValue} onChange={handleChange} />;
+  return <StringField {...props} uiSchema={fieldUiSchema} formData={displayValue} onChange={handleChange} />;
 }
 
 export default NumberField;

--- a/packages/core/test/NumberField.test.tsx
+++ b/packages/core/test/NumberField.test.tsx
@@ -1,5 +1,5 @@
 import { createRef } from 'react';
-import type { RJSFSchema, UiSchema } from '@rjsf/utils';
+import type { RJSFSchema, UiSchema, WidgetProps } from '@rjsf/utils';
 import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -631,6 +631,40 @@ describe('NumberField', () => {
       await user.type(node.querySelector('input')!, '2,5');
 
       expectToHaveBeenCalledWithFormData(onChange, 2.5, 'root');
+    });
+
+    it('should handle a change event using comma decimal separator with the default input', async () => {
+      const { node, onChange } = createFormComponent({
+        schema: {
+          type: 'number',
+        },
+      });
+
+      const input = node.querySelector('input')!;
+      expect(input).toHaveAttribute('type', 'text');
+
+      await user.type(input, '2,5');
+
+      expectToHaveBeenCalledWithFormData(onChange, 2.5, 'root');
+    });
+
+    it('should preserve custom format widgets', () => {
+      const CustomFormatWidget = (props: WidgetProps) => {
+        expect(props.options.inputType).toBeUndefined();
+        return <div id='custom-format-widget' />;
+      };
+
+      const { node } = createFormComponent({
+        schema: {
+          type: 'number',
+          format: 'custom-format',
+        },
+        widgets: {
+          'custom-format': CustomFormatWidget,
+        },
+      });
+
+      expect(node.querySelector('#custom-format-widget')).toBeInTheDocument();
     });
 
     it('should render with trailing zeroes using comma', async () => {


### PR DESCRIPTION
### Reasons for making this change

When the browser uses a comma decimal separator, the default `NumberField` renders a localized value into a native `input[type="number"]`. Native number inputs reject that representation and can also discard the comma while typing, so values such as `2,5` are lost or interpreted as `25`.

For `type: number` fields using the default/text widget without an explicit `inputType`, use a text input in comma-decimal locales so the existing locale normalization can receive the original value. Explicit input types and non-text widgets keep their existing behavior.

Fixes #5199

### Checklist

- [x] I'm adding or updating code
  - [x] I've added and/or updated tests.
  - [x] I've updated docs if needed
  - [x] I've updated the changelog

### Validation

- `pnpm --filter @rjsf/core exec vitest run`
- `pnpm --filter @rjsf/utils exec vitest run --coverage.enabled=false test/asNumber.test.ts test/getDecimalSeparator.test.ts test/getInputProps.test.ts`
- `pnpm --filter @rjsf/core run build`
- changed-file format/lint and pre-commit checks