### PR TITLE
fix 5250: sanitize stale data for a dependencies/if branch nested inside a property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 6.10.1
 
+## @rjsf/core
+
+- Fixed a `dependencies`/`if` branch switch nested inside an object property never sanitizing a sibling field's now-invalid value. The check gating sanitization only compared the root retrieved schema, which never reflects a conditional resolved deeper in the tree, so it always skipped sanitizing in that case, fixing ([#5250](https://github.com/rjsf-team/react-jsonschema-form/issues/5250))
+
+## @rjsf/utils
+
+- Fixed `sanitizeDataForNewSchema()` to resolve `dependencies`, `if`/`then`/`else` and `allOf` (not just `$ref`) on each property's old/new schema before comparing them, so a conditional nested inside an object property is taken into account when sanitizing its data, fixing ([#5250](https://github.com/rjsf-team/react-jsonschema-form/issues/5250))
+- Added `schemaHasNestedConditional()`, which `Form` uses to detect a `dependencies`/`if` nested below a schema's top level (behind a `$ref`, `patternProperties`, tuple `items`, `additionalProperties` or `allOf`/`anyOf`/`oneOf`) so sanitization isn't skipped just because the root retrieved schema looks unchanged ([#5250](https://github.com/rjsf-team/react-jsonschema-form/issues/5250))
+
 ## Dev / docs / playground
 
 - Fixed the size-limit report never being posted on a pull request from a fork. The comment workflow resolved the PR from its head sha, which the base repository cannot associate with a fork's commit, so it warned and skipped — leaving a green check and no comment. The measuring job now records the PR number in its artifact, and the comment workflow looks that PR up directly, accepts it only if its head sha matches the run's trusted `workflow_run` head sha, and fails loudly rather than skipping when the PR cannot be found

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -53,6 +53,7 @@ import {
   ID_KEY,
   getUsedFormData,
   getFieldNames,
+  schemaHasNestedConditional,
   ANY_OF_KEY,
   ONE_OF_KEY,
 } from '@rjsf/utils';
@@ -616,6 +617,11 @@ export default class Form<
     let computedRetrievedSchema: S;
     let wasSanitized = false;
     const preventInfiniteSanitize: string[] = [];
+    // A `dependencies`/`if` branch switch nested inside an object property never changes the ROOT retrieved
+    // schema (only the schema's own top-level `dependencies`/`if` get resolved into it), so comparing
+    // `computedRetrievedSchema` to `state.retrievedSchema` below can't detect it. When the schema has such a
+    // nested conditional, skip that (root-only) short-circuit so sanitization is still attempted (#5250).
+    const hasNestedConditionalSchema = shouldSanitize && schemaHasNestedConditional(rootSchema, rootSchema);
     do {
       formData = schemaUtils.getDefaultFormState(
         rootSchema,
@@ -631,10 +637,10 @@ export default class Form<
       if (
         shouldSanitize &&
         !preventInfiniteSanitize.includes(formHash) &&
-        !deepEquals(computedRetrievedSchema, state.retrievedSchema)
+        (hasNestedConditionalSchema || !deepEquals(computedRetrievedSchema, state.retrievedSchema))
       ) {
         // Sanitize the form data if shouldSanitize is true, we haven't already processed this same formData AND
-        // we have a different retrieved schema from when we last ran the state
+        // either the retrieved schema changed or the schema has a nested conditional that the check above can't see
         const sanitizedFormData = schemaUtils.sanitizeDataForNewSchema(
           computedRetrievedSchema,
           state.retrievedSchema,

--- a/packages/core/test/Form.errors.test.tsx
+++ b/packages/core/test/Form.errors.test.tsx
@@ -1144,6 +1144,95 @@ describeRepeated('Form common: error contextualization', (createFormComponent) =
         await user.selectOptions(node.querySelector<HTMLSelectElement>('#root_food')!, '0');
         expect(formRef.current!.state.retrievedSchema.properties).not.toHaveProperty('water');
       });
+
+      it('should sanitize stale enum data for a dependency nested inside an object (#5250)', async () => {
+        const nestedDependentEnumSchema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            m: {
+              type: 'object',
+              properties: {
+                animal: {
+                  type: 'string',
+                  enum: ['Cat', 'Fish'],
+                },
+              },
+              dependencies: {
+                animal: {
+                  oneOf: [
+                    {
+                      properties: {
+                        animal: { enum: ['Cat'] },
+                        food: { type: 'string', enum: ['meat'] },
+                      },
+                    },
+                    {
+                      properties: {
+                        animal: { enum: ['Fish'] },
+                        food: { type: 'string', enum: ['worms'] },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        };
+        const { node, onChange } = createFormComponent({
+          schema: nestedDependentEnumSchema,
+          formData: { m: { animal: 'Fish', food: 'worms' } },
+        });
+
+        await user.selectOptions(node.querySelector<HTMLSelectElement>('#root_m_animal')!, '0');
+
+        expectToHaveBeenCalledWithFormData(onChange, { m: { animal: 'Cat', food: 'meat' } }, 'root_m_animal');
+      });
+
+      it('should sanitize stale enum data for a dependency nested behind a $ref (#5250)', async () => {
+        const refDependentEnumSchema: RJSFSchema = {
+          type: 'object',
+          definitions: {
+            Animal: {
+              type: 'object',
+              properties: {
+                animal: {
+                  type: 'string',
+                  enum: ['Cat', 'Fish'],
+                },
+              },
+              dependencies: {
+                animal: {
+                  oneOf: [
+                    {
+                      properties: {
+                        animal: { enum: ['Cat'] },
+                        food: { type: 'string', enum: ['meat'] },
+                      },
+                    },
+                    {
+                      properties: {
+                        animal: { enum: ['Fish'] },
+                        food: { type: 'string', enum: ['worms'] },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          properties: {
+            m: { $ref: '#/definitions/Animal' },
+          },
+        };
+        const { node, onChange } = createFormComponent({
+          schema: refDependentEnumSchema,
+          formData: { m: { animal: 'Fish', food: 'worms' } },
+        });
+
+        await user.selectOptions(node.querySelector<HTMLSelectElement>('#root_m_animal')!, '0');
+
+        expectToHaveBeenCalledWithFormData(onChange, { m: { animal: 'Cat', food: 'meat' } }, 'root_m_animal');
+      });
     });
 
     describe('customValidate errors, live validation', () => {

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -1126,6 +1126,23 @@ Resolution order (later sources override earlier):
 
 - UiSchema&lt;T, S, F>: The resolved uiSchema with definitions merged in
 
+### schemaHasNestedConditional&lt;S extends StrictRJSFSchema = RJSFSchema>()
+
+Recursively checks whether the given raw `schema` contains a `dependencies` or `if` keyword anywhere below its top level, e.g. inside a nested object's `properties`, a `$ref`, an array's tuple `items`, or a `patternProperties` entry.
+`retrieveSchema()` only resolves the `dependencies`/`if` declared directly on the schema it is given, so a root-level retrieved schema never reflects a conditional branch switch that happens deeper in the tree.
+`Form` uses this to detect when a comparison of root-level retrieved schemas can't be trusted to decide whether sanitization is needed.
+
+#### Parameters
+
+- schema: S | boolean | undefined - The raw schema node to search
+- rootSchema: S - The root schema, used to resolve any `$ref`s encountered while searching
+- atRoot: boolean = true - Whether `schema` is the root of the search, whose own `dependencies`/`if` don't count
+- seenRefs: string[] = [] - The `$ref`s already resolved along this branch of the search, to guard against cycles
+
+#### Returns
+
+- boolean: True if a `dependencies` or `if` keyword exists below the root of the schema
+
 ### schemaRequiresTrueValue&lt;S extends StrictRJSFSchema = RJSFSchema>()
 
 Check to see if a `schema` specifies that a value must be true. This happens when:

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -72,6 +72,7 @@ import rangeSpec from './rangeSpec.ts';
 import removeOptionalEmptyObjects from './removeOptionalEmptyObjects.ts';
 import replaceStringParameters from './replaceStringParameters.ts';
 import resolveUiSchema from './resolveUiSchema.ts';
+import schemaHasNestedConditional from './schemaHasNestedConditional.ts';
 import schemaRequiresTrueValue from './schemaRequiresTrueValue.ts';
 import SelectedOptionDescription from './SelectedOptionDescription.tsx';
 import type { SelectedOptionDescriptionProps } from './SelectedOptionDescription.tsx';
@@ -187,6 +188,7 @@ export {
   removeOptionalEmptyObjects,
   replaceStringParameters,
   resolveUiSchema,
+  schemaHasNestedConditional,
   schemaRequiresTrueValue,
   setByPath,
   SelectedOptionDescription,

--- a/packages/utils/src/schema/sanitizeDataForNewSchema.ts
+++ b/packages/utils/src/schema/sanitizeDataForNewSchema.ts
@@ -131,27 +131,22 @@ export default function sanitizeDataForNewSchema<
     keys.forEach((key) => {
       const formValue = data?.[key];
       const isNewProperty = !hasByPath(oldSchema, [PROPERTIES_KEY, key]);
-      let oldKeyedSchema = getPropertySchema<S>(oldSchema, key);
-      let newKeyedSchema = getPropertySchema<S>(newSchema, key);
-      // Resolve the refs if they exist
-      if (hasByPath(oldKeyedSchema, REF_KEY)) {
-        oldKeyedSchema = retrieveSchema<T, S, F>(
-          validator,
-          oldKeyedSchema,
-          rootSchema,
-          formValue,
-          experimental_customMergeAllOf,
-        );
-      }
-      if (hasByPath(newKeyedSchema, REF_KEY)) {
-        newKeyedSchema = retrieveSchema<T, S, F>(
-          validator,
-          newKeyedSchema,
-          rootSchema,
-          formValue,
-          experimental_customMergeAllOf,
-        );
-      }
+      const oldRawKeyedSchema = getPropertySchema<S>(oldSchema, key);
+      const newRawKeyedSchema = getPropertySchema<S>(newSchema, key);
+      // Resolve refs, dependencies, if/then/else and allOf so a dependency nested inside this key
+      // (not just at the root schema) is taken into account when sanitizing its data (#5250)
+      const oldKeyedSchema = retrieveSchema<T, S, F>(
+        validator,
+        oldRawKeyedSchema,
+        rootSchema,
+        formValue,
+        experimental_customMergeAllOf,
+      );
+      // The old and new raw schema for a key are usually identical (most keys aren't touched by whatever changed),
+      // so skip resolving (and re-running any oneOf/dependency validity checks) a second time in that common case.
+      const newKeyedSchema = deepEquals(oldRawKeyedSchema, newRawKeyedSchema)
+        ? oldKeyedSchema
+        : retrieveSchema<T, S, F>(validator, newRawKeyedSchema, rootSchema, formValue, experimental_customMergeAllOf);
       // Now get types and see if they are the same
       const oldSchemaTypeForKey = oldKeyedSchema.type;
       const newSchemaTypeForKey = newKeyedSchema.type;
@@ -226,6 +221,10 @@ export default function sanitizeDataForNewSchema<
       !Array.isArray(oldSchemaItems) &&
       !Array.isArray(newSchemaItems)
     ) {
+      // Keep the raw (pre-$ref-resolution) items schema around: a conditional nested inside `items` must be
+      // re-resolved per element below, against that element's own value, rather than the whole array (#5250)
+      const oldSchemaItemsRaw = oldSchemaItems as S;
+      const newSchemaItemsRaw = newSchemaItems as S;
       if (hasByPath(oldSchemaItems, REF_KEY)) {
         oldSchemaItems = retrieveSchema<T, S, F>(
           validator,
@@ -252,11 +251,29 @@ export default function sanitizeDataForNewSchema<
         const maxItems = newSchema.maxItems ?? -1;
         if (newSchemaType === 'object') {
           newFormData = data.reduce((newValue, aValue) => {
+            // Resolve refs, dependencies, if/then/else and allOf against this item's own value, so a conditional
+            // nested inside `items` picks the branch that matches this element rather than the whole array (#5250)
+            const oldItemSchema = retrieveSchema<T, S, F>(
+              validator,
+              oldSchemaItemsRaw,
+              rootSchema,
+              aValue,
+              experimental_customMergeAllOf,
+            );
+            const newItemSchema = deepEquals(oldSchemaItemsRaw, newSchemaItemsRaw)
+              ? oldItemSchema
+              : retrieveSchema<T, S, F>(
+                  validator,
+                  newSchemaItemsRaw,
+                  rootSchema,
+                  aValue,
+                  experimental_customMergeAllOf,
+                );
             const itemValue = sanitizeDataForNewSchema<T, S, F>(
               validator,
               rootSchema,
-              newSchemaItems as S,
-              oldSchemaItems as S,
+              newItemSchema,
+              oldItemSchema,
               aValue,
               experimental_customMergeAllOf,
             );

--- a/packages/utils/src/schemaHasNestedConditional.ts
+++ b/packages/utils/src/schemaHasNestedConditional.ts
@@ -1,0 +1,78 @@
+import {
+  ADDITIONAL_PROPERTIES_KEY,
+  ALL_OF_KEY,
+  ANY_OF_KEY,
+  DEPENDENCIES_KEY,
+  IF_KEY,
+  ITEMS_KEY,
+  ONE_OF_KEY,
+  PATTERN_PROPERTIES_KEY,
+  PROPERTIES_KEY,
+  REF_KEY,
+} from './constants.ts';
+import findSchemaDefinition from './findSchemaDefinition.ts';
+import isObject from './isObject.ts';
+import type { RJSFSchema, StrictRJSFSchema } from './types.ts';
+
+/** Recursively checks whether the given raw `schema` contains a `dependencies` or `if` keyword anywhere below its
+ * top level, e.g. inside a nested object's `properties`, a `$ref`, an array's tuple `items`, or a
+ * `patternProperties` entry. `retrieveSchema()` only resolves the `dependencies`/`if` declared directly on the
+ * schema it is given, so a root-level retrieved schema never reflects a conditional branch switch that happens
+ * deeper in the tree. `Form` uses this to detect when a comparison of root-level retrieved schemas can't be trusted
+ * to decide whether sanitization is needed.
+ *
+ * @param schema - The raw schema node to search
+ * @param rootSchema - The root schema, used to resolve any `$ref`s encountered while searching
+ * @param [atRoot=true] - Whether `schema` is the root of the search, whose own `dependencies`/`if` don't count
+ * @param [seenRefs=[]] - The `$ref`s already resolved along this branch of the search, to guard against cycles
+ * @returns - True if a `dependencies` or `if` keyword exists below the root of the schema
+ */
+export default function schemaHasNestedConditional<S extends StrictRJSFSchema = RJSFSchema>(
+  schema: S | boolean | undefined,
+  rootSchema: S,
+  atRoot = true,
+  seenRefs: string[] = [],
+): boolean {
+  if (!isObject(schema)) {
+    return false;
+  }
+  let resolved: S = schema;
+  let refs = seenRefs;
+  if (typeof resolved[REF_KEY] === 'string') {
+    const ref: string = resolved[REF_KEY];
+    if (refs.includes(ref)) {
+      return false;
+    }
+    refs = [...refs, ref];
+    try {
+      const target = findSchemaDefinition<S>(ref, rootSchema);
+      if (isObject(target)) {
+        // Merge, don't replace: sibling keywords declared alongside `$ref` are preserved and applied by
+        // `retrieveSchema()` (via `{ ...refSchema, ...localSchema }`), so a local `dependencies`/`if` next to a
+        // `$ref` must still be seen here, not just ones found on the ref target.
+        const { [REF_KEY]: _ref, ...localSchema } = resolved;
+        resolved = { ...target, ...localSchema } as S;
+      }
+    } catch {
+      // An unresolvable $ref will already have surfaced elsewhere (e.g. when rendering the field); treat it as
+      // having no nested conditional here rather than letting this best-effort check throw.
+      return false;
+    }
+  }
+  if (!atRoot && (DEPENDENCIES_KEY in resolved || IF_KEY in resolved)) {
+    return true;
+  }
+  const properties = resolved[PROPERTIES_KEY];
+  const patternProperties = resolved[PATTERN_PROPERTIES_KEY];
+  const items = resolved[ITEMS_KEY] as S | boolean | (S | boolean)[] | undefined;
+  const nestedSchemas: (S | boolean | undefined)[] = [
+    ...(isObject(properties) ? (Object.values(properties) as (S | boolean)[]) : []),
+    ...(isObject(patternProperties) ? (Object.values(patternProperties) as (S | boolean)[]) : []),
+    ...(Array.isArray(items) ? items : [items]),
+    resolved[ADDITIONAL_PROPERTIES_KEY] as S | boolean | undefined,
+    ...((resolved[ALL_OF_KEY] as (S | boolean)[] | undefined) ?? []),
+    ...((resolved[ANY_OF_KEY] as (S | boolean)[] | undefined) ?? []),
+    ...((resolved[ONE_OF_KEY] as (S | boolean)[] | undefined) ?? []),
+  ];
+  return nestedSchemas.some((nested) => schemaHasNestedConditional(nested, rootSchema, false, refs));
+}

--- a/packages/utils/test/schema/sanitizeDataForNewSchemaTest.ts
+++ b/packages/utils/test/schema/sanitizeDataForNewSchemaTest.ts
@@ -572,6 +572,70 @@ export default function sanitizeDataForNewSchemaTest(testValidator: TestValidato
         {},
       );
     });
+    it('resolves a dependency nested inside a property before sanitizing its data (#5250)', () => {
+      // The root schema itself has no top-level `dependencies`, so its own retrieved form is identical whether
+      // `animal` is "Cat" or "Fish" -- only calling retrieveSchema() on the `m` property itself (as
+      // sanitizeDataForNewSchema now does) picks up the active `food` branch for the current `animal` value.
+      const rootSchema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          m: {
+            type: 'object',
+            properties: {
+              animal: { type: 'string', enum: ['Cat', 'Fish'] },
+            },
+            dependencies: {
+              animal: {
+                oneOf: [
+                  { properties: { animal: { enum: ['Cat'] }, food: { type: 'string', enum: ['meat'] } } },
+                  { properties: { animal: { enum: ['Fish'] }, food: { type: 'string', enum: ['worms'] } } },
+                ],
+              },
+            },
+          },
+        },
+      };
+      // The old and new schema for `m` are identical here, so its dependency is only resolved once (not once per
+      // side); that resolution checks both oneOf branches: the "Cat" branch matches, the "Fish" branch does not.
+      testValidator.setReturnValues({ isValid: [true, false] });
+      expect(
+        sanitizeDataForNewSchema(testValidator, rootSchema, rootSchema, rootSchema, {
+          m: { animal: 'Cat', food: 'worms' },
+        }),
+      ).toEqual({ m: { animal: 'Cat', food: 'meat' } });
+    });
+    it('resolves a dependency nested inside array items, per item, before sanitizing its data (#5250)', () => {
+      const rootSchema: RJSFSchema = {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            animal: { type: 'string', enum: ['Cat', 'Fish'] },
+          },
+          dependencies: {
+            animal: {
+              oneOf: [
+                { properties: { animal: { enum: ['Cat'] }, food: { type: 'string', enum: ['meat'] } } },
+                { properties: { animal: { enum: ['Fish'] }, food: { type: 'string', enum: ['worms'] } } },
+              ],
+            },
+          },
+        },
+      };
+      // Each of the two array items resolves its own dependency independently: item 0 matches the "Cat" branch,
+      // item 1 matches the "Fish" branch. The old and new items schema is identical, so each item's dependency is
+      // only resolved once (not once per side).
+      testValidator.setReturnValues({ isValid: [true, false, false, true] });
+      expect(
+        sanitizeDataForNewSchema(testValidator, rootSchema, rootSchema, rootSchema, [
+          { animal: 'Cat', food: 'worms' },
+          { animal: 'Fish', food: 'meat' },
+        ]),
+      ).toEqual([
+        { animal: 'Cat', food: 'meat' },
+        { animal: 'Fish', food: 'worms' },
+      ]);
+    });
     it('returns data when two arrays have same boolean items', () => {
       const oldSchema: RJSFSchema = {
         type: 'array',

--- a/packages/utils/test/schemaHasNestedConditional.test.ts
+++ b/packages/utils/test/schemaHasNestedConditional.test.ts
@@ -1,0 +1,202 @@
+import type { RJSFSchema } from '../src/index.ts';
+import { schemaHasNestedConditional } from '../src/index.ts';
+
+describe('schemaHasNestedConditional()', () => {
+  it('returns false for a non-object schema', () => {
+    expect(schemaHasNestedConditional(true, {})).toBe(false);
+    expect(schemaHasNestedConditional(undefined, {})).toBe(false);
+  });
+  it('returns false for a schema with no conditional anywhere', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(false);
+  });
+  it("returns false for the root schema's own dependencies/if, which don't count as nested", () => {
+    const dependenciesSchema: RJSFSchema = {
+      type: 'object',
+      dependencies: { foo: { required: ['bar'] } },
+    };
+    expect(schemaHasNestedConditional(dependenciesSchema, dependenciesSchema)).toBe(false);
+
+    const ifSchema: RJSFSchema = {
+      type: 'object',
+      if: { properties: { foo: { const: 'bar' } } },
+      then: { required: ['bar'] },
+    };
+    expect(schemaHasNestedConditional(ifSchema, ifSchema)).toBe(false);
+  });
+  it('returns true for a dependencies keyword nested inside properties', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        m: {
+          type: 'object',
+          properties: { animal: { type: 'string' } },
+          dependencies: { animal: { required: ['food'] } },
+        },
+      },
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(true);
+  });
+  it('returns true for an if keyword nested inside properties', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: {
+        m: {
+          type: 'object',
+          if: { properties: { animal: { const: 'Cat' } } },
+          then: { required: ['food'] },
+        },
+      },
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(true);
+  });
+  it('resolves a $ref to find a dependencies keyword nested behind it', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      definitions: {
+        Animal: {
+          type: 'object',
+          properties: { animal: { type: 'string' } },
+          dependencies: { animal: { required: ['food'] } },
+        },
+      },
+      properties: { m: { $ref: '#/definitions/Animal' } },
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(true);
+  });
+  it('finds a dependencies keyword declared locally alongside a $ref, not just on the ref target', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      definitions: {
+        Animal: {
+          type: 'object',
+          properties: { animal: { type: 'string' } },
+        },
+      },
+      properties: {
+        m: {
+          $ref: '#/definitions/Animal',
+          dependencies: { animal: { required: ['food'] } },
+        },
+      },
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(true);
+  });
+  it('returns false and does not throw for an unresolvable $ref', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      properties: { m: { $ref: '#/definitions/Missing' } },
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(false);
+  });
+  it('returns false and does not infinitely recurse for a circular $ref', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      definitions: {
+        Node: {
+          type: 'object',
+          properties: { next: { $ref: '#/definitions/Node' } },
+        },
+      },
+      properties: { root: { $ref: '#/definitions/Node' } },
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(false);
+  });
+  it('ignores a $ref that resolves to a boolean schema', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      definitions: { Foo: true as unknown as RJSFSchema },
+      properties: { m: { $ref: '#/definitions/Foo' } },
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(false);
+  });
+  it('returns true for a dependencies keyword nested inside patternProperties', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      patternProperties: {
+        '^x-': {
+          type: 'object',
+          properties: { animal: { type: 'string' } },
+          dependencies: { animal: { required: ['food'] } },
+        },
+      },
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(true);
+  });
+  it('returns true for a dependencies keyword nested inside a single items schema', () => {
+    const schema: RJSFSchema = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { animal: { type: 'string' } },
+        dependencies: { animal: { required: ['food'] } },
+      },
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(true);
+  });
+  it('returns true for a dependencies keyword nested inside a tuple items array', () => {
+    const schema: RJSFSchema = {
+      type: 'array',
+      items: [
+        {
+          type: 'object',
+          properties: { animal: { type: 'string' } },
+          dependencies: { animal: { required: ['food'] } },
+        },
+        { type: 'string' },
+      ],
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(true);
+  });
+  it('returns true for a dependencies keyword nested inside additionalProperties', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      additionalProperties: {
+        type: 'object',
+        properties: { animal: { type: 'string' } },
+        dependencies: { animal: { required: ['food'] } },
+      },
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(true);
+  });
+  it('returns true for a dependencies keyword nested inside allOf', () => {
+    const schema: RJSFSchema = {
+      type: 'object',
+      allOf: [
+        {
+          type: 'object',
+          properties: { animal: { type: 'string' } },
+          dependencies: { animal: { required: ['food'] } },
+        },
+      ],
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(true);
+  });
+  it('returns true for a dependencies keyword nested inside anyOf', () => {
+    const schema: RJSFSchema = {
+      anyOf: [
+        {
+          type: 'object',
+          properties: { animal: { type: 'string' } },
+          dependencies: { animal: { required: ['food'] } },
+        },
+      ],
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(true);
+  });
+  it('returns true for a dependencies keyword nested inside oneOf', () => {
+    const schema: RJSFSchema = {
+      oneOf: [
+        {
+          type: 'object',
+          properties: { animal: { type: 'string' } },
+          dependencies: { animal: { required: ['food'] } },
+        },
+      ],
+    };
+    expect(schemaHasNestedConditional(schema, schema)).toBe(true);
+  });
+});


### PR DESCRIPTION
### Reasons for making this change

Fixes #5250

A dependencies/if branch switch nested inside an object property never sanitized a sibling field's now-invalid value. retrieveSchema() only resolves dependencies/if declared directly on the schema it's given, so the root-level retrieved schema Form used to decide whether to sanitize never reflected a conditional resolved deeper in the tree, and sanitizeDataForNewSchema() only resolved $ref (not dependencies/if/allOf) on each property's keyed schema before comparing it.

- Form now also treats sanitization as needed when the schema has a dependencies/if nested below its root (via the new schemaHasNestedConditional() utility, which resolves $ref, patternProperties, tuple items and allOf/anyOf/oneOf to find it, and merges local sibling keywords with a ref target rather than discarding them), since the plain root-schema-equality check can't see it.
- sanitizeDataForNewSchema() now resolves each property's old/new keyed schema fully (dependencies, if/then/else, allOf, not just $ref) before comparing them, including per-element for array items, and skips a redundant second resolution when a key's old and new raw schema are identical.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `pnpm exec nx run-many --target=build --exclude=@rjsf/docs && pnpm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
