### PR TITLE
Fix 4907: remove defaultProps merging from getWidget

### DIFF
--- a/CHANGELOG-v7.md
+++ b/CHANGELOG-v7.md
@@ -18,6 +18,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 7.0.0
 
+## @rjsf/utils
+
+- **BREAKING CHANGE** Removed `defaultProps`-based options merging from `getWidget()`; a widget passed as a component is now returned as-is instead of being wrapped in a cached `MergedWidget`. Apply option defaults inside the widget itself instead (e.g. via destructuring). The now-unused `MergedWidget` property was also removed from the `Widget` type, and the `react-is` dependency was dropped
+
 ## Dev / docs / playground
 
 - **BREAKING CHANGE** Dropped support for Node 20, 23, 25, and 24 releases before 24.11.0; `engines.node` is now `^22.18.0 || ^24.11.0 || >=26.0.0` across all packages, matching the active Node.js LTS lines, and CI now runs against Node 22, 24, and 26

--- a/packages/core/test/uiSchema.test.tsx
+++ b/packages/core/test/uiSchema.test.tsx
@@ -227,32 +227,6 @@ describe('uiSchema', () => {
         );
       });
 
-      it('should cache MergedWidget instance', () => {
-        // Cast to get to the underlying cached object without typescript warnings
-        expect((widget as GenericObjectType).MergedWidget).not.toBeDefined();
-        createFormComponent({
-          schema: {
-            type: 'string',
-          },
-          uiSchema: {
-            'ui:widget': 'widget',
-          },
-          widgets,
-        });
-        const cached = (widget as GenericObjectType).MergedWidget;
-        expect(cached).toBeDefined();
-        createFormComponent({
-          schema: {
-            type: 'string',
-          },
-          uiSchema: {
-            'ui:widget': 'widget',
-          },
-          widgets,
-        });
-        expect((widget as GenericObjectType).MergedWidget).toBe(cached);
-      });
-
       it('should render merged ui:widget options for widget referenced as function', () => {
         const { node } = createFormComponent({
           schema,

--- a/packages/docs/docs/advanced-customization/custom-widgets-fields.md
+++ b/packages/docs/docs/advanced-customization/custom-widgets-fields.md
@@ -251,7 +251,8 @@ This is useful if you expose the `uiSchema` as pure JSON, which can't carry func
 
 ### Custom widget options
 
-If you need to pass options to your custom widget, you can add a `ui:options` object containing those properties. If the widget has `defaultProps`, the options will be merged with the (optional) options object from `defaultProps`:
+If you need to pass options to your custom widget, you can add a `ui:options` object containing those properties.
+To provide defaults for options that aren't set via `ui:options`, apply them inside the widget itself:
 
 ```tsx
 import { RJSFSchema, UiSchema, WidgetProps } from '@rjsf/utils';
@@ -263,15 +264,9 @@ const schema: RJSFSchema = {
 
 function MyCustomWidget(props: WidgetProps) {
   const { options } = props;
-  const { color, backgroundColor } = options;
+  const { color = 'red', backgroundColor } = options;
   return <input style={{ color, backgroundColor }} />;
 }
-
-MyCustomWidget.defaultProps = {
-  options: {
-    color: 'red',
-  },
-};
 
 const uiSchema: UiSchema = {
   'ui:widget': MyCustomWidget,

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -655,9 +655,9 @@ Any `globalOptions` will always be returned, unless they are overridden by optio
 ### getWidget&lt;T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>()
 
 Given a schema representing a field to render and either the name or actual `Widget` implementation, returns the
-React component that is used to render the widget. If the `widget` is already a React component, then it is wrapped
-with a `MergedWidget`. Otherwise an attempt is made to look up the widget inside of the `registeredWidgets` map based
-on the schema type and `widget` name. If no widget component can be found an `Error` is thrown.
+React component that is used to render the widget. If the `widget` is already a React component, it is returned
+as-is. Otherwise an attempt is made to look up the widget inside of the `registeredWidgets` map based on the
+schema type and `widget` name. If no widget component can be found an `Error` is thrown.
 
 #### Parameters
 

--- a/packages/docs/docs/migration-guides/v7.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v7.x upgrade guide.md
@@ -27,6 +27,18 @@ Dropping Node 20 also let us upgrade `pnpm` past version 10, which had been pinn
 RJSF is no longer actively supporting React version < 19.x.
 React 19 is officially supported on all the themes.
 
+### Removal of `defaultProps` support on widgets BREAKING CHANGE
+
+`getWidget()` no longer merges a widget component's (deprecated) `defaultProps.options` into the `options` it renders with. React 19 removed `defaultProps` support for function components, so this merging behavior was already broken for function widgets there and only ever worked for `forwardRef`/`memo`-wrapped ones.
+
+If you relied on `defaultProps` to supply default `options` for a custom widget, apply the defaults inside the widget itself instead, e.g. via destructuring defaults: `const { color = 'red' } = options;`. See [Custom widget options](../advanced-customization/custom-widgets-fields.md#custom-widget-options).
+
+### `Widget` type BREAKING CHANGE
+
+The `Widget<T, S, F>` type in `@rjsf/utils` is now a plain `ComponentType<WidgetProps<T, S, F>>` alias. It no longer carries the optional `MergedWidget` property, which `getWidget()` used to stamp onto a widget component to cache the wrapper it created for merging `defaultProps.options` (see above). That caching is gone along with the merging behavior it supported.
+
+This is only a breaking change if you referenced `Widget['MergedWidget']` directly, or otherwise depended on the `Widget` type being an intersection type rather than a plain component type.
+
 ## New Features
 
 ### New types

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -70,12 +70,10 @@
     "@x0k/json-schema-merge": "^1.0.3",
     "fast-equals": "^6.0.0",
     "fast-uri": "^4.1.4",
-    "jsonpointer": "^5.0.1",
-    "react-is": "^18.3.1"
+    "jsonpointer": "^5.0.1"
   },
   "devDependencies": {
     "@types/json-schema": "^7.0.15",
-    "@types/react-is": "^18.3.1",
     "deep-freeze-es6": "^5.0.0"
   },
   "publishConfig": {

--- a/packages/utils/src/getWidget.tsx
+++ b/packages/utils/src/getWidget.tsx
@@ -1,6 +1,3 @@
-import { createElement } from 'react';
-import ReactIs from 'react-is';
-
 import getSchemaType from './getSchemaType.ts';
 import type { FormContextType, RJSFSchema, Widget, RegistryWidgetsType, StrictRJSFSchema } from './types.ts';
 
@@ -59,33 +56,10 @@ const widgetMap: Record<string, Record<string, string>> = {
   },
 };
 
-/** Wraps the given widget with stateless functional component that will merge any `defaultProps.options` with the
- * `options` that are provided in the props. It will add the wrapper component as a `MergedWidget` property onto the
- * `Widget` so that future attempts to wrap `AWidget` will return the already existing wrapper.
- *
- * @param AWidget - A widget that will be wrapped or one that is already wrapped
- * @returns - The wrapper widget
- */
-function mergeWidgetOptions<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
-  AWidget: Widget<T, S, F>,
-) {
-  let { MergedWidget } = AWidget;
-  // cache return value as property of widget for proper react reconciliation
-  if (!MergedWidget) {
-    // oxlint-disable-next-line typescript/no-deprecated
-    const defaultOptions = AWidget.defaultProps?.options || {};
-    MergedWidget = ({ options, ...props }) => <AWidget options={{ ...defaultOptions, ...options }} {...props} />;
-    // The mutation is deliberate: the wrapper is cached on the widget itself for React reconciliation
-    // oxlint-disable-next-line no-param-reassign
-    AWidget.MergedWidget = MergedWidget;
-  }
-  return MergedWidget;
-}
-
 /** Given a schema representing a field to render and either the name or actual `Widget` implementation, returns the
- * React component that is used to render the widget. If the `widget` is already a React component, then it is wrapped
- * with a `MergedWidget`. Otherwise an attempt is made to look up the widget inside of the `registeredWidgets` map based
- * on the schema type and `widget` name. If no widget component can be found an `Error` is thrown.
+ * React component that is used to render the widget. If the `widget` is already a React component, it is returned
+ * as-is. Otherwise an attempt is made to look up the widget inside of the `registeredWidgets` map based on the
+ * schema type and `widget` name. If no widget component can be found an `Error` is thrown.
  *
  * @param schema - The schema for the field
  * @param [widget] - Either the name of the widget OR a `Widget` implementation to use
@@ -100,12 +74,8 @@ export default function getWidget<T = any, S extends StrictRJSFSchema = RJSFSche
 ): Widget<T, S, F> {
   const type = getSchemaType(schema);
 
-  if (
-    typeof widget === 'function' ||
-    (widget && ReactIs.isForwardRef(createElement(widget))) ||
-    ReactIs.isMemo(widget)
-  ) {
-    return mergeWidgetOptions<T, S, F>(widget as Widget<T, S, F>);
+  if (widget && typeof widget !== 'string') {
+    return widget;
   }
 
   if (typeof widget !== 'string') {

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1027,12 +1027,7 @@ export interface WidgetProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F
 /** The definition of a React-based Widget component */
 export type Widget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any> = ComponentType<
   WidgetProps<T, S, F>
-> & {
-  /** A cached wrapper component that merges the widget's `defaultProps.options` into its props, stamped onto the
-   * widget by `getWidget()` so that repeated lookups return the same component for proper React reconciliation
-   */
-  MergedWidget?: Widget<T, S, F>;
-};
+>;
 
 /** The properties that are passed to the BaseInputTemplate */
 export interface BaseInputTemplateProps<

--- a/packages/utils/test/getWidget.test.tsx
+++ b/packages/utils/test/getWidget.test.tsx
@@ -35,37 +35,28 @@ const schemaStr = JSON.stringify(schema);
 
 const TestRefWidget: Widget = forwardRef<HTMLSpanElement, Partial<WidgetProps>>(
   (props: Partial<WidgetProps>, ref: ForwardedRef<HTMLSpanElement>) => {
-    const { options } = props;
+    const { id = 'test-id', ...options } = props.options ?? {};
     return (
-      <span {...options} ref={ref}>
+      <span id={id} {...options} ref={ref}>
         test
       </span>
     );
   },
 );
 
-// oxlint-disable-next-line typescript/no-deprecated
-TestRefWidget.defaultProps = {
-  options: { id: 'test-id' },
-};
-
 function TestWidget(props: WidgetProps) {
   const { options } = props;
   return <div {...options}>test</div>;
 }
 
-TestWidget.defaultProps = {
-  id: 'foo',
-};
-
-function TestWidgetDefaults(props: WidgetProps) {
-  const { options } = props;
-  return <div {...options}>test</div>;
+function TestWidgetWithDefaultOptions(props: WidgetProps) {
+  const { color = 'yellow', ...options } = props.options;
+  return (
+    <div color={color} {...options}>
+      test
+    </div>
+  );
 }
-
-TestWidgetDefaults.defaultProps = {
-  options: { color: 'yellow' },
-};
 
 const widgetProps: WidgetProps = {
   id: '',
@@ -119,14 +110,14 @@ describe('getWidget()', () => {
   });
 
   it('should return `SelectWidget` for boolean type', () => {
-    const registry = { SelectWidget: TestWidgetDefaults };
+    const registry = { SelectWidget: TestWidgetWithDefaultOptions };
     const TheWidget = getWidget(subschema, 'select', registry);
     const { asFragment } = render(<TheWidget {...widgetProps} options={{ color: 'green' }} />);
     expect(asFragment()).toMatchSnapshot();
   });
 
   it('should not fail on correct component', () => {
-    const TheWidget = getWidget(schema, TestWidgetDefaults);
+    const TheWidget = getWidget(schema, TestWidgetWithDefaultOptions);
     const { asFragment } = render(<TheWidget {...widgetProps} />);
     expect(asFragment()).toMatchSnapshot();
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -759,16 +759,10 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
-      react-is:
-        specifier: ^18.3.1
-        version: 18.3.1
     devDependencies:
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
-      '@types/react-is':
-        specifier: ^18.3.1
-        version: 18.3.1
       deep-freeze-es6:
         specifier: ^5.0.0
         version: 5.0.0
@@ -5474,9 +5468,6 @@ packages:
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
       '@types/react': ^18.0.0
-
-  '@types/react-is@18.3.1':
-    resolution: {integrity: sha512-zts4lhQn5ia0cF/y2+3V6Riu0MAfez9/LJYavdM8TvcVl+S91A/7VWxyBT8hbRuWspmuCaiGI0F41OJYGrKhRA==}
 
   '@types/react-router-config@5.0.11':
     resolution: {integrity: sha512-WmSAg7WgqW7m4x8Mt4N6ZyKz0BubSj/2tVUMsAHp+Yd2AMwcSbeFq9WympT19p5heCFmF97R9eD5uUR/t4HEqw==}
@@ -16952,10 +16943,6 @@ snapshots:
   '@types/range-parser@1.2.7': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.31)':
-    dependencies:
-      '@types/react': 18.3.31
-
-  '@types/react-is@18.3.1':
     dependencies:
       '@types/react': 18.3.31
 


### PR DESCRIPTION
### Reasons for making this change

Fixes #4907

React 19 dropped defaultProps support for function components, so getWidget()'s merging of a widget's defaultProps.options into its rendered options was already broken there and only ever worked for forwardRef/memo-wrapped widgets. Remove the merging entirely along with the now-unused react-is dependency and the MergedWidget property on the Widget type; widgets should apply their own option defaults via destructuring instead.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
