### PR TITLE
feat(core)!: move getTestRegistry to @rjsf/core/testing

### DIFF
--- a/.github/size-limit/.size-limit.js
+++ b/.github/size-limit/.size-limit.js
@@ -48,7 +48,7 @@ module.exports = released.flatMap(({ dir, pkg }) => {
   const optionalPeers = Object.keys(pkg.peerDependenciesMeta ?? {});
   const peers = [...Object.keys(pkg.peerDependencies ?? {}), 'react-dom'].filter((dep) => !optionalPeers.includes(dep));
   const { installed, own, canaries = [], nodeOnly = [] } = PACKAGES[pkg.name] ?? {};
-  const subpaths = Object.entries(pkg.exports).filter(
+  const subpaths = Object.entries(pkg.exports ?? {}).filter(
     ([key]) => key !== '.' && !key.startsWith('./lib') && !nodeOnly.includes(key),
   );
 

--- a/.github/size-limit/.size-limit.js
+++ b/.github/size-limit/.size-limit.js
@@ -6,8 +6,8 @@ const ROOT = join(__dirname, '..', '..');
 // Budgets only where one already existed; elsewhere the PR comment's delta column
 // catches a regression without the bump commits a per-theme budget invites.
 // Canaries are single-export imports that fail if tree-shaking regresses.
-// Every export subpath is measured as its own entry, except the Node-only ones.
-const NODE_ONLY_SUBPATHS = ['./compileSchemaValidators']; // imports fs
+// Every export subpath is measured as its own entry, except those listed in a package's `nodeOnly`, which import
+// Node built-ins such as `fs` and cannot be bundled for a browser.
 const PACKAGES = {
   '@rjsf/core': {
     installed: '47 kB',
@@ -19,8 +19,18 @@ const PACKAGES = {
     own: '19 kB',
     canaries: [{ label: 'getUiOptions', import: '{ getUiOptions }', limit: '1 kB' }],
   },
-  '@rjsf/validator-ajv8': { installed: '39 kB', own: '3 kB' },
+  '@rjsf/validator-ajv8': { installed: '39 kB', own: '3 kB', nodeOnly: ['./compileSchemaValidators'] },
+  '@rjsf/validator-ata': { nodeOnly: ['./compileSchemaValidators'] },
 };
+
+// The `default` condition is what a consumer's bundler resolves; a subpath without one has no browser entry to measure
+function subpathEntry(pkg, key, target) {
+  const entry = typeof target === 'string' ? target : target.default;
+  if (!entry) {
+    throw new Error(`${pkg.name} exports "${key}" without a "default" condition; add one or list it in nodeOnly`);
+  }
+  return entry;
+}
 
 const released = readdirSync(join(ROOT, 'packages'))
   .filter((dir) => existsSync(join(ROOT, 'packages', dir, 'package.json')))
@@ -33,25 +43,20 @@ const released = readdirSync(join(ROOT, 'packages'))
 module.exports = released.flatMap(({ dir, pkg }) => {
   const path = join(ROOT, 'packages', dir, 'lib', 'index.js');
   const deps = Object.keys(pkg.dependencies ?? {});
-  // react-dom is never declared but is always the host's to provide; devDependencies (which @rjsf/core/testing
-  // reaches) are never installed by a consumer. An optional peer is measured: the consumer only installs it for the
-  // subpath that needs it, so its cost belongs to that subpath's row.
+  // react-dom is never declared but is always the host's to provide. An optional peer is measured: the consumer only
+  // installs it for the subpath that needs it, so its cost belongs to that subpath's row.
   const optionalPeers = Object.keys(pkg.peerDependenciesMeta ?? {});
-  const peers = [
-    ...Object.keys(pkg.peerDependencies ?? {}),
-    ...Object.keys(pkg.devDependencies ?? {}),
-    'react-dom',
-  ].filter((dep) => !optionalPeers.includes(dep));
-  const { installed, own, canaries = [] } = PACKAGES[pkg.name] ?? {};
+  const peers = [...Object.keys(pkg.peerDependencies ?? {}), 'react-dom'].filter((dep) => !optionalPeers.includes(dep));
+  const { installed, own, canaries = [], nodeOnly = [] } = PACKAGES[pkg.name] ?? {};
   const subpaths = Object.entries(pkg.exports).filter(
-    ([key]) => key !== '.' && !key.startsWith('./lib') && !NODE_ONLY_SUBPATHS.includes(key),
+    ([key]) => key !== '.' && !key.startsWith('./lib') && !nodeOnly.includes(key),
   );
 
   return [
     { name: pkg.name, path, ignore: peers, ...(installed && { limit: installed }) },
     ...subpaths.map(([key, target]) => ({
       name: `${pkg.name}${key.slice(1)}`,
-      path: join(ROOT, 'packages', dir, typeof target === 'string' ? target : target.default),
+      path: join(ROOT, 'packages', dir, subpathEntry(pkg, key, target)),
       ignore: peers,
     })),
     ...(deps.length

--- a/.github/size-limit/.size-limit.js
+++ b/.github/size-limit/.size-limit.js
@@ -6,14 +6,13 @@ const ROOT = join(__dirname, '..', '..');
 // Budgets only where one already existed; elsewhere the PR comment's delta column
 // catches a regression without the bump commits a per-theme budget invites.
 // Canaries are single-export imports that fail if tree-shaking regresses.
+// Every export subpath is measured as its own entry, except the Node-only ones.
+const NODE_ONLY_SUBPATHS = ['./compileSchemaValidators']; // imports fs
 const PACKAGES = {
   '@rjsf/core': {
-    installed: '92 kB',
+    installed: '47 kB',
     own: '24 kB',
-    // getTestRegistry pulls the AJV chain into core's lib/, but it is a
-    // devDependency there — a consumer installing @rjsf/core never gets it.
-    extraIgnore: ['@rjsf/validator-ajv8'],
-    canaries: [{ label: 'Form', import: 'Form', limit: '53 kB' }],
+    canaries: [{ label: 'Form', import: 'Form', limit: '47 kB' }],
   },
   '@rjsf/utils': {
     installed: '34 kB',
@@ -34,18 +33,33 @@ const released = readdirSync(join(ROOT, 'packages'))
 module.exports = released.flatMap(({ dir, pkg }) => {
   const path = join(ROOT, 'packages', dir, 'lib', 'index.js');
   const deps = Object.keys(pkg.dependencies ?? {});
-  // react-dom is never declared but is always the host's to provide.
-  const peers = [...Object.keys(pkg.peerDependencies ?? {}), 'react-dom'];
-  const { installed, own, extraIgnore = [], canaries = [] } = PACKAGES[pkg.name] ?? {};
+  // react-dom is never declared but is always the host's to provide; devDependencies (which @rjsf/core/testing
+  // reaches) are never installed by a consumer. An optional peer is measured: the consumer only installs it for the
+  // subpath that needs it, so its cost belongs to that subpath's row.
+  const optionalPeers = Object.keys(pkg.peerDependenciesMeta ?? {});
+  const peers = [
+    ...Object.keys(pkg.peerDependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+    'react-dom',
+  ].filter((dep) => !optionalPeers.includes(dep));
+  const { installed, own, canaries = [] } = PACKAGES[pkg.name] ?? {};
+  const subpaths = Object.entries(pkg.exports).filter(
+    ([key]) => key !== '.' && !key.startsWith('./lib') && !NODE_ONLY_SUBPATHS.includes(key),
+  );
 
   return [
     { name: pkg.name, path, ignore: peers, ...(installed && { limit: installed }) },
-    ...(deps.length || extraIgnore.length
+    ...subpaths.map(([key, target]) => ({
+      name: `${pkg.name}${key.slice(1)}`,
+      path: join(ROOT, 'packages', dir, typeof target === 'string' ? target : target.default),
+      ignore: peers,
+    })),
+    ...(deps.length
       ? [
           {
             name: `${pkg.name} (without dependencies)`,
             path,
-            ignore: [...peers, ...deps, ...extraIgnore],
+            ignore: [...peers, ...deps],
             ...(own && { limit: own }),
           },
         ]

--- a/CHANGELOG-v7.md
+++ b/CHANGELOG-v7.md
@@ -36,6 +36,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `validateFormWithFormData()` (used by form submission and the `validateForm()` instance method) silently dropping a `customError` raised by a field/widget's `onChange` on submit; it's now merged in and blocks submission the same way schema and (non-warning) `extraErrors` do
 - **BREAKING CHANGE:** Removed the private `_internalFormWrapper` prop from `FormProps` and `ThemeProps`; its only consumer was the removed `@rjsf/semantic-ui` theme. Use `tagName` to render a different element in place of `<form>`
 - **BREAKING CHANGE** Dropped the `experimental_` prefix from `FormProps`, now that these features are no longer experimental: `experimental_defaultFormStateBehavior` → `defaultFormStateBehavior`, `experimental_customMergeAllOf` → `customMergeAllOf`
+- **BREAKING CHANGE:** `getTestRegistry()` moved to `@rjsf/core/testing` as a named export; `@rjsf/validator-ajv8`, which it needs, is an optional peer dependency that only this entry point requires. Its positional arguments remain supported. Fixed three theme test helpers that previously passed an options object instead of positional arguments
 
 ## @rjsf/mantine
 

--- a/CHANGELOG-v7.md
+++ b/CHANGELOG-v7.md
@@ -38,6 +38,10 @@ should change the heading of the (upcoming) version to include a major version b
 - **BREAKING CHANGE** Dropped the `experimental_` prefix from `FormProps`, now that these features are no longer experimental: `experimental_defaultFormStateBehavior` → `defaultFormStateBehavior`, `experimental_customMergeAllOf` → `customMergeAllOf`
 - **BREAKING CHANGE:** `getTestRegistry()` moved to `@rjsf/core/testing` as a named export; `@rjsf/validator-ajv8`, which it needs, is an optional peer dependency that only this entry point requires. Its positional arguments remain supported. Fixed three theme test helpers that previously passed an options object instead of positional arguments
 
+## @rjsf/daisyui
+
+- Fixed the `getTestRegistry()` test helper passing an options object where positional arguments were expected, which silently dropped its templates and widgets; it now imports from `@rjsf/core/testing` ([#5272](https://github.com/rjsf-team/react-jsonschema-form/pull/5272))
+
 ## @rjsf/mantine
 
 - **BREAKING CHANGE** Dropped support for `mantine` version 8; upgraded to `mantine` version 9, which requires React 19.2+. The `react` peer dependency floor is `>=19.2`, matching what `@mantine/core`/`@mantine/hooks` 9.6.1 themselves require (their `useEffectEvent` usage needs it)
@@ -53,10 +57,12 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/react-bootstrap
 
 - Fixed `lib/index.js` being unloadable by Node: it imported `react-bootstrap/Col`-style directory subpaths and extensionless `@react-icons/all-files` paths, which only bundlers resolve. Components are now imported from `react-bootstrap` itself and icon files by their full `.js` name ([#5244](https://github.com/rjsf-team/react-jsonschema-form/pull/5244))
+- Fixed the `getTestRegistry()` test helper passing an options object where positional arguments were expected, which silently dropped its templates and widgets; it now imports from `@rjsf/core/testing` ([#5272](https://github.com/rjsf-team/react-jsonschema-form/pull/5272))
 
 ## @rjsf/shadcn
 
 - Converted the internal `forwardRef`-wrapped `Command` and `CommandInput` components to plain function components that accept `ref` as a regular prop, now that React 19 supports this natively
+- Fixed the `getTestRegistry()` test helper passing an options object where positional arguments were expected, which silently dropped its templates and widgets; it now imports from `@rjsf/core/testing` ([#5272](https://github.com/rjsf-team/react-jsonschema-form/pull/5272))
 
 ## @rjsf/utils
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,11 @@
       "default": "./lib/index.js"
     },
     "./lib": "./lib/index.js",
-    "./lib/*.js": "./lib/*.js"
+    "./lib/*.js": "./lib/*.js",
+    "./testing": {
+      "@rjsf/source": "./src/testing.ts",
+      "default": "./lib/testing.js"
+    }
   },
   "files": [
     "lib",
@@ -43,7 +47,13 @@
   },
   "peerDependencies": {
     "@rjsf/utils": "workspace:^",
+    "@rjsf/validator-ajv8": "workspace:^",
     "react": ">=19"
+  },
+  "peerDependenciesMeta": {
+    "@rjsf/validator-ajv8": {
+      "optional": true
+    }
   },
   "dependencies": {
     "markdown-to-jsx": "^9.8.2"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,6 @@ import RichHelp from './components/RichHelp.tsx';
 import type { SchemaExamplesProps } from './components/SchemaExamples.tsx';
 import SchemaExamples from './components/SchemaExamples.tsx';
 import getDefaultRegistry from './getDefaultRegistry.ts';
-import getTestRegistry from './getTestRegistry.tsx';
 import type { ThemeProps } from './withTheme.tsx';
 import withTheme from './withTheme.tsx';
 
@@ -21,5 +20,5 @@ export type {
   SchemaExamplesProps,
 };
 
-export { withTheme, getDefaultRegistry, getTestRegistry, RichDescription, RichHelp, SchemaExamples };
+export { withTheme, getDefaultRegistry, RichDescription, RichHelp, SchemaExamples };
 export default Form;

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -6,8 +6,8 @@ import getDefaultRegistry from './getDefaultRegistry.ts';
 
 /** Use for react testing library tests where we directly test the component rather than testing inside a Form
  */
-export default function getTestRegistry(
-  rootSchema: Registry['rootSchema'],
+export function getTestRegistry(
+  rootSchema: Registry['rootSchema'] = {},
   fields: Registry['fields'] = {},
   templates: Partial<Registry['templates']> = {},
   widgets: Registry['widgets'] = {},

--- a/packages/core/test/DescriptionField.test.tsx
+++ b/packages/core/test/DescriptionField.test.tsx
@@ -2,7 +2,7 @@ import type { DescriptionFieldProps } from '@rjsf/utils';
 import { render } from '@testing-library/react';
 
 import DescriptionField from '../src/components/templates/DescriptionField.tsx';
-import { getTestRegistry } from '../src/index.ts';
+import { getTestRegistry } from '../src/testing.ts';
 
 const registry = getTestRegistry({});
 

--- a/packages/core/test/LayoutGridField.test.tsx
+++ b/packages/core/test/LayoutGridField.test.tsx
@@ -47,7 +47,7 @@ import LayoutGridField, {
   LAYOUT_GRID_OPTION,
   Operators,
 } from '../src/components/fields/LayoutGridField.tsx';
-import getTestRegistry from '../src/getTestRegistry.tsx';
+import { getTestRegistry } from '../src/testing.ts';
 import { SAMPLE_SCHEMA, sampleUISchema, SIMPLE_ONEOF, SIMPLE_ONEOF_OPTIONS } from './testData/layoutData.ts';
 
 const ColumnWidth3 = 'col-xs-3';

--- a/packages/core/test/LayoutMultiSchemaField.test.tsx
+++ b/packages/core/test/LayoutMultiSchemaField.test.tsx
@@ -30,7 +30,7 @@ import LayoutMultiSchemaField, {
 } from '../src/components/fields/LayoutMultiSchemaField.tsx';
 import RadioWidget from '../src/components/widgets/RadioWidget.tsx';
 import SelectWidget from '../src/components/widgets/SelectWidget.tsx';
-import getTestRegistry from '../src/getTestRegistry.tsx';
+import { getTestRegistry } from '../src/testing.ts';
 import { SIMPLE_ONEOF, SIMPLE_ONEOF_OPTIONS } from './testData/layoutData.ts';
 import { setupConsoleErrorSuppression } from './testUtils.tsx';
 

--- a/packages/core/test/TitleField.test.tsx
+++ b/packages/core/test/TitleField.test.tsx
@@ -2,7 +2,7 @@ import type { TitleFieldProps } from '@rjsf/utils';
 import { render } from '@testing-library/react';
 
 import TitleField from '../src/components/templates/TitleField.tsx';
-import { getTestRegistry } from '../src/index.ts';
+import { getTestRegistry } from '../src/testing.ts';
 
 const registry = getTestRegistry({});
 

--- a/packages/daisyui/test/helpers/createMocks.ts
+++ b/packages/daisyui/test/helpers/createMocks.ts
@@ -1,4 +1,4 @@
-import { getTestRegistry } from '@rjsf/core';
+import { getTestRegistry } from '@rjsf/core/testing';
 import type { RJSFSchema, WidgetProps } from '@rjsf/utils';
 
 import Templates from '../../src/templates/Templates.tsx';
@@ -14,7 +14,7 @@ const mockSchema: RJSFSchema = {
 const mockEventHandlers = (): void => undefined;
 
 function mockRegistry() {
-  return getTestRegistry({ templates: Templates, rootSchema: mockSchema, widgets: generateWidgets() });
+  return getTestRegistry(mockSchema, undefined, Templates, generateWidgets());
 }
 
 export function makeWidgetMockProps(props: Partial<WidgetProps> = {}): WidgetProps {

--- a/packages/docs/docs/migration-guides/v7.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v7.x upgrade guide.md
@@ -17,6 +17,21 @@ The CommonJS (`dist/index.cjs`), bundled ESM (`dist/<name>.esm.js`) and UMD (`di
 
 The private `_internalFormWrapper` prop, and its entry in the `ThemeProps` a theme passes to `withTheme()`, have been removed. It existed so `@rjsf/semantic-ui` could wrap the `<form>` element in that library's own `Form` component, and it was the only theme that ever used it. Use the public `tagName` prop to render a different element in place of `<form>`.
 
+### `getTestRegistry()` moved to `@rjsf/core/testing` BREAKING CHANGE
+
+Update the import and add `@rjsf/validator-ajv8` to your dev dependencies:
+
+```diff
+-import { getTestRegistry } from '@rjsf/core';
++import { getTestRegistry } from '@rjsf/core/testing';
+```
+
+```bash
+npm install --save-dev @rjsf/validator-ajv8
+```
+
+`@rjsf/validator-ajv8` is now an optional peer dependency of `@rjsf/core` that only this entry point needs, so it no longer ships as a transitive dependency of the main entry. The arguments are unchanged: `getTestRegistry(schema, {}, templates)` still works.
+
 ### Theme removals
 
 #### @rjsf/primereact

--- a/packages/react-bootstrap/package.json
+++ b/packages/react-bootstrap/package.json
@@ -48,6 +48,7 @@
     "@rjsf/core": "workspace:^",
     "@rjsf/snapshot-tests": "workspace:^",
     "@rjsf/utils": "workspace:^",
+    "@rjsf/validator-ajv8": "workspace:^",
     "react-bootstrap": "^2.10.10"
   },
   "publishConfig": {

--- a/packages/react-bootstrap/test/helpers/createMocks.ts
+++ b/packages/react-bootstrap/test/helpers/createMocks.ts
@@ -1,4 +1,4 @@
-import { getTestRegistry } from '@rjsf/core';
+import { getTestRegistry } from '@rjsf/core/testing';
 import type { WidgetProps, RJSFSchema } from '@rjsf/utils';
 
 import BaseInputTemplate from '../../src/BaseInputTemplate/index.ts';
@@ -14,7 +14,7 @@ const mockSchema: RJSFSchema = {
 const mockEventHandlers = (): void => undefined;
 
 function mockRegistry() {
-  return getTestRegistry({ templates: Templates, rootSchema: mockSchema, widgets: { TextWidget: BaseInputTemplate } });
+  return getTestRegistry(mockSchema, undefined, Templates, { TextWidget: BaseInputTemplate });
 }
 
 export function makeWidgetMockProps(props: Partial<WidgetProps> = {}): WidgetProps {

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -48,8 +48,9 @@
     "@rjsf/core": "workspace:^",
     "@rjsf/snapshot-tests": "workspace:^",
     "@rjsf/utils": "workspace:^",
-    "@testing-library/user-event": "^14.6.6",
+    "@rjsf/validator-ajv8": "workspace:^",
     "@tailwindcss/cli": "^4.3.0",
+    "@testing-library/user-event": "^14.6.6",
     "tailwindcss": "^4.3.0"
   },
   "dependencies": {

--- a/packages/shadcn/test/helpers/createMocks.ts
+++ b/packages/shadcn/test/helpers/createMocks.ts
@@ -1,4 +1,4 @@
-import { getTestRegistry } from '@rjsf/core';
+import { getTestRegistry } from '@rjsf/core/testing';
 import type { WidgetProps, RJSFSchema } from '@rjsf/utils';
 
 import BaseInputTemplate from '../../src/BaseInputTemplate/index.ts';
@@ -14,7 +14,7 @@ const mockSchema: RJSFSchema = {
 const mockEventHandlers = (): void => undefined;
 
 function mockRegistry() {
-  return getTestRegistry({ templates: Templates, rootSchema: mockSchema, widgets: { TextWidget: BaseInputTemplate } });
+  return getTestRegistry(mockSchema, undefined, Templates, { TextWidget: BaseInputTemplate });
 }
 
 export function makeWidgetMockProps(props: Partial<WidgetProps> = {}): WidgetProps {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -610,6 +610,9 @@ importers:
       '@rjsf/utils':
         specifier: workspace:^
         version: link:../utils
+      '@rjsf/validator-ajv8':
+        specifier: workspace:^
+        version: link:../validator-ajv8
       react-bootstrap:
         specifier: ^2.10.10
         version: 2.10.10(@types/react@19.3.0)(react-dom@19.3.0(react@19.3.0))(react@19.3.0)
@@ -668,6 +671,9 @@ importers:
       '@rjsf/utils':
         specifier: workspace:^
         version: link:../utils
+      '@rjsf/validator-ajv8':
+        specifier: workspace:^
+        version: link:../validator-ajv8
       '@tailwindcss/cli':
         specifier: ^4.3.0
         version: 4.3.0


### PR DESCRIPTION
### Reasons for making this change

`getTestRegistry()` sat on the production root entry of `@rjsf/core` while depending on `@rjsf/validator-ajv8`, a devDependency. Consumers never got the validator, but core's `lib/` still pulled the AJV chain into every size measurement, and a test-only helper was part of the runtime API surface.

Split out of #5266 so that PR is only about the component exports.

### Changes

- `getTestRegistry()` is a named export of the new `@rjsf/core/testing` entry point (`src/testing.ts`). Its positional arguments are unchanged; `rootSchema` now defaults to `{}`.
- `@rjsf/validator-ajv8` becomes an optional peer dependency of `@rjsf/core` that only the testing entry needs.
- Three theme test helpers (`daisyui`, `shadcn`, `react-bootstrap`) passed an options object where positional arguments were expected, so the object landed in `rootSchema`. They now pass positional arguments.
- size-limit measures every export subpath as its own row and ignores only required peers, so a subpath's row includes what it actually reaches. The `@rjsf/core` row drops from 92 kB to 45 kB because the AJV chain is no longer counted against the main entry; the new `@rjsf/core/testing` row carries it at 76 kB. Node-only subpaths are declared per package in the config.
- Migration guide section and `CHANGELOG-v7.md` entry.

### Checklist

- [x] **I'm updating documentation**
- [x] **I'm adding or updating code**
  - [x] I've verified the existing tests pass (`core`, `daisyui`, `shadcn`, `react-bootstrap`) and root `typecheck`, `knip` and lint are clean
  - [x] I've updated the migration guide
  - [x] I've updated `CHANGELOG-v7.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)