### PR TITLE
feat(core)!: remove the private _internalFormWrapper prop

### DIFF
--- a/CHANGELOG-v7.md
+++ b/CHANGELOG-v7.md
@@ -34,6 +34,7 @@ should change the heading of the (upcoming) version to include a major version b
 - **BREAKING CHANGE:** Removed deprecated `Form` APIs: the `getUsedFormData()` and `getFieldNames()` instance methods (no direct replacement), the `omitExtraData()` instance method (use `SchemaUtils.omitExtraData(schema, formData)` instead), the `removeEmptyOptionalObjects` prop (already a no-op; use `omitExtraData`, which now prunes empty optional objects itself), and `boolean` values for the `liveValidate`/`liveOmit` props (use `'onChange'` in place of `true`, or omit the prop in place of `false`). Also removed the `ui:rootFieldId` uiSchema directive; use the `Form.idPrefix` prop instead
 - **BREAKING CHANGE** Replaced the `extraErrorsBlockSubmit` prop with `extraErrorsAreWarnings`, inverting the default: `extraErrors` now block form submission unless `extraErrorsAreWarnings` is set to `true`, fixing [#4964](https://github.com/rjsf-team/react-jsonschema-form/issues/4964)
 - Fixed `validateFormWithFormData()` (used by form submission and the `validateForm()` instance method) silently dropping a `customError` raised by a field/widget's `onChange` on submit; it's now merged in and blocks submission the same way schema and (non-warning) `extraErrors` do
+- **BREAKING CHANGE:** Removed the private `_internalFormWrapper` prop from `FormProps` and `ThemeProps`; its only consumer was the removed `@rjsf/semantic-ui` theme. Use `tagName` to render a different element in place of `<form>`
 
 ## @rjsf/mantine
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -240,23 +240,6 @@ export interface FormProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   /** Optional function that allows for custom merging of `allOf` schemas
    */
   experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>;
-  // Private
-  /**
-   * _internalFormWrapper lets a theme provide a custom wrapper around `<Form />` to support the proper rendering
-   * of that theme. To use this prop, one must pass a component that takes two
-   * props: `children` and `as`. That component, at minimum, should render the `children` inside of a <form /> tag
-   * unless `as` is provided, in which case, use the `as` prop in place of `<form />`.
-   * i.e.:
-   * ```
-   * export default function InternalForm({ children, as }) {
-   *   const FormTag = as || 'form';
-   *   return <FormTag>{children}</FormTag>;
-   * }
-   * ```
-   *
-   * Use at your own risk as this prop is private and may change at any time without notice.
-   */
-  _internalFormWrapper?: ElementType;
   /** Support receiving a React ref to the Form
    */
   ref?: Ref<Form<T, S, F>>;
@@ -358,8 +341,8 @@ export default class Form<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 > extends Component<FormProps<T, S, F>, FormState<T, S, F>> {
-  /** The ref used to hold the `form` element, this needs to be `any` because `tagName` or `_internalFormWrapper` can
-   * provide any possible type here
+  /** The ref used to hold the `form` element, this needs to be `any` because `tagName` can provide any possible type
+   * here
    */
   formElement: RefObject<any>;
 
@@ -1414,8 +1397,8 @@ export default class Form<
     return this.validateFormWithFormData(newFormData);
   }
 
-  /** Renders the `Form` fields inside the <form> | `tagName` or `_internalFormWrapper`, rendering any errors if
-   * needed along with the submit button or any children of the form.
+  /** Renders the `Form` fields inside the <form> | `tagName`, rendering any errors if needed along with the submit
+   * button or any children of the form.
    */
   render() {
     const {
@@ -1434,16 +1417,12 @@ export default class Form<
       disabled,
       readonly,
       showErrorList = 'top',
-      _internalFormWrapper,
     } = this.props;
 
     const { schema, uiSchema, formData, errorSchema, fieldPathId, registry } = this.state;
     const { SchemaField: SchemaFieldComponent } = registry.fields;
     const { SubmitButton } = registry.templates.ButtonTemplates;
-    // A theme's `_internalFormWrapper` can take an `as` prop that is the PropTypes.elementType to use for the
-    // inner tag, so we'll need to pass `tagName` along if it is provided.
-    const as = _internalFormWrapper ? tagName : undefined;
-    const FormTag = _internalFormWrapper || tagName || 'form';
+    const FormTag = tagName || 'form';
 
     let { [SUBMIT_BTN_OPTIONS_KEY]: submitOptions = {} } = getUiOptions<T, S, F>(uiSchema);
     if (disabled) {
@@ -1464,7 +1443,6 @@ export default class Form<
         acceptCharset={acceptCharset}
         noValidate={noHtml5Validate}
         onSubmit={this.onSubmit}
-        as={as}
         ref={this.formElement}
       >
         {showErrorList === 'top' && this.renderErrors(registry)}

--- a/packages/core/src/withTheme.tsx
+++ b/packages/core/src/withTheme.tsx
@@ -9,7 +9,7 @@ import Form from './components/Form.tsx';
  */
 export type ThemeProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any> = Pick<
   FormProps<T, S, F>,
-  'fields' | 'templates' | 'widgets' | '_internalFormWrapper'
+  'fields' | 'templates' | 'widgets'
 >;
 
 /** A Higher-Order component that creates a wrapper around a `Form` with the overrides from the `WithThemeProps`.

--- a/packages/docs/docs/migration-guides/v7.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v7.x upgrade guide.md
@@ -13,6 +13,10 @@ The CommonJS (`dist/index.cjs`), bundled ESM (`dist/<name>.esm.js`) and UMD (`di
 - Deep imports through `@rjsf/<package>/lib/<file>.js` are unchanged.
 - If you loaded a UMD bundle from a CDN with a `<script>` tag, switch to an ESM CDN (for example `import Form from 'https://esm.sh/@rjsf/core'`) or a bundler.
 
+### `_internalFormWrapper` removed BREAKING CHANGE
+
+The private `_internalFormWrapper` prop, and its entry in the `ThemeProps` a theme passes to `withTheme()`, have been removed. It existed so `@rjsf/semantic-ui` could wrap the `<form>` element in that library's own `Form` component, and it was the only theme that ever used it. Use the public `tagName` prop to render a different element in place of `<form>`.
+
 ### Theme removals
 
 #### @rjsf/semantic-ui


### PR DESCRIPTION
### Reasons for making this change

`_internalFormWrapper` was a private `FormProps`/`ThemeProps` prop that let a theme wrap the `<form>` element in its own component. Its only consumer was `@rjsf/semantic-ui`, which v7 already removes, so the prop is dead weight in the `Form` render path and in the theme type.

Split out of #5266 so that PR is only about theme composition.

### Changes

- Removed `_internalFormWrapper` from `FormProps` and from the `ThemeProps` pick in `withTheme()`.
- `Form.render()` renders `tagName || 'form'` directly and no longer forwards an `as` prop.
- Migration guide section and `CHANGELOG-v7.md` entry pointing users at the public `tagName` prop.

### Checklist

- [x] **I'm updating documentation**
- [x] **I'm adding or updating code**
  - [x] I've verified the existing tests pass (`@rjsf/core`: 36 files, 1967 tests) and root `typecheck` is clean
  - [x] I've updated the migration guide
  - [x] I've updated `CHANGELOG-v7.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)