### PR TITLE
ci: build the size-limit measurement with the build target, not build:ts

### DIFF
--- a/.github/size-limit/.size-limit.js
+++ b/.github/size-limit/.size-limit.js
@@ -26,9 +26,9 @@ const PACKAGES = {
 const released = readdirSync(join(ROOT, 'packages'))
   .filter((dir) => existsSync(join(ROOT, 'packages', dir, 'package.json')))
   .map((dir) => ({ dir, pkg: JSON.parse(readFileSync(join(ROOT, 'packages', dir, 'package.json'), 'utf8')) }))
-  // build:ts emits the lib/ entry point being measured; a package without one
-  // (@rjsf/snapshot-tests) ships no bundle to measure.
-  .filter(({ pkg }) => !pkg.private && pkg.scripts?.['build:ts'])
+  // @rjsf/snapshot-tests is a test harness for the themes, not a bundle a
+  // consumer installs.
+  .filter(({ pkg }) => !pkg.private && pkg.name !== '@rjsf/snapshot-tests')
   .sort((a, b) => a.pkg.name.localeCompare(b.pkg.name));
 
 module.exports = released.flatMap(({ dir, pkg }) => {

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -27,15 +27,14 @@ jobs:
             .github/size-limit/pnpm-lock.yaml
       - name: Measure PR head
         run: |
-          # docs and playground have no build:ts and pull in docusaurus and vite;
+          # docs and playground ship no lib/ and pull in docusaurus and vite;
           # skipping them is the bulk of the install.
           pnpm install --frozen-lockfile --filter '!@rjsf/docs' --filter '!@rjsf/playground'
           pnpm install --frozen-lockfile --ignore-workspace --dir .github/size-limit
           echo ${{ github.event.pull_request.number }} > "$RUNNER_TEMP/pr_number"
-          # size-limit measures lib/, not the cjs/esm/umd bundles, and only the
-          # released packages declare build:ts. Safe to let nx cache: lib/ is a
-          # declared build:ts output in nx.json, so a hit restores it to disk.
-          pnpm exec nx run-many --target=build:ts --all
+          # size-limit measures each package's lib/. Safe to let nx cache: lib/
+          # is a declared build output in nx.json, so a hit restores it to disk.
+          pnpm exec nx run-many --target=build --all --exclude=@rjsf/docs,@rjsf/playground
           # size-limit exits non-zero when a budget is exceeded but still emits
           # JSON; record the outcome and enforce it at the end so the report
           # comment is produced either way.
@@ -58,7 +57,7 @@ jobs:
             [ -f .github/size-limit/.size-limit.js ] &&
             pnpm install --frozen-lockfile --filter '!@rjsf/docs' --filter '!@rjsf/playground' &&
             pnpm install --frozen-lockfile --ignore-workspace --dir .github/size-limit &&
-            pnpm exec nx run-many --target=build:ts --all; then
+            pnpm exec nx run-many --target=build --all --exclude=@rjsf/docs,@rjsf/playground; then
             pnpm --dir .github/size-limit exec size-limit --json > "$RUNNER_TEMP/base.json" || echo '[]' > "$RUNNER_TEMP/base.json"
           else
             echo '[]' > "$RUNNER_TEMP/base.json"


### PR DESCRIPTION
### Reasons for making this change

Ports the size-limit workflow change from #5255 to `main`, as asked in https://github.com/rjsf-team/react-jsonschema-form/pull/5255#discussion_r3980636353.

The size job built with `nx run-many --target=build:ts --all` and its config measured only packages that declare a `build:ts` script. On `v7`, #5255 replaces `build:ts` with a single `build` step, so the job built nothing there and size-limit failed on a missing `lib/`. Landing the same fix on `main` keeps `.github/workflows/size-limit.yml` and `.github/size-limit/.size-limit.js` identical on both branches, so the next main-to-v7 merge has nothing to resolve in them.

- Both nx invocations (head and base) run `--target=build --all --exclude=@rjsf/docs,@rjsf/playground`. The exclude is explicit because the job deliberately skips installing those two packages.
- The size-limit config measures every non-private package except `@rjsf/snapshot-tests`, instead of keying on the `build:ts` script name.

On `main` the `build` target also produces the `dist/` bundles that size-limit does not read, so the measurement build takes longer: 29 s instead of 14 s locally, cold, with the nx cache disabled. That goes away once `v7` merges.

Verified locally on `main`: 16 projects build, size-limit reports 29 entries, none over budget.

### Checklist

- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. Not applicable, CI workflow only.
  - [x] I've updated docs if needed. Not applicable.
  - [x] I've updated the changelog. Not applicable, no package change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)