### PR TITLE
Support specifying multiple types in an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 6.10.1
 
+## @rjsf/core
+
+- When additionnalProperties is set to `true`, new properties do not have any type instead of forcing it to 'string'.
+- Multiple schema type now display a type selector
+
 ## Dev / docs / playground
 
 - Fixed the size-limit report never being posted on a pull request from a fork. The comment workflow resolved the PR from its head sha, which the base repository cannot associate with a fork's commit, so it warned and skipped — leaving a green check and no comment. The measuring job now records the PR number in its artifact, and the comment workflow looks that PR up directly, accepts it only if its head sha matches the run's trusted `workflow_run` head sha, and fails loudly rather than skipping when the PR cannot be found

--- a/package.json
+++ b/package.json
@@ -78,5 +78,5 @@
     "packages/snapshot-tests",
     "packages/shadcn"
   ],
-  "packageManager": "pnpm@10.17.1"
+  "packageManager": "pnpm@12.4.0"
 }

--- a/packages/core/src/components/fields/FallbackField.tsx
+++ b/packages/core/src/components/fields/FallbackField.tsx
@@ -4,6 +4,7 @@ import {
   getTemplate,
   getUiOptions,
   hashObject,
+  JSON_SCHEMA_TYPES_NAME,
   toFieldPathId,
   TranslatableString,
   useDeepCompareMemo,
@@ -11,16 +12,21 @@ import {
 import type { JSONSchema7TypeName } from 'json-schema';
 
 /**
- * Get the schema for the type selection component.
- * @param title - The translated title for the type selection schema.
+ * Get the schema enum for the type selection component.
+ * @param type - The additionalProperties type value.
  */
-function getFallbackTypeSelectionSchema(title: string): RJSFSchema {
-  return {
-    type: 'string',
-    enum: ['string', 'number', 'boolean', 'object', 'array'],
-    default: 'string',
-    title,
-  };
+function getTypeEnum(type: JSONSchema7TypeName | JSONSchema7TypeName[] | undefined): JSONSchema7TypeName[] {
+  if (!type) {
+    return JSON_SCHEMA_TYPES_NAME;
+  }
+
+  if (Array.isArray(type)) {
+    const filteredTypes = type.filter((t) => JSON_SCHEMA_TYPES_NAME.includes(t));
+
+    return filteredTypes.length === 0 ? JSON_SCHEMA_TYPES_NAME : filteredTypes;
+  }
+
+  return JSON_SCHEMA_TYPES_NAME.includes(type) ? [type] : JSON_SCHEMA_TYPES_NAME;
 }
 
 /**
@@ -52,8 +58,18 @@ function castToNewType<T = any>(formData: T, newType: JSONSchema7TypeName): T {
       const castedNumber = Number(formData);
       return (Number.isNaN(castedNumber) ? 0 : castedNumber) as T;
     }
+    case 'integer': {
+      const castedNumber = Number(formData);
+      return (Number.isNaN(castedNumber) ? 0 : Math.round(castedNumber)) as T;
+    }
     case 'boolean':
       return Boolean(formData) as T;
+    case 'null':
+      return null as T;
+    case 'array':
+      return [] as T;
+    case 'object':
+      return {} as T;
     default:
       return formData;
   }
@@ -86,7 +102,7 @@ export default function FallbackField<
     errorSchema,
   } = props;
   const { translateString, fields, globalFormOptions } = registry;
-  const [type, setType] = useState<JSONSchema7TypeName>(getTypeOfFormData(formData));
+  const [type, setType] = useState<JSONSchema7TypeName>(() => getTypeOfFormData(formData));
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
 
@@ -95,7 +111,15 @@ export default function FallbackField<
   );
 
   const schemaTitle = translateString(TranslatableString.Type);
-  const typesOptionSchema = useMemo(() => getFallbackTypeSelectionSchema(schemaTitle), [schemaTitle]);
+  const typesOptionSchema = useMemo(
+    () => ({
+      type: 'string',
+      enum: getTypeEnum(schema.type),
+      default: 'string',
+      title: schemaTitle,
+    }),
+    [schemaTitle, schema],
+  );
 
   const onTypeChange = (newType: T | undefined) => {
     if (newType != null) {

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -70,6 +70,11 @@ function getFieldComponent<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   }
 
   const schemaType = getSchemaType(schema);
+
+  if (Array.isArray(schemaType) && schemaType.length !== 1) {
+    return fields.FallbackField;
+  }
+
   const type: string = Array.isArray(schemaType) ? schemaType[0] : schemaType || '';
 
   const schemaId = schema.$id;

--- a/packages/core/test/Form.rendering.test.tsx
+++ b/packages/core/test/Form.rendering.test.tsx
@@ -98,7 +98,7 @@ describeRepeated('Form common: rendering', (createFormComponent) => {
       expect(node.querySelector('select')).toBeInTheDocument();
       let select = node.querySelector('select')!;
       let options = node.querySelectorAll<HTMLOptionElement>('select option');
-      expect(options).toHaveLength(5);
+      expect(options).toHaveLength(7);
       expect(options[0]).toHaveTextContent('string');
       expect(options[0].selected).toBe(true);
       expect(node.querySelector<HTMLInputElement>('input[type=text]')!).toHaveAttribute('value', '123456');

--- a/packages/docs/docs/json-schema/single.md
+++ b/packages/docs/docs/json-schema/single.md
@@ -193,14 +193,15 @@ render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, docum
 
 ## Nullable types
 
-JSON Schema supports specifying multiple types in an array; however, react-jsonschema-form only supports a restricted subset of this -- nullable types, in which an element is either a given type or equal to null.
+JSON Schema supports specifying multiple types in an array.
+If an array with multiple values is given in schema type, a selector with those types will be displayed, allowing to switch between them.
 
 ```tsx
 import { RJSFSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 
 const schema: RJSFSchema = {
-  type: ['string', 'null'],
+  type: ['string', 'boolean', 'null'],
 };
 
 render(<Form schema={schema} validator={validator} />, document.getElementById('app'));

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -1,3 +1,5 @@
+import type { JSONSchema7TypeName } from 'json-schema';
+
 /** Below are the list of all the keys into various elements of a RJSFSchema or UiSchema that are used by the various
  * utility functions. In addition to those keys, there are the special `ADDITIONAL_PROPERTY_FLAG`,
  * `RJSF_REF_KEY`, and `RJSF_REF_CYCLE_KEY` Symbols that are added to a schema under certain conditions by the
@@ -55,3 +57,13 @@ export const UI_DEFINITIONS_KEY = 'ui:definitions';
  */
 export const JSON_SCHEMA_DRAFT_2019_09 = 'https://json-schema.org/draft/2019-09/schema';
 export const JSON_SCHEMA_DRAFT_2020_12 = 'https://json-schema.org/draft/2020-12/schema';
+
+export const JSON_SCHEMA_TYPES_NAME = [
+  'string',
+  'number',
+  'boolean',
+  'object',
+  'array',
+  'integer',
+  'null',
+] as const satisfies JSONSchema7TypeName[];

--- a/packages/utils/src/getSchemaType.ts
+++ b/packages/utils/src/getSchemaType.ts
@@ -1,3 +1,4 @@
+import { JSON_SCHEMA_TYPES_NAME } from './constants.ts';
 import guessType from './guessType.ts';
 import type { RJSFSchema, StrictRJSFSchema } from './types.ts';
 
@@ -16,7 +17,7 @@ import type { RJSFSchema, StrictRJSFSchema } from './types.ts';
 export default function getSchemaType<S extends StrictRJSFSchema = RJSFSchema>(
   schema: S,
 ): string | string[] | undefined {
-  let { type } = schema;
+  const { type } = schema;
 
   if (!type && schema.const) {
     return guessType(schema.const);
@@ -31,12 +32,17 @@ export default function getSchemaType<S extends StrictRJSFSchema = RJSFSchema>(
   }
 
   if (Array.isArray(type)) {
-    if (type.length === 2 && type.includes('null')) {
-      type = type.find((t) => t !== 'null');
-    } else {
-      // oxlint-disable-next-line prefer-destructuring
-      type = type[0];
+    const filteredTypes = type.filter((t) => JSON_SCHEMA_TYPES_NAME.includes(t));
+
+    if (filteredTypes.length === 1) {
+      return type[0];
     }
+
+    if (filteredTypes.length === 2 && filteredTypes.includes('null')) {
+      return filteredTypes.find((t) => t !== 'null');
+    }
+
+    return filteredTypes;
   }
 
   return type;

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -17,7 +17,6 @@ import {
 import deepEquals from '../deepEquals.ts';
 import findSchemaDefinition, { splitKeyElementFromObject } from '../findSchemaDefinition.ts';
 import getDiscriminatorFieldFromSchema from '../getDiscriminatorFieldFromSchema.ts';
-import guessType from '../guessType.ts';
 import isObject from '../isObject.ts';
 import mergeSchemas from '../mergeSchemas.ts';
 import { getByPath } from '../pathUtils.ts';
@@ -520,10 +519,10 @@ export function stubExistingAdditionalProperties<
             ...schema.additionalProperties,
           };
         } else {
-          additionalProperties = { type: guessType(formData[key]) };
+          additionalProperties = { type: undefined };
         }
       } else {
-        additionalProperties = { type: guessType(formData[key]) };
+        additionalProperties = { type: undefined };
       }
 
       // The type of our new key should match the additionalProperties value;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,161 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.4.0
+        version: 12.4.0
+
+packages:
+
+  '@pnpm/exe.android-arm64@12.4.0':
+    resolution: {integrity: sha512-sAwslzCw74OpqK2P9l39cgdrRWHSqf5wEjB58JEzeVX6wdLvaHyg9i/GeRK5Ou6PZNA3AkD4yLO3c/y7UqOf8w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@pnpm/exe.android-x64@12.4.0':
+    resolution: {integrity: sha512-Ps3Gz0OrqYjuRfhzeNqcvIow6QmNrU3BSzMxJu5rUCSl7inVUUFX2gZbNL9naQsNLoorKCdxUf4N+WI9Mr1WBg==}
+    cpu: [x64]
+    os: [android]
+
+  '@pnpm/exe.darwin-arm64@12.4.0':
+    resolution: {integrity: sha512-75EYiF8GuiTsnvP4cbZsviMBjohXUYtg2zjD4gdfhqxlU1y9Nj+KdEsbH4jfgB/FgyJSYPB2rqfmvvgLnRlVug==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.4.0':
+    resolution: {integrity: sha512-b74TzBg8lxl0lqZImGOXpRbAGcqVKX+UMckl3wG+KH52yYHI86VBJP86HbJX30HJ/EFeC6Tgbz2E4b5hhKRvdA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.freebsd-x64@12.4.0':
+    resolution: {integrity: sha512-A45d6axdQIFNyNTYZAC64wh5+6LJ6dNKhNAoNMNi/EC5y9CRfv0GL3ZYDBqpkmsN9KMAkVsFWizq/Ng6xtjnhw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@pnpm/exe.linux-arm64-musl@12.4.0':
+    resolution: {integrity: sha512-yS6DNel7twfEUoW1yka1hpQrnhRe/s1JZ1MThVfgrmNQrNaPyHxQvAihm/GtL2CM6OeMV6z5532H/W/yDjQp5g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.4.0':
+    resolution: {integrity: sha512-6npQUwq3D/WXbTgR4evApEKQ9ITznZ6Iz/dptcjBzA7+wSLTaYkK98Od2wsHCoPmEFb9tGtM+cvG82+wy0o9uA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-ppc64@12.4.0':
+    resolution: {integrity: sha512-7shJ4WytyvBEdjrbIDqx2gDAH7sr0HBDooTmnNQ7DlzcLeeGi7Yqir7gJjOTm6s9S1cVnT56IwmqnnwQMP1HTQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-riscv64@12.4.0':
+    resolution: {integrity: sha512-q03EGUFoe/oOU/67E3sEAePr3qjFu8xrsX+WOXTodcFXfO5FondC6TPs7BSwhTiV27j3jeDP56qhJP05pXn+vw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-s390x@12.4.0':
+    resolution: {integrity: sha512-GZ5YellCtNnaLe9zVj9l3avlw9CbSzExUFDh7v+tVbLfOOfkkRLpx2lsw1ytJ/nFWvxF2TO6M6Q9JDT7q8svRg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.4.0':
+    resolution: {integrity: sha512-c8YyjVL39L48tRg9i3iw3d90fN6q84UjxlgWBhplcBOpzCgmglDVkPMtEAVDC+t9iobvYzs2hJnmTqLaA87MVA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.4.0':
+    resolution: {integrity: sha512-SQVgRkcR4Xyqf8+VNbtY0rtcEnfDq48RhH30HWo2/UfqKEfle2rOMyGZOmN1DbMw4ZzG5mWYoC81O7ZqHFZcPw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.4.0':
+    resolution: {integrity: sha512-ZamXPhx0X6APZJAIkcH+K9KAsKcTYwxEgOyTQ/NXE+2UHBT9bRnSQ91sBeY6ELNd58V5cmMAkXSW5xmU+2ry+w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.4.0':
+    resolution: {integrity: sha512-b8bLaprnpYi/2zN0M3H9RDAHuxCP3fmV5agPPwdp9fIdjNSUkV7V/RC3L4oWwbZvVgYEjjFLx1RuJOdltoKP6g==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.4.0:
+    resolution: {integrity: sha512-N1NsJu1Aq0E0tlEeCfayfz67RWh0aPJAbKOAUnmk5coVjBkxNQrZd01qshCNcbPbrrOZQxWSlDdeTQU+jgVoXA==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.android-arm64@12.4.0':
+    optional: true
+
+  '@pnpm/exe.android-x64@12.4.0':
+    optional: true
+
+  '@pnpm/exe.darwin-arm64@12.4.0':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.4.0':
+    optional: true
+
+  '@pnpm/exe.freebsd-x64@12.4.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.4.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.4.0':
+    optional: true
+
+  '@pnpm/exe.linux-ppc64@12.4.0':
+    optional: true
+
+  '@pnpm/exe.linux-riscv64@12.4.0':
+    optional: true
+
+  '@pnpm/exe.linux-s390x@12.4.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.4.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.4.0':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.4.0':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.4.0':
+    optional: true
+
+  pnpm@12.4.0:
+    optionalDependencies:
+      '@pnpm/exe.android-arm64': 12.4.0
+      '@pnpm/exe.android-x64': 12.4.0
+      '@pnpm/exe.darwin-arm64': 12.4.0
+      '@pnpm/exe.darwin-x64': 12.4.0
+      '@pnpm/exe.freebsd-x64': 12.4.0
+      '@pnpm/exe.linux-arm64': 12.4.0
+      '@pnpm/exe.linux-arm64-musl': 12.4.0
+      '@pnpm/exe.linux-ppc64': 12.4.0
+      '@pnpm/exe.linux-riscv64': 12.4.0
+      '@pnpm/exe.linux-s390x': 12.4.0
+      '@pnpm/exe.linux-x64': 12.4.0
+      '@pnpm/exe.linux-x64-musl': 12.4.0
+      '@pnpm/exe.win32-arm64': 12.4.0
+      '@pnpm/exe.win32-x64': 12.4.0
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
- Support specifying multiple types in an array
- Additional Properties with empty type now fall in FallbackFieldy

### Reasons for making this change

Fixes #5238 

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
