### PR TITLE
chore(antd,mui)!: drop support for antd 5 and MUI 7

### DIFF
--- a/CHANGELOG-v7.md
+++ b/CHANGELOG-v7.md
@@ -18,10 +18,9 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 7.0.0
 
-
 ## @rjsf/antd
 
-- **BREAKING CHANGE** Dropped support for `antd` version 5; the peer dependency range is now `>6.3.5`. `ErrorList` and `CyclicSchemaExpandTemplate` use of `Alert` always passing `title` prop now
+- **BREAKING CHANGE** Dropped support for `antd` version 5; the peer dependency range is now `^6.3.6`. `ErrorList` and `CyclicSchemaExpandTemplate` use of `Alert` always passing `title` prop now. The `6.3.6` floor isn't arbitrary: antd 6.0.0-6.3.5 crash `@rjsf/antd` forms on first render (`getRealHeight` destructuring a `null` node), fixed upstream in [ant-design/ant-design#57636](https://github.com/ant-design/ant-design/pull/57636)
 
 ## @rjsf/chakra-ui
 

--- a/CHANGELOG-v7.md
+++ b/CHANGELOG-v7.md
@@ -18,16 +18,21 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 7.0.0
 
-## @rjsf/core
 
-- **BREAKING CHANGE:** `GridType` and `Operators` are now `as const` objects with same-named union types instead of `enum`s, so the source is valid under Node's type stripping. Values and `GridType.ROW`-style member access are unchanged; code that used a member as a type must write `typeof GridType.ROW` instead of `GridType.ROW` ([#5244](https://github.com/rjsf-team/react-jsonschema-form/pull/5244))
-- **BREAKING CHANGE** `withTheme()` now returns a plain function component instead of a `forwardRef`-wrapped one, and `FormProps['onSubmit']`'s event parameter is now typed as `SubmitEvent<any>` instead of the deprecated `FormEvent<any>`
-- **BREAKING CHANGE:** Removed deprecated `Form` APIs: the `getUsedFormData()` and `getFieldNames()` instance methods (no direct replacement), the `omitExtraData()` instance method (use `SchemaUtils.omitExtraData(schema, formData)` instead), the `removeEmptyOptionalObjects` prop (already a no-op; use `omitExtraData`, which now prunes empty optional objects itself), and `boolean` values for the `liveValidate`/`liveOmit` props (use `'onChange'` in place of `true`, or omit the prop in place of `false`). Also removed the `ui:rootFieldId` uiSchema directive; use the `Form.idPrefix` prop instead
+## @rjsf/antd
+
+- **BREAKING CHANGE** Dropped support for `antd` version 5; the peer dependency range is now `>6.3.5`. `ErrorList` and `CyclicSchemaExpandTemplate` use of `Alert` always passing `title` prop now
 
 ## @rjsf/chakra-ui
 
 - Converted the internal `forwardRef`-wrapped UI primitives (`Field`, `Slider`, `Alert`, `NumberInputRoot`, `Checkbox`, `Radio`, `CloseButton`, and the `Select` family) to plain function components that accept `ref` as a regular prop, now that React 19 supports this natively
 - `SelectRoot` is now a plain generic function (`function SelectRoot<T extends CollectionItem>(...)`) instead of a non-generic arrow function cast to `ChakraSelect.RootComponent`, removing the cast and the wrapping parens it required
+
+## @rjsf/core
+
+- **BREAKING CHANGE:** `GridType` and `Operators` are now `as const` objects with same-named union types instead of `enum`s, so the source is valid under Node's type stripping. Values and `GridType.ROW`-style member access are unchanged; code that used a member as a type must write `typeof GridType.ROW` instead of `GridType.ROW` ([#5244](https://github.com/rjsf-team/react-jsonschema-form/pull/5244))
+- **BREAKING CHANGE** `withTheme()` now returns a plain function component instead of a `forwardRef`-wrapped one, and `FormProps['onSubmit']`'s event parameter is now typed as `SubmitEvent<any>` instead of the deprecated `FormEvent<any>`
+- **BREAKING CHANGE:** Removed deprecated `Form` APIs: the `getUsedFormData()` and `getFieldNames()` instance methods (no direct replacement), the `omitExtraData()` instance method (use `SchemaUtils.omitExtraData(schema, formData)` instead), the `removeEmptyOptionalObjects` prop (already a no-op; use `omitExtraData`, which now prunes empty optional objects itself), and `boolean` values for the `liveValidate`/`liveOmit` props (use `'onChange'` in place of `true`, or omit the prop in place of `false`). Also removed the `ui:rootFieldId` uiSchema directive; use the `Form.idPrefix` prop instead
 
 ## @rjsf/mantine
 
@@ -39,6 +44,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/mui
 
 - Updated the README, which said "Material UI 7 requires React 18, so you will need to upgrade" — the peer requirement is now React 19
+- **BREAKING CHANGE** Dropped support for `@mui/material`/`@mui/icons-material` version 7; the peer dependency range is now `^9.0.0`
 
 ## @rjsf/react-bootstrap
 

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -38,7 +38,7 @@
     "@ant-design/icons": "^6.0.0",
     "@rjsf/core": "workspace:^",
     "@rjsf/utils": "workspace:^",
-    "antd": ">6.3.5",
+    "antd": "^6.3.6",
     "dayjs": "^1.8.0",
     "react": ">=19"
   },

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -38,7 +38,7 @@
     "@ant-design/icons": "^6.0.0",
     "@rjsf/core": "workspace:^",
     "@rjsf/utils": "workspace:^",
-    "antd": "^5 || >6.3.5",
+    "antd": ">6.3.5",
     "dayjs": "^1.8.0",
     "react": ">=19"
   },

--- a/packages/antd/src/templates/CyclicSchemaExpandTemplate/index.tsx
+++ b/packages/antd/src/templates/CyclicSchemaExpandTemplate/index.tsx
@@ -1,8 +1,6 @@
 import type { CyclicSchemaExpandProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
 import { ID_KEY, TranslatableString } from '@rjsf/utils';
-import { Alert, Button, Space, version } from 'antd';
-
-const antdMajor = parseInt(version.split('.')[0], 10);
+import { Alert, Button, Space } from 'antd';
 
 /** The `CyclicSchemaExpandTemplate` is the template to use to render the cyclic schema expand message and controls
  *
@@ -17,15 +15,10 @@ export default function CyclicSchemaExpandTemplate<
   const { translateString } = registry;
   const buttonId = `${fieldPathId[ID_KEY]}-button`;
 
-  const headerProp =
-    antdMajor >= 6
-      ? { title: translateString(TranslatableString.CycleDetected, [name]) }
-      : { message: translateString(TranslatableString.CycleDetected, [name]) };
-
   return (
     <Alert
       type='warning'
-      {...headerProp}
+      title={translateString(TranslatableString.CycleDetected, [name])}
       action={
         <Space>
           <Button id={buttonId} size='small' type='default' onClick={() => onExpand(fieldPathId[ID_KEY])}>

--- a/packages/antd/src/templates/ErrorList/index.tsx
+++ b/packages/antd/src/templates/ErrorList/index.tsx
@@ -1,9 +1,7 @@
 import { ExclamationCircleOutlined } from '@ant-design/icons';
 import type { ErrorListProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
 import { TranslatableString } from '@rjsf/utils';
-import { Alert, Space, theme, version } from 'antd';
-
-const antdMajor = parseInt(version.split('.')[0], 10);
+import { Alert, Space, theme } from 'antd';
 
 /** The `ErrorList` component is the template that renders the all the errors associated with the fields in the `Form`
  *
@@ -41,11 +39,12 @@ export default function ErrorList<T = any, S extends StrictRJSFSchema = RJSFSche
     </ul>
   );
 
-  // Deal with the two versions of antd that we support (v5, v6). In RJSF v7, we will drop support for antd 5, so clean this up
-  const headerProp =
-    antdMajor >= 6
-      ? { title: translateString(TranslatableString.ErrorsLabel) }
-      : { message: translateString(TranslatableString.ErrorsLabel) };
-
-  return <Alert className='panel panel-danger errors' description={renderErrors()} type='error' {...headerProp} />;
+  return (
+    <Alert
+      className='panel panel-danger errors'
+      description={renderErrors()}
+      type='error'
+      title={translateString(TranslatableString.ErrorsLabel)}
+    />
+  );
 }

--- a/packages/docs/docs/migration-guides/v7.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v7.x upgrade guide.md
@@ -24,6 +24,7 @@ This theme has been removed as it does not support React 19 and has become unmai
 #### @rjsf/antd
 
 Version 7 is dropping official support for `antd` version 5. You must upgrade to `antd` 6.3.6 or later.
+The `6.3.6` floor isn't arbitrary: `antd` 6.0.0-6.3.5 crash `@rjsf/antd` forms on first render, fixed upstream in [ant-design/ant-design#57636](https://github.com/ant-design/ant-design/pull/57636)
 
 #### @rjsf/mui
 

--- a/packages/docs/docs/migration-guides/v7.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v7.x upgrade guide.md
@@ -21,6 +21,14 @@ This theme has been removed as it does not support React 19 and has become unmai
 
 ### Theme version support changes
 
+#### @rjsf/antd
+
+Version 7 is dropping official support for `antd` version 5. You must upgrade to `antd` 6.3.6 or later.
+
+#### @rjsf/mui
+
+Version 7 is dropping official support for `@mui/material`/`@mui/icons-material` version 7. You must upgrade to version 9.
+
 #### @rjsf/mantine
 
 Version 7 is dropping official support for `mantine` version 8. You must upgrade to version 9, which requires React 19.2 or later.

--- a/packages/mui/README.md
+++ b/packages/mui/README.md
@@ -47,14 +47,14 @@
 
 ## About The Project
 
-Exports `MUI` version 5 theme, fields, and widgets for `react-jsonschema-form`.
+Exports `MUI` version 9 theme, fields, and widgets for `react-jsonschema-form`.
 
 [<img src="./screenshot.png" alt="product-screenshot" width="800" />](https://rjsf-team.github.io/@rjsf/mui)
 
 ### Built With
 
 - [react-jsonschema-form](https://github.com/rjsf-team/react-jsonschema-form/)
-- [Material UI 7](https://mui.com/)
+- [Material UI 9](https://mui.com/)
 - [TypeScript](https://www.typescriptlang.org/)
 
 <!-- GETTING STARTED -->
@@ -65,8 +65,8 @@ Exports `MUI` version 5 theme, fields, and widgets for `react-jsonschema-form`.
 
 NOTE: This theme requires React 19, so you will need to upgrade if you are on an older version
 
-- `@mui/material >= 7`
-- `@mui/icons-material >= 7`
+- `@mui/material >= 9`
+- `@mui/icons-material >= 9`
 - `@emotion/react >= 11`
 - `@emotion/styled >= 11`
 - `@rjsf/core >= 6`

--- a/packages/mui/README.md
+++ b/packages/mui/README.md
@@ -38,7 +38,7 @@
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
 - [Usage](#usage)
-  - [Material UI version 7](#material-ui-version-7)
+  - [Material UI version 9](#material-ui-version-9)
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
 - [Contact](#contact)
@@ -87,7 +87,7 @@ yarn add @rjsf/mui
 
 ## Usage
 
-### Material UI version 7
+### Material UI version 9
 
 ```js
 import Form from '@rjsf/mui';
@@ -127,7 +127,6 @@ You can pass MUI-specific props (like `sx`, `rjsfSlotProps`, `variant`, etc.) di
 ```
 
 For more details on available properties and `rjsfSlotProps` targets, see the [Material UI Customization Documentation](https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/themes/mui/uiSchema/).
-
 
 <!-- ROADMAP -->
 

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -5,7 +5,7 @@
   "types": "./lib/index.d.ts",
   "type": "module",
   "sideEffects": false,
-  "description": "Material UI 7 theme, fields and widgets for react-jsonschema-form",
+  "description": "Material UI 9 theme, fields and widgets for react-jsonschema-form",
   "exports": {
     ".": "./lib/index.js",
     "./lib": "./lib/index.js",
@@ -36,8 +36,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.7.0",
     "@emotion/styled": "^11.6.0",
-    "@mui/icons-material": "^7.0.0 || ^9.0.0",
-    "@mui/material": "^7.0.0 || ^9.0.0",
+    "@mui/icons-material": "^9.0.0",
+    "@mui/material": "^9.0.0",
     "@rjsf/core": "workspace:^",
     "@rjsf/utils": "workspace:^",
     "react": ">=19"


### PR DESCRIPTION
### Reasons for making this change

Removes the runtime antd-major detection in @rjsf/antd's ErrorList and CyclicSchemaExpandTemplate (used to pick Alert's message vs title prop), now that we only support antd 6.3.6+. Tightens @rjsf/mui's peer range to MUI 9 only, since the code never actually branched on MUI 7 vs 9 - the wide peer range had nothing behind it.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
